### PR TITLE
Switch to python3

### DIFF
--- a/.github/workflows/macos_10_15.yml
+++ b/.github/workflows/macos_10_15.yml
@@ -47,22 +47,6 @@ jobs:
       - run: python3 samples/drop/build.py
       - run: python3 samples/drop/build.py --erb-target vcvrack
 
-  software_py2:
-    name: Software (Python 2 Compat)
-    runs-on: macos-10.15
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - run: pip2 install future
-      - run: brew install armmbed/formulae/arm-none-eabi-gcc
-      - run: brew install ninja
-      - run: python2 blocks/test/configure.py
-      - run: python2 blocks/test/build.py
-      - run: python2 samples/drop/configure.py
-      - run: python2 samples/drop/build.py
-      - run: python2 samples/drop/build.py --erb-target vcvrack
-
   unit_tests:
     name: Unit Tests
     runs-on: macos-10.15
@@ -74,17 +58,3 @@ jobs:
       - run: python3 test/configure.py
       - run: python3 test/build.py
       - run: python3 test/run.py
-
-  unit_tests_py2:
-    name: Unit Tests (Python 2 Compat)
-    runs-on: macos-10.15
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - run: pip2 install future
-      - run: brew install ninja
-      - run: python2 test/configure.py
-      - run: python2 test/build.py
-      - run: python2 test/run.py
-

--- a/blocks/kits/build.py
+++ b/blocks/kits/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     build.py
 #
@@ -21,8 +21,8 @@ import zipfile
 
 ##############################################################################
 
-if sys.version_info < (2, 7):
-   print ('This script requires python 2.7 or greater.', file = sys.stderr)
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
    sys.exit (1)
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))

--- a/blocks/kits/stats.py
+++ b/blocks/kits/stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     stats.py
 #
@@ -21,8 +21,8 @@ import subprocess
 
 ##############################################################################
 
-if sys.version_info < (2, 7):
-   print ('This script requires python 2.7 or greater.', file = sys.stderr)
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
    sys.exit (1)
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))

--- a/blocks/test/build.py
+++ b/blocks/test/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     build.py
 #     Copyright (c) 2020 Raphael Dinge
@@ -23,8 +23,8 @@ import erbb
 
 ##############################################################################
 
-if sys.version_info < (2, 7):
-   print ('This script requires python 2.7 or greater.', file = sys.stderr)
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
    sys.exit (1)
 
 

--- a/blocks/test/configure.py
+++ b/blocks/test/configure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     configure.py
 #     Copyright (c) 2020 Raphael Dinge
@@ -23,8 +23,8 @@ import erbb
 
 ##############################################################################
 
-if sys.version_info < (2, 7):
-   print ('This script requires python 2.7 or greater.', file = sys.stderr)
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
    sys.exit (1)
 
 

--- a/blocks/test/deploy.py
+++ b/blocks/test/deploy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     deploy.py
 #     Copyright (c) 2020 Raphael Dinge
@@ -24,8 +24,8 @@ import erbb
 
 ##############################################################################
 
-if sys.version_info < (2, 7):
-   print ('This script requires python 2.7 or greater.', file = sys.stderr)
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
    sys.exit (1)
 
 

--- a/blocks/util/replace-bom-parts.py
+++ b/blocks/util/replace-bom-parts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     build.py
 #
@@ -8,6 +8,7 @@
 
 ##### IMPORT #################################################################
 
+from __future__ import print_function
 import argparse
 import ast
 import logging
@@ -22,8 +23,8 @@ PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
 
 ##############################################################################
 
-if sys.version_info < (2, 7):
-   print >>sys.stderr, 'This script requires python 2.7 or greater.'
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
    sys.exit (1)
 
 
@@ -267,5 +268,5 @@ if __name__ == '__main__':
       sys.exit (replace (parse_args ()))
 
    except subprocess.CalledProcessError as error:
-      print >>sys.stderr, 'Build command exited with %d' % error.returncode
+      print ('Replace command exited with %d' % error.returncode, file = sys.stderr)
       sys.exit(1)

--- a/samples/drop/build.py
+++ b/samples/drop/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     build.py
 #     Copyright (c) 2020 Raphael Dinge
@@ -24,8 +24,8 @@ import erbb
 
 ##############################################################################
 
-if sys.version_info < (2, 7):
-   print ('This script requires python 2.7 or greater.', file = sys.stderr)
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
    sys.exit (1)
 
 

--- a/samples/drop/configure.py
+++ b/samples/drop/configure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     configure.py
 #     Copyright (c) 2020 Raphael Dinge
@@ -23,8 +23,8 @@ import erbb
 
 ##############################################################################
 
-if sys.version_info < (2, 7):
-   print ('This script requires python 2.7 or greater.', file = sys.stderr)
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
    sys.exit (1)
 
 

--- a/samples/drop/deploy-vcv.py
+++ b/samples/drop/deploy-vcv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     deploy.py
 #     Copyright (c) 2020 Raphael Dinge
@@ -30,8 +30,8 @@ TARGET_BUILD_DIR = os.environ ['TARGET_BUILD_DIR']
 
 ##############################################################################
 
-if sys.version_info < (2, 7):
-   print >>sys.stderr, 'This script requires python 2.7 or greater.'
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
    sys.exit (1)
 
 
@@ -62,5 +62,5 @@ if __name__ == '__main__':
       )
 
    except subprocess.CalledProcessError as error:
-      print >>sys.stderr, 'Run command exited with %d' % error.returncode
+      print ('Deploy command exited with %d' % error.returncode, file = sys.stderr)
       sys.exit (1)

--- a/samples/drop/deploy.py
+++ b/samples/drop/deploy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     deploy.py
 #     Copyright (c) 2020 Raphael Dinge
@@ -23,8 +23,8 @@ import erbb
 
 ##############################################################################
 
-if sys.version_info < (2, 7):
-   print ('This script requires python 2.7 or greater.', file = sys.stderr)
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
    sys.exit (1)
 
 

--- a/samples/drop/drop.gyp
+++ b/samples/drop/drop.gyp
@@ -68,7 +68,7 @@
             {
                'postbuild_name': 'Copy to VCV Rack plug-ins folder',
                'action': [
-                  'python', 'deploy-vcv.py'
+                  'python3', 'deploy-vcv.py'
                ],
             },
          ],

--- a/test/build.py
+++ b/test/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     build.py
 #     Copyright (c) 2020 Raphael DINGE
@@ -20,8 +20,8 @@ import sys
 
 ##############################################################################
 
-if sys.version_info < (2, 7):
-   print ('This script requires python 2.7 or greater.', file = sys.stderr)
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
    sys.exit (1)
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))

--- a/test/configure.py
+++ b/test/configure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     configure.py
 #     Copyright (c) 2020 Raphael DINGE
@@ -25,8 +25,8 @@ import gyp
 
 ##############################################################################
 
-if sys.version_info < (2, 7):
-   print ('This script requires python 2.7 or greater.', file = sys.stderr)
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
    sys.exit (1)
 
 

--- a/test/run.py
+++ b/test/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #     run.py
 #     Copyright (c) 2020 Raphael DINGE
@@ -18,8 +18,8 @@ import sys
 
 ##############################################################################
 
-if sys.version_info < (2, 7):
-   print ('This script requires python 2.7 or greater.', file = sys.stderr)
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
    sys.exit (1)
 
 PATH_THIS = os.path.dirname (__file__)
@@ -66,5 +66,5 @@ if __name__ == '__main__':
       sys.exit (run (parse_args ()))
 
    except subprocess.CalledProcessError as error:
-      print ('Configure command exited with %d' % error.returncode, file = sys.stderr)
+      print ('Run command exited with %d' % error.returncode, file = sys.stderr)
       sys.exit(1)


### PR DESCRIPTION
This PR removes `python2` support and updates all she-bangs to `python3`.

This PR is motivated by he upcoming work on automations that requires at least Python 3.7.

> Note: because Kicad is still using internally python2.7 at least on macOS, the hardware implicit support for python2.7 is kept for those targets.
