### PR TITLE
Fix label positioning for sample drop mute/hp control

### DIFF
--- a/samples/drop/DropGui.py
+++ b/samples/drop/DropGui.py
@@ -42,8 +42,8 @@
                'style': 'dailywell.2ms1',
                'rotation': '90°CCW',
                'labels': [
-                  { 'text': 'HP', 'positioning': 'left' },
-                  { 'text': 'MUTE', 'positioning': 'right' },
+                  { 'text': 'MUTE', 'positioning': 'left' },
+                  { 'text': 'HP', 'positioning': 'right' },
                ],
             },
             {


### PR DESCRIPTION
This PR fixes the label for the MUTE/HP control for which label positioning was wrong.