### PR TITLE
Fix pot type name

### DIFF
--- a/include/erb/erb.h
+++ b/include/erb/erb.h
@@ -30,7 +30,7 @@ namespace erb
 
 
 using Button = GateIn;
-using Knob = CvIn;
+using Pot = CvIn;
 using Trim = CvIn;
 
 static constexpr float sample_rate = 48014.f;


### PR DESCRIPTION
Fix `Pot` type name (was previously `Knob`)