### PR TITLE
Remove falling edge mode and rename rising edge to trigger

### DIFF
--- a/include/erb/GateIn.h
+++ b/include/erb/GateIn.h
@@ -37,10 +37,10 @@ public:
 
    enum class Mode
    {
-      RisingEdge, FallingEdge, Gate
+      Trigger, Gate
    };
 
-                  GateIn (Module & module, const dsy_gpio_pin & pin, Mode mode = Mode::RisingEdge);
+                  GateIn (Module & module, const dsy_gpio_pin & pin, Mode mode = Mode::Trigger);
    virtual        ~GateIn () override = default;
 
    void           set_mode (Mode mode);

--- a/src/GateIn.cpp
+++ b/src/GateIn.cpp
@@ -62,16 +62,13 @@ GateIn::operator bool () const
 {
    switch (_mode)
    {
-   case Mode::RisingEdge:
+   case Mode::Trigger:
       return _current && !_previous;
-
-   case Mode::FallingEdge:
-      return _previous && !_current;
 
    case Mode::Gate:
       return _current;
 
-#if defined (__GNUC__)
+#if defined (__GNUC__) && ! defined (__clang__)
    default:
       return false;
 #endif


### PR DESCRIPTION
This PR uses simpler function mode names for gates.