### PR TITLE
Disable warnings daisy include macro

### DIFF
--- a/include/erb/Module.h
+++ b/include/erb/Module.h
@@ -16,19 +16,11 @@
 #include "erb/AdcChannels.h"
 #include "erb/Constants.h"
 #include "erb/ModuleListeners.h"
+#include "erb/def.h"
 
-#if defined (__GNUC__)
-   #pragma GCC diagnostic push
-   #pragma GCC diagnostic ignored "-Wpedantic"
-   #pragma GCC diagnostic ignored "-Wignored-qualifiers"
-   #pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+erb_DISABLE_WARNINGS_DAISY
 #include "daisy_seed.h"
-
-#if defined (__GNUC__)
-   #pragma GCC diagnostic pop
-#endif
+erb_RESTORE_WARNINGS
 
 #include <array>
 #include <functional>

--- a/include/erb/def.h
+++ b/include/erb/def.h
@@ -24,5 +24,34 @@
 #endif
 
 
+/*\\\ WARNINGS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#if defined (__clang__)
+   #define erb_DISABLE_WARNINGS_DAISY \
+      _Pragma ("clang diagnostic push")
+
+   #define erb_RESTORE_WARNINGS \
+      _Pragma ("clang diagnostic pop")
+
+#elif defined (__GNUC__)
+   #define erb_DISABLE_WARNINGS_DAISY \
+      _Pragma ("GCC diagnostic push") \
+      _Pragma ("GCC diagnostic ignored \"-Wpedantic\"") \
+      _Pragma ("GCC diagnostic ignored \"-Wignored-qualifiers\"") \
+      _Pragma ("GCC diagnostic ignored \"-Wunused-parameter\"") \
+
+   #define erb_RESTORE_WARNINGS \
+      _Pragma ("GCC diagnostic pop")
+
+#elif defined (_MSC_VER)
+   #define erb_DISABLE_WARNINGS_DAISY \
+      __pragma (warning (push))
+
+   #define erb_RESTORE_WARNINGS \
+      __pragma (warning (pop))
+
+#endif
+
+
 
 /*\\\ EOF \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/src/AdcChannels.cpp
+++ b/src/AdcChannels.cpp
@@ -13,19 +13,11 @@
 
 #include "erb/AnalogControlBase.h"
 #include "erb/Multiplexer.h"
+#include "erb/def.h"
 
-#if defined (__GNUC__)
-   #pragma GCC diagnostic push
-   #pragma GCC diagnostic ignored "-Wpedantic"
-   #pragma GCC diagnostic ignored "-Wignored-qualifiers"
-   #pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+erb_DISABLE_WARNINGS_DAISY
 #include "daisy_seed.h"
-
-#if defined (__GNUC__)
-   #pragma GCC diagnostic pop
-#endif
+erb_RESTORE_WARNINGS
 
 
 

--- a/src/GateOut.cpp
+++ b/src/GateOut.cpp
@@ -12,19 +12,11 @@
 #include "erb/GateOut.h"
 
 #include "erb/Module.h"
+#include "erb/def.h"
 
-#if defined (__GNUC__)
-   #pragma GCC diagnostic push
-   #pragma GCC diagnostic ignored "-Wpedantic"
-   #pragma GCC diagnostic ignored "-Wignored-qualifiers"
-   #pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+erb_DISABLE_WARNINGS_DAISY
 #include "daisy_seed.h"
-
-#if defined (__GNUC__)
-   #pragma GCC diagnostic pop
-#endif
+erb_RESTORE_WARNINGS
 
 
 

--- a/src/Led.cpp
+++ b/src/Led.cpp
@@ -12,19 +12,11 @@
 #include "erb/Led.h"
 
 #include "erb/Module.h"
+#include "erb/def.h"
 
-#if defined (__GNUC__)
-   #pragma GCC diagnostic push
-   #pragma GCC diagnostic ignored "-Wpedantic"
-   #pragma GCC diagnostic ignored "-Wignored-qualifiers"
-   #pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+erb_DISABLE_WARNINGS_DAISY
 #include "daisy_seed.h"
-
-#if defined (__GNUC__)
-   #pragma GCC diagnostic pop
-#endif
+erb_RESTORE_WARNINGS
 
 
 

--- a/src/LedBi.cpp
+++ b/src/LedBi.cpp
@@ -14,18 +14,9 @@
 #include "erb/Module.h"
 #include "erb/def.h"
 
-#if defined (__GNUC__)
-   #pragma GCC diagnostic push
-   #pragma GCC diagnostic ignored "-Wpedantic"
-   #pragma GCC diagnostic ignored "-Wignored-qualifiers"
-   #pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+erb_DISABLE_WARNINGS_DAISY
 #include "daisy_seed.h"
-
-#if defined (__GNUC__)
-   #pragma GCC diagnostic pop
-#endif
+erb_RESTORE_WARNINGS
 
 
 

--- a/src/erb.cpp
+++ b/src/erb.cpp
@@ -10,19 +10,11 @@
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 #include "erb/erb.h"
+#include "erb/def.h"
 
-#if defined (__GNUC__)
-   #pragma GCC diagnostic push
-   #pragma GCC diagnostic ignored "-Wpedantic"
-   #pragma GCC diagnostic ignored "-Wignored-qualifiers"
-   #pragma GCC diagnostic ignored "-Wunused-parameter"
-#endif
-
+erb_DISABLE_WARNINGS_DAISY
 #include "daisy_seed.h"
-
-#if defined (__GNUC__)
-   #pragma GCC diagnostic pop
-#endif
+erb_RESTORE_WARNINGS
 
 
 


### PR DESCRIPTION
This PR fixes a warning were gcc is confused with enum classes when checking for switch coverage.