### PR TITLE
Fix symbol and footprint relative paths to kicad lib submodule

### DIFF
--- a/blocks/audio-in-daisy/fp-lib-table
+++ b/blocks/audio-in-daisy/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Connector_Thonk)(type KiCad)(uri ${KIPRJMOD}/../submodules/kicad-libs/footprints/Connector_Thonk.pretty)(options "")(descr ""))
+  (lib (name Connector_Thonk)(type KiCad)(uri ${KIPRJMOD}/../../submodules/kicad-libs/footprints/Connector_Thonk.pretty)(options "")(descr ""))
 )

--- a/blocks/audio-out-daisy/fp-lib-table
+++ b/blocks/audio-out-daisy/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Connector_Thonk)(type KiCad)(uri ${KIPRJMOD}/../submodules/kicad-libs/footprints/Connector_Thonk.pretty)(options "")(descr ""))
+  (lib (name Connector_Thonk)(type KiCad)(uri ${KIPRJMOD}/../../submodules/kicad-libs/footprints/Connector_Thonk.pretty)(options "")(descr ""))
 )

--- a/blocks/cv-in/fp-lib-table
+++ b/blocks/cv-in/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Connector_Thonk)(type KiCad)(uri ${KIPRJMOD}/../submodules/kicad-libs/footprints/Connector_Thonk.pretty)(options "")(descr ""))
+  (lib (name Connector_Thonk)(type KiCad)(uri ${KIPRJMOD}/../../submodules/kicad-libs/footprints/Connector_Thonk.pretty)(options "")(descr ""))
 )

--- a/blocks/gate-in/fp-lib-table
+++ b/blocks/gate-in/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Connector_Thonk)(type KiCad)(uri ${KIPRJMOD}/../submodules/kicad-libs/footprints/Connector_Thonk.pretty)(options "")(descr ""))
+  (lib (name Connector_Thonk)(type KiCad)(uri ${KIPRJMOD}/../../submodules/kicad-libs/footprints/Connector_Thonk.pretty)(options "")(descr ""))
 )

--- a/blocks/gate-out/fp-lib-table
+++ b/blocks/gate-out/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Connector_Thonk)(type KiCad)(uri ${KIPRJMOD}/../submodules/kicad-libs/footprints/Connector_Thonk.pretty)(options "")(descr ""))
+  (lib (name Connector_Thonk)(type KiCad)(uri ${KIPRJMOD}/../../submodules/kicad-libs/footprints/Connector_Thonk.pretty)(options "")(descr ""))
 )

--- a/blocks/kits/fp-lib-table
+++ b/blocks/kits/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Panelization)(type KiCad)(uri ${KIPRJMOD}/../submodules/kicad-libs/footprints/Panelization.pretty)(options "")(descr ""))
+  (lib (name Panelization)(type KiCad)(uri ${KIPRJMOD}/../../submodules/kicad-libs/footprints/Panelization.pretty)(options "")(descr ""))
 )

--- a/blocks/pot/fp-lib-table
+++ b/blocks/pot/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Potentiometer_Thonk)(type KiCad)(uri ${KIPRJMOD}/../submodules/kicad-libs/footprints/Potentiometer_Thonk.pretty)(options "")(descr ""))
+  (lib (name Potentiometer_Thonk)(type KiCad)(uri ${KIPRJMOD}/../../submodules/kicad-libs/footprints/Potentiometer_Thonk.pretty)(options "")(descr ""))
 )

--- a/blocks/slider/fp-lib-table
+++ b/blocks/slider/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Package_Bourns)(type KiCad)(uri /${KIPRJMOD}/../submodules/kicad-libs/footprints/Package_Bourns.pretty)(options "")(descr ""))
+  (lib (name Package_Bourns)(type KiCad)(uri /${KIPRJMOD}/../../submodules/kicad-libs/footprints/Package_Bourns.pretty)(options "")(descr ""))
 )

--- a/blocks/slider/sym-lib-table
+++ b/blocks/slider/sym-lib-table
@@ -1,3 +1,3 @@
 (sym_lib_table
-  (lib (name Bourns)(type Legacy)(uri "$(KIPRJMOD)/../submodules/kicad-libs/symbols/Bourns.lib")(options "")(descr ""))
+  (lib (name Bourns)(type Legacy)(uri "$(KIPRJMOD)/../../submodules/kicad-libs/symbols/Bourns.lib")(options "")(descr ""))
 )

--- a/blocks/switch/fp-lib-table
+++ b/blocks/switch/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Switch_Thonk)(type KiCad)(uri ${KIPRJMOD}/../submodules/kicad-libs/footprints/Switch_Thonk.pretty)(options "")(descr ""))
+  (lib (name Switch_Thonk)(type KiCad)(uri ${KIPRJMOD}/../../submodules/kicad-libs/footprints/Switch_Thonk.pretty)(options "")(descr ""))
 )

--- a/blocks/trim/fp-lib-table
+++ b/blocks/trim/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name Potentiometer_Thonk)(type KiCad)(uri ${KIPRJMOD}/../submodules/kicad-libs/footprints/Potentiometer_Thonk.pretty)(options "")(descr ""))
+  (lib (name Potentiometer_Thonk)(type KiCad)(uri ${KIPRJMOD}/../../submodules/kicad-libs/footprints/Potentiometer_Thonk.pretty)(options "")(descr ""))
 )


### PR DESCRIPTION
This PR fixes symbol and footprint relative paths to the `kicad-libs` submodule in blocks KiCad projects.