### PR TITLE
Uniformise audio daisy pin

### DIFF
--- a/audio-in-daisy/test/main.cpp
+++ b/audio-in-daisy/test/main.cpp
@@ -27,11 +27,11 @@ int main ()
 
    Module module;
 
-   AudioInDaisy audio_in_left (module, AudioInDaisy::Pin::Left);
-   AudioInDaisy audio_in_right (module, AudioInDaisy::Pin::Right);
+   AudioInDaisy audio_in_left (module, AudioInDaisyPinLeft);
+   AudioInDaisy audio_in_right (module, AudioInDaisyPinRight);
 
-   AudioOutDaisy audio_out_left (module, AudioOutDaisy::Pin::Left);
-   AudioOutDaisy audio_out_right (module, AudioOutDaisy::Pin::Right);
+   AudioOutDaisy audio_out_left (module, AudioOutDaisyPinLeft);
+   AudioOutDaisy audio_out_right (module, AudioOutDaisyPinRight);
 
    module.run ([&](){
       audio_out_left = audio_in_left;

--- a/audio-out-daisy/test/main.cpp
+++ b/audio-out-daisy/test/main.cpp
@@ -28,8 +28,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out_left (module, AudioOutDaisy::Pin::Left);
-   AudioOutDaisy audio_out_right (module, AudioOutDaisy::Pin::Right);
+   AudioOutDaisy audio_out_left (module, AudioOutDaisyPinLeft);
+   AudioOutDaisy audio_out_right (module, AudioOutDaisyPinRight);
 
    constexpr float pim2 = 2.f * float (M_PI);
    constexpr float phase_step = pim2 * 440.f / erb::sample_rate;

--- a/button/test/main.cpp
+++ b/button/test/main.cpp
@@ -26,8 +26,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out_left (module, AudioOutDaisy::Pin::Left);
-   AudioOutDaisy audio_out_right (module, AudioOutDaisy::Pin::Right);
+   AudioOutDaisy audio_out_left (module, AudioOutDaisyPinLeft);
+   AudioOutDaisy audio_out_right (module, AudioOutDaisyPinRight);
 
    // Pins are the same as the GATE IN 1/2 on Daisy Patch
    Button button_1 (module, Pin20);

--- a/cv-in/test/main.cpp
+++ b/cv-in/test/main.cpp
@@ -62,8 +62,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out_left (module, AudioOutDaisy::Pin::Left);
-   AudioOutDaisy audio_out_right (module, AudioOutDaisy::Pin::Right);
+   AudioOutDaisy audio_out_left (module, AudioOutDaisyPinLeft);
+   AudioOutDaisy audio_out_right (module, AudioOutDaisyPinRight);
 
    // Pins are the same as the CTRL 1..4 on Daisy Patch
    CvIn ctrl_1 (module, AdcPin0); // osc1 amplitude

--- a/gate-in/test/main.cpp
+++ b/gate-in/test/main.cpp
@@ -26,8 +26,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out0 (module, AudioOutDaisy::Pin::Channel0);
-   AudioOutDaisy audio_out1 (module, AudioOutDaisy::Pin::Channel1);
+   AudioOutDaisy audio_out0 (module, AudioOutDaisyPin0);
+   AudioOutDaisy audio_out1 (module, AudioOutDaisyPin1);
 
    // Pins are the same as the GATE IN 1/2 on Daisy Patch
    GateIn gate_in_1 (module, Pin20);

--- a/gate-out/test/main.cpp
+++ b/gate-out/test/main.cpp
@@ -26,10 +26,10 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioInDaisy audio_in0 (module, AudioInDaisy::Pin::Channel0);
-   AudioInDaisy audio_in1 (module, AudioInDaisy::Pin::Channel1);
-   AudioOutDaisy audio_out0 (module, AudioOutDaisy::Pin::Channel0);
-   AudioOutDaisy audio_out1 (module, AudioOutDaisy::Pin::Channel1);
+   AudioInDaisy audio_in0 (module, AudioInDaisyPin0);
+   AudioInDaisy audio_in1 (module, AudioInDaisyPin1);
+   AudioOutDaisy audio_out0 (module, AudioOutDaisyPin0);
+   AudioOutDaisy audio_out1 (module, AudioOutDaisyPin1);
 
    // Pin is the same as the GATE OUT on Daisy Patch
    GateOut gate_out (module, Pin17);

--- a/include/erb/AudioInDaisy.h
+++ b/include/erb/AudioInDaisy.h
@@ -15,6 +15,7 @@
 
 #include "erb/Constants.h"
 #include "erb/ModuleListener.h"
+#include "erb/Pins.h"
 
 #include <array>
 
@@ -34,17 +35,9 @@ class AudioInDaisy
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
-   enum class Pin
-   {
-                  Left,
-                  Right,
-                  Channel0,   // alias to 'Left'
-                  Channel1,   // alias to 'Right'
-   };
-
    using Buffer = std::array <float, buffer_size>;
 
-                  AudioInDaisy (Module & module, Pin pin);
+                  AudioInDaisy (Module & module, AudioInDaisyPin pin);
    virtual        ~AudioInDaisy () override = default;
 
                   operator Buffer () const;
@@ -70,7 +63,6 @@ protected:
 /*\\\ PRIVATE \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 private:
-   static size_t  to_channel (Pin pin);
 
    Module &       _module;
    const size_t   _channel;

--- a/include/erb/AudioOutDaisy.h
+++ b/include/erb/AudioOutDaisy.h
@@ -15,6 +15,7 @@
 
 #include "erb/Constants.h"
 #include "erb/ModuleListener.h"
+#include "erb/Pins.h"
 
 #include <array>
 
@@ -34,17 +35,9 @@ class AudioOutDaisy
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
-   enum class Pin
-   {
-                  Left,
-                  Right,
-                  Channel0,   // alias to 'Left'
-                  Channel1,   // alias to 'Right'
-   };
-
    using Buffer = std::array <float, buffer_size>;
 
-                  AudioOutDaisy (Module & module, Pin pin);
+                  AudioOutDaisy (Module & module, AudioOutDaisyPin pin);
    virtual        ~AudioOutDaisy () override = default;
 
    AudioOutDaisy &
@@ -73,7 +66,6 @@ protected:
 /*\\\ PRIVATE \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 private:
-   static size_t  to_channel (Pin pin);
 
    Module &       _module;
    const size_t   _channel;

--- a/include/erb/Pins.h
+++ b/include/erb/Pins.h
@@ -79,6 +79,30 @@ static constexpr AdcPin AdcPin11 = {Pin28};
 
 
 
+struct AudioInDaisyPin
+{
+   size_t pin;
+};
+
+static constexpr AudioInDaisyPin AudioInDaisyPinLeft =  {0};
+static constexpr AudioInDaisyPin AudioInDaisyPinRight = {1};
+static constexpr AudioInDaisyPin AudioInDaisyPin0 =     {0};
+static constexpr AudioInDaisyPin AudioInDaisyPin1 =     {1};
+
+
+
+struct AudioOutDaisyPin
+{
+   size_t pin;
+};
+
+static constexpr AudioOutDaisyPin AudioOutDaisyPinLeft =  {0};
+static constexpr AudioOutDaisyPin AudioOutDaisyPinRight = {1};
+static constexpr AudioOutDaisyPin AudioOutDaisyPin0 =     {0};
+static constexpr AudioOutDaisyPin AudioOutDaisyPin1 =     {1};
+
+
+
 }  // namespace erb
 
 

--- a/pot/test/main.cpp
+++ b/pot/test/main.cpp
@@ -62,8 +62,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out0 (module, AudioOutDaisy::Pin::Channel0);
-   AudioOutDaisy audio_out1 (module, AudioOutDaisy::Pin::Channel1);
+   AudioOutDaisy audio_out0 (module, AudioOutDaisyPin0);
+   AudioOutDaisy audio_out1 (module, AudioOutDaisyPin1);
 
    // Pins are the same as the CTRL 1..4 on Daisy Patch
    Pot ctrl_1 (module, AdcPin0); // osc1 amplitude

--- a/src/AudioInDaisy.cpp
+++ b/src/AudioInDaisy.cpp
@@ -30,9 +30,9 @@ Name : ctor
 ==============================================================================
 */
 
-AudioInDaisy::AudioInDaisy (Module & module, Pin pin)
+AudioInDaisy::AudioInDaisy (Module & module, AudioInDaisyPin pin)
 :  _module (module)
-,  _channel (to_channel (pin))
+,  _channel (pin.pin)
 {
    module.add (*this);
 }
@@ -100,28 +100,6 @@ void  AudioInDaisy::impl_notify_audio_buffer_start ()
 
 
 /*\\\ PRIVATE \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
-
-/*
-==============================================================================
-Name : to_channel
-==============================================================================
-*/
-
-size_t   AudioInDaisy::to_channel (Pin pin)
-{
-   switch (pin)
-   {
-   case Pin::Left:
-   case Pin::Channel0:
-      return 0;
-
-   case Pin::Right:
-   case Pin::Channel1:
-      return 1;
-   }
-
-   __builtin_unreachable ();
-}
 
 
 

--- a/src/AudioOutDaisy.cpp
+++ b/src/AudioOutDaisy.cpp
@@ -30,9 +30,9 @@ Name : ctor
 ==============================================================================
 */
 
-AudioOutDaisy::AudioOutDaisy (Module & module, Pin pin)
+AudioOutDaisy::AudioOutDaisy (Module & module, AudioOutDaisyPin pin)
 :  _module (module)
-,  _channel (to_channel (pin))
+,  _channel (pin.pin)
 {
    module.add (*this);
 }
@@ -128,28 +128,6 @@ void  AudioOutDaisy::impl_notify_audio_buffer_end ()
 
 
 /*\\\ PRIVATE \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
-
-/*
-==============================================================================
-Name : to_channel
-==============================================================================
-*/
-
-size_t   AudioOutDaisy::to_channel (Pin pin)
-{
-   switch (pin)
-   {
-   case Pin::Left:
-   case Pin::Channel0:
-      return 0;
-
-   case Pin::Right:
-   case Pin::Channel1:
-      return 1;
-   }
-
-   __builtin_unreachable ();
-}
 
 
 

--- a/switch/test/main.cpp
+++ b/switch/test/main.cpp
@@ -28,8 +28,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out0 (module, AudioOutDaisy::Pin::Channel0);
-   AudioOutDaisy audio_out1 (module, AudioOutDaisy::Pin::Channel1);
+   AudioOutDaisy audio_out0 (module, AudioOutDaisyPin0);
+   AudioOutDaisy audio_out1 (module, AudioOutDaisyPin1);
    Switch switch_ (module, Pin19, Pin20);
 
    constexpr float pim2 = 2.f * float (M_PI);


### PR DESCRIPTION
This PR uniformises the audio pin configuration for `AudioInDaisy` and `AudioOutDaisy`, so that it is similar to the other blocks' software implementations.