### PR TITLE
Add pin type alias to dsy_gpio_pin

### DIFF
--- a/include/erb/AdcChannels.h
+++ b/include/erb/AdcChannels.h
@@ -13,7 +13,7 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-#include "per/adc.h"
+#include "erb/Pins.h"
 
 #include <array>
 
@@ -42,7 +42,7 @@ public:
                   AdcChannels (daisy::DaisySeed & seed);
    virtual        ~AdcChannels () = default;
 
-   void           add (AnalogControlBase & control, const dsy_gpio_pin & pin);
+   void           add (AnalogControlBase & control, const Pin & pin);
 
    void           init ();
 

--- a/include/erb/Button.h
+++ b/include/erb/Button.h
@@ -14,8 +14,8 @@
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 #include "erb/ModuleListener.h"
+#include "erb/Pins.h"
 
-#include "daisy_core.h"
 #include "per/gpio.h"
 
 
@@ -34,7 +34,7 @@ class Button
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
-                  Button (Module & module, const dsy_gpio_pin & pin);
+                  Button (Module & module, const Pin & pin);
    virtual        ~Button () override = default;
 
    bool           pressed () const;
@@ -61,7 +61,7 @@ protected:
 private:
 
    static dsy_gpio
-                  to_gpio (const dsy_gpio_pin & pin);
+                  to_gpio (const Pin & pin);
 
    const dsy_gpio _gpio;
 

--- a/include/erb/GateIn.h
+++ b/include/erb/GateIn.h
@@ -14,8 +14,8 @@
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 #include "erb/ModuleListener.h"
+#include "erb/Pins.h"
 
-#include "daisy_core.h"
 #include "per/gpio.h"
 
 
@@ -40,7 +40,7 @@ public:
       Trigger, Gate
    };
 
-                  GateIn (Module & module, const dsy_gpio_pin & pin, Mode mode = Mode::Trigger);
+                  GateIn (Module & module, const Pin & pin, Mode mode = Mode::Trigger);
    virtual        ~GateIn () override = default;
 
    void           set_mode (Mode mode);
@@ -50,7 +50,7 @@ public:
 
 /*\\\ INTERNAL \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-                  GateIn (const dsy_gpio_pin & pin, Mode mode);
+                  GateIn (const Pin & pin, Mode mode);
 
    // ModuleListener
    virtual void   impl_notify_audio_buffer_start () override;
@@ -68,7 +68,7 @@ protected:
 private:
 
    static dsy_gpio
-                  to_gpio (const dsy_gpio_pin & pin);
+                  to_gpio (const Pin & pin);
 
    const dsy_gpio _gpio;
 

--- a/include/erb/GateOut.h
+++ b/include/erb/GateOut.h
@@ -14,8 +14,8 @@
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 #include "erb/ModuleListener.h"
+#include "erb/Pins.h"
 
-#include "daisy_core.h"
 #include "per/gpio.h"
 
 #include <chrono>
@@ -40,7 +40,7 @@ class GateOut
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
-                  GateOut (Module & module, const dsy_gpio_pin & pin);
+                  GateOut (Module & module, const Pin & pin);
    virtual        ~GateOut () = default;
 
    void           on ();
@@ -72,7 +72,7 @@ private:
    };
 
    static dsy_gpio
-                  to_gpio (const dsy_gpio_pin & pin);
+                  to_gpio (const Pin & pin);
 
    Module &       _module;
    const dsy_gpio _gpio;

--- a/include/erb/Led.h
+++ b/include/erb/Led.h
@@ -14,8 +14,8 @@
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 #include "erb/ModuleListener.h"
+#include "erb/Pins.h"
 
-#include "daisy_core.h"
 #include "per/gpio.h"
 
 #include <chrono>
@@ -40,7 +40,7 @@ class Led
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
-                  Led (Module & module, const dsy_gpio_pin & pin);
+                  Led (Module & module, const Pin & pin);
    virtual        ~Led () = default;
 
    void           on (bool state = true);
@@ -73,7 +73,7 @@ private:
    };
 
    static dsy_gpio
-                  to_gpio (const dsy_gpio_pin & pin);
+                  to_gpio (const Pin & pin);
 
    Module &       _module;
    const dsy_gpio _gpio;

--- a/include/erb/LedBi.h
+++ b/include/erb/LedBi.h
@@ -39,7 +39,7 @@ public:
       Red, Yellow, Green
    };
 
-                  LedBi (Module & module, const dsy_gpio_pin & pin_r, const dsy_gpio_pin & pin_g);
+                  LedBi (Module & module, const Pin & pin_r, const Pin & pin_g);
    virtual        ~LedBi () = default;
 
    void           on (Color color);

--- a/include/erb/Module.h
+++ b/include/erb/Module.h
@@ -62,7 +62,7 @@ public:
 /*\\\ INTERNAL \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
    uint32_t       now_ms ();
-   void           add (AnalogControlBase & control, const dsy_gpio_pin & pin);
+   void           add (AnalogControlBase & control, const Pin & pin);
    void           add (ModuleListener & listener);
 
    const Buffer & impl_onboard_codec_buffer_input () const;

--- a/include/erb/Pins.h
+++ b/include/erb/Pins.h
@@ -22,40 +22,42 @@ namespace erb
 
 
 
-static constexpr dsy_gpio_pin Pin0 =  {DSY_GPIOB, 12};
-static constexpr dsy_gpio_pin Pin1 =  {DSY_GPIOC, 11};
-static constexpr dsy_gpio_pin Pin2 =  {DSY_GPIOC, 10};
-static constexpr dsy_gpio_pin Pin3 =  {DSY_GPIOC, 9};
-static constexpr dsy_gpio_pin Pin4 =  {DSY_GPIOC, 8};
-static constexpr dsy_gpio_pin Pin5 =  {DSY_GPIOD, 2};
-static constexpr dsy_gpio_pin Pin6 =  {DSY_GPIOC, 12};
+using Pin = dsy_gpio_pin;
 
-static constexpr dsy_gpio_pin Pin7 =  {DSY_GPIOG, 10};
-static constexpr dsy_gpio_pin Pin8 =  {DSY_GPIOG, 11};
-static constexpr dsy_gpio_pin Pin9 =  {DSY_GPIOB, 4};
-static constexpr dsy_gpio_pin Pin10 = {DSY_GPIOB, 5};
-static constexpr dsy_gpio_pin Pin11 = {DSY_GPIOB, 8};
-static constexpr dsy_gpio_pin Pin12 = {DSY_GPIOB, 9};
-static constexpr dsy_gpio_pin Pin13 = {DSY_GPIOB, 6};
-static constexpr dsy_gpio_pin Pin14 = {DSY_GPIOB, 7};
+static constexpr Pin Pin0 =  {DSY_GPIOB, 12};
+static constexpr Pin Pin1 =  {DSY_GPIOC, 11};
+static constexpr Pin Pin2 =  {DSY_GPIOC, 10};
+static constexpr Pin Pin3 =  {DSY_GPIOC, 9};
+static constexpr Pin Pin4 =  {DSY_GPIOC, 8};
+static constexpr Pin Pin5 =  {DSY_GPIOD, 2};
+static constexpr Pin Pin6 =  {DSY_GPIOC, 12};
 
-static constexpr dsy_gpio_pin Pin15 = {DSY_GPIOC, 0};
-static constexpr dsy_gpio_pin Pin16 = {DSY_GPIOA, 3};
-static constexpr dsy_gpio_pin Pin17 = {DSY_GPIOB, 1};
-static constexpr dsy_gpio_pin Pin18 = {DSY_GPIOA, 7};
-static constexpr dsy_gpio_pin Pin19 = {DSY_GPIOA, 6};
-static constexpr dsy_gpio_pin Pin20 = {DSY_GPIOC, 1};
-static constexpr dsy_gpio_pin Pin21 = {DSY_GPIOC, 4};
-static constexpr dsy_gpio_pin Pin22 = {DSY_GPIOA, 5};
+static constexpr Pin Pin7 =  {DSY_GPIOG, 10};
+static constexpr Pin Pin8 =  {DSY_GPIOG, 11};
+static constexpr Pin Pin9 =  {DSY_GPIOB, 4};
+static constexpr Pin Pin10 = {DSY_GPIOB, 5};
+static constexpr Pin Pin11 = {DSY_GPIOB, 8};
+static constexpr Pin Pin12 = {DSY_GPIOB, 9};
+static constexpr Pin Pin13 = {DSY_GPIOB, 6};
+static constexpr Pin Pin14 = {DSY_GPIOB, 7};
 
-static constexpr dsy_gpio_pin Pin23 = {DSY_GPIOA, 4};
-static constexpr dsy_gpio_pin Pin24 = {DSY_GPIOA, 1};
-static constexpr dsy_gpio_pin Pin25 = {DSY_GPIOA, 0};
-static constexpr dsy_gpio_pin Pin26 = {DSY_GPIOD, 11};
-static constexpr dsy_gpio_pin Pin27 = {DSY_GPIOG, 9};
-static constexpr dsy_gpio_pin Pin28 = {DSY_GPIOA, 2};
-static constexpr dsy_gpio_pin Pin29 = {DSY_GPIOB, 14};
-static constexpr dsy_gpio_pin Pin30 = {DSY_GPIOB, 15};
+static constexpr Pin Pin15 = {DSY_GPIOC, 0};
+static constexpr Pin Pin16 = {DSY_GPIOA, 3};
+static constexpr Pin Pin17 = {DSY_GPIOB, 1};
+static constexpr Pin Pin18 = {DSY_GPIOA, 7};
+static constexpr Pin Pin19 = {DSY_GPIOA, 6};
+static constexpr Pin Pin20 = {DSY_GPIOC, 1};
+static constexpr Pin Pin21 = {DSY_GPIOC, 4};
+static constexpr Pin Pin22 = {DSY_GPIOA, 5};
+
+static constexpr Pin Pin23 = {DSY_GPIOA, 4};
+static constexpr Pin Pin24 = {DSY_GPIOA, 1};
+static constexpr Pin Pin25 = {DSY_GPIOA, 0};
+static constexpr Pin Pin26 = {DSY_GPIOD, 11};
+static constexpr Pin Pin27 = {DSY_GPIOG, 9};
+static constexpr Pin Pin28 = {DSY_GPIOA, 2};
+static constexpr Pin Pin29 = {DSY_GPIOB, 14};
+static constexpr Pin Pin30 = {DSY_GPIOB, 15};
 
 
 

--- a/include/erb/Switch.h
+++ b/include/erb/Switch.h
@@ -38,7 +38,7 @@ public:
       Out0, Center, Out1
    };
 
-                  Switch (Module & module, const dsy_gpio_pin & pin_0, const dsy_gpio_pin & pin_1);
+                  Switch (Module & module, const Pin & pin_0, const Pin & pin_1);
    virtual        ~Switch () override = default;
 
                   operator Position () const;

--- a/src/AdcChannels.cpp
+++ b/src/AdcChannels.cpp
@@ -54,7 +54,7 @@ Name : add
 ==============================================================================
 */
 
-void  AdcChannels::add (AnalogControlBase & control, const dsy_gpio_pin & pin)
+void  AdcChannels::add (AnalogControlBase & control, const Pin & pin)
 {
    auto & channel = _channels [_nbr_adc_channel];
    ++_nbr_adc_channel;

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -30,7 +30,7 @@ Name : ctor
 ==============================================================================
 */
 
-Button::Button (Module & module, const dsy_gpio_pin & pin)
+Button::Button (Module & module, const Pin & pin)
 :  _gpio (to_gpio (pin))
 {
    module.add (*this);
@@ -98,7 +98,7 @@ Name : to_gpio
 ==============================================================================
 */
 
-dsy_gpio Button::to_gpio (const dsy_gpio_pin & pin)
+dsy_gpio Button::to_gpio (const Pin & pin)
 {
    dsy_gpio gpio;
    gpio.pin = pin;

--- a/src/GateIn.cpp
+++ b/src/GateIn.cpp
@@ -30,7 +30,7 @@ Name : ctor
 ==============================================================================
 */
 
-GateIn::GateIn (Module & module, const dsy_gpio_pin & pin, Mode mode)
+GateIn::GateIn (Module & module, const Pin & pin, Mode mode)
 :  _gpio (to_gpio (pin))
 ,  _mode (mode)
 {
@@ -85,7 +85,7 @@ Name : ctor
 ==============================================================================
 */
 
-GateIn::GateIn (const dsy_gpio_pin & pin, Mode mode)
+GateIn::GateIn (const Pin & pin, Mode mode)
 :  _gpio (to_gpio (pin))
 ,  _mode (mode)
 {
@@ -114,7 +114,7 @@ Name : to_gpio
 ==============================================================================
 */
 
-dsy_gpio GateIn::to_gpio (const dsy_gpio_pin & pin)
+dsy_gpio GateIn::to_gpio (const Pin & pin)
 {
    dsy_gpio gpio;
    gpio.pin = pin;

--- a/src/GateOut.cpp
+++ b/src/GateOut.cpp
@@ -41,7 +41,7 @@ Name : ctor
 ==============================================================================
 */
 
-GateOut::GateOut (Module & module, const dsy_gpio_pin & pin)
+GateOut::GateOut (Module & module, const Pin & pin)
 :  _module (module)
 ,  _gpio (to_gpio (pin))
 {
@@ -125,7 +125,7 @@ Name : to_gpio
 ==============================================================================
 */
 
-dsy_gpio GateOut::to_gpio (const dsy_gpio_pin & pin)
+dsy_gpio GateOut::to_gpio (const Pin & pin)
 {
    dsy_gpio gpio;
    gpio.pin = pin;

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -41,7 +41,7 @@ Name : ctor
 ==============================================================================
 */
 
-Led::Led (Module & module, const dsy_gpio_pin & pin)
+Led::Led (Module & module, const Pin & pin)
 :  _module (module)
 ,  _gpio (to_gpio (pin))
 {
@@ -148,7 +148,7 @@ Name : to_gpio
 ==============================================================================
 */
 
-dsy_gpio Led::to_gpio (const dsy_gpio_pin & pin)
+dsy_gpio Led::to_gpio (const Pin & pin)
 {
    dsy_gpio gpio;
    gpio.pin = pin;

--- a/src/LedBi.cpp
+++ b/src/LedBi.cpp
@@ -41,7 +41,7 @@ Name : ctor
 ==============================================================================
 */
 
-LedBi::LedBi (Module & module, const dsy_gpio_pin & pin_r, const dsy_gpio_pin & pin_g)
+LedBi::LedBi (Module & module, const Pin & pin_r, const Pin & pin_g)
 :  _led_red (module, pin_r)
 ,  _led_green (module, pin_g)
 {

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -69,7 +69,7 @@ Name : add
 ==============================================================================
 */
 
-void  Module::add (AnalogControlBase & control, const dsy_gpio_pin & pin)
+void  Module::add (AnalogControlBase & control, const Pin & pin)
 {
    _adc_channels.add (control, pin);
    _listeners.add (control);

--- a/src/Switch.cpp
+++ b/src/Switch.cpp
@@ -30,7 +30,7 @@ Name : ctor
 ==============================================================================
 */
 
-Switch::Switch (Module & module, const dsy_gpio_pin & pin_0, const dsy_gpio_pin & pin_1)
+Switch::Switch (Module & module, const Pin & pin_0, const Pin & pin_1)
 :  _gate_0 (pin_0, GateIn::Mode::Gate)
 ,  _gate_1 (pin_1, GateIn::Mode::Gate)
 {


### PR DESCRIPTION
This PR adds an alias to the pin description to abstract libDaisy better.