### PR TITLE
Fix samples drop build

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -115,6 +115,26 @@ def build (name, path):
 
 """
 ==============================================================================
+Name : build_target
+==============================================================================
+"""
+
+def build_target (name, target, path):
+   path_artifacts = os.path.join (path, 'artifacts')
+   configuration = 'Release'
+
+   cmd = [
+      'ninja',
+      '-C', os.path.join (path_artifacts, 'out', configuration),
+      target
+   ]
+
+   subprocess.check_call (cmd)
+
+
+
+"""
+==============================================================================
 Name : objcopy
 ==============================================================================
 """

--- a/samples/drop/build.py
+++ b/samples/drop/build.py
@@ -32,7 +32,7 @@ if sys.version_info < (2, 7):
 
 if __name__ == '__main__':
    try:
-      erbb.build ('drop', PATH_THIS)
+      erbb.build_target ('drop', 'drop', PATH_THIS)
       erbb.objcopy ('drop', PATH_THIS)
 
    except subprocess.CalledProcessError as error:


### PR DESCRIPTION
This PR fixes when building `drop` when the `test` target, not meant to be built along the daisy target, was built and a link warning was issued. Now we only compile the right target.

This PR is also preparation work for the upcoming vcvrack target.