### PR TITLE
Fix audio in daisy subscript operator return type

### DIFF
--- a/include/erb/AudioInDaisy.h
+++ b/include/erb/AudioInDaisy.h
@@ -50,7 +50,7 @@ public:
                   operator Buffer () const;
 
    size_t         size () const;
-   float          operator [] (size_t index);
+   const float &  operator [] (size_t index);
 
 
 

--- a/src/AudioInDaisy.cpp
+++ b/src/AudioInDaisy.cpp
@@ -71,7 +71,7 @@ Name : operator []
 ==============================================================================
 */
 
-float AudioInDaisy::operator [] (size_t index)
+const float &  AudioInDaisy::operator [] (size_t index)
 {
    return _buffer [index];
 }


### PR DESCRIPTION
This PR fixes the `AudioInDaisy` subscript operator to allow `&audio_in [0]` syntax to access underlying buffer.