### PR TITLE
Change current time implementation to 64-bit and sample process based

### DIFF
--- a/include/erb/GateOut.h
+++ b/include/erb/GateOut.h
@@ -79,8 +79,8 @@ private:
 
    Mode           _mode;
    bool           _current = false;
-   uint32_t       _start = 0;
-   uint32_t       _duration = 0;
+   uint64_t       _start = 0;
+   uint64_t       _duration = 0;
 
 
 

--- a/include/erb/Led.h
+++ b/include/erb/Led.h
@@ -80,8 +80,8 @@ private:
 
    Mode           _mode;
    bool           _current = false;
-   uint32_t       _start = 0;
-   uint32_t       _duration = 0;
+   uint64_t       _start = 0;
+   uint64_t       _duration = 0;
 
 
 

--- a/include/erb/Module.h
+++ b/include/erb/Module.h
@@ -54,7 +54,7 @@ public:
 
 /*\\\ INTERNAL \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-   uint32_t       now_ms ();
+   uint64_t       now_ms ();
    void           add (AnalogControlBase & control, const Pin & pin);
    void           add (Multiplexer & multiplexer, const Pin & pin, const MultiplexerAddressPins & address_pins);
    void           add (ModuleListener & listener);
@@ -87,6 +87,9 @@ private:
                   _seed;
    std::function <void ()>
                   _buffer_callback;
+
+   uint64_t       _now_spl = 0ull;
+   uint64_t       _now_ms = 0ull;
 
    Buffer         _onboard_codec_buffer_input;
    Buffer         _onboard_codec_buffer_output;

--- a/src/GateOut.cpp
+++ b/src/GateOut.cpp
@@ -82,7 +82,7 @@ void  GateOut::trigger (std::chrono::milliseconds duration)
 {
    _mode = Mode::Pulse;
    _start = _module.now_ms ();
-   _duration = uint32_t (duration.count ());
+   _duration = uint64_t (duration.count ());
 
    _current = true;
 }

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -82,7 +82,7 @@ void  Led::pulse (std::chrono::milliseconds duration)
 {
    _mode = Mode::Pulse;
    _start = _module.now_ms ();
-   _duration = uint32_t (duration.count ());
+   _duration = uint64_t (duration.count ());
 
    _current = true;
 }
@@ -99,7 +99,7 @@ void  Led::blink (std::chrono::milliseconds half_period)
 {
    _mode = Mode::Blink;
    _start = _module.now_ms ();
-   _duration = uint32_t (half_period.count ());
+   _duration = uint64_t (half_period.count ());
 
    _current = true;
 }

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -54,9 +54,9 @@ Name : now_ms
 ==============================================================================
 */
 
-uint32_t Module::now_ms ()
+uint64_t Module::now_ms ()
 {
-   return _seed.system.GetNow ();
+   return _now_ms;
 }
 
 
@@ -190,6 +190,9 @@ Name : audio_callback
 
 void  Module::audio_callback (float ** in, float ** out, size_t /* size */)
 {
+   constexpr uint64_t sample_rate_ull = uint64_t (sample_rate);
+   constexpr uint64_t buffer_size_ull = buffer_size;
+
    // Map eurorack audio level (-5V, 5V) to (-1.f, 1.f)
    constexpr float gain_in = 2.3f;
 
@@ -203,6 +206,9 @@ void  Module::audio_callback (float ** in, float ** out, size_t /* size */)
          frame [j] = gain_in * in_arr [j];
       }
    }
+
+   _now_ms = (_now_spl * 1000) / sample_rate_ull;
+   _now_spl += buffer_size_ull;
 
    _listeners.notify_audio_buffer_start ();
 


### PR DESCRIPTION
This PR update the `now_ms` implementation to a 64-bit representation of time in ms, to overcome potential 32-bit wrapping bugs after around 50 days of continuous use. The definition of time is also now sample based and is therefore predictable.

This PR is preparation work for the upcoming vcvrack target.
