### PR TITLE
Add missing samples drop panel svg file to copy rule

### DIFF
--- a/samples/drop/drop.gyp
+++ b/samples/drop/drop.gyp
@@ -49,6 +49,11 @@
          'type': 'shared_library',
 
          'dependencies': [ 'drop', 'erb-vcvrack' ],
+
+         'copies': [{
+            'destination': '<(PRODUCT_DIR)/res',
+            'files': [ 'artifacts/drop.svg' ],
+         }],
       },
    ],
 }


### PR DESCRIPTION
This PR is fixing the sample `drop` code to include the copy rule for the SVG panel.

The previous state was configuring and building but not running. This PR fixes that.