### PR TITLE
Fix and refactor ck d6 name to d6r

### DIFF
--- a/build-system/erbb/ast.py
+++ b/build-system/erbb/ast.py
@@ -516,12 +516,12 @@ class Style (Scope):
       return self.name == 'tl1105'
 
    @property
-   def is_ck_d6 (self):
-      return self.is_ck_d6_black
+   def is_ck_d6r (self):
+      return self.is_ck_d6r_black
 
    @property
-   def is_ck_d6_black (self):
-      return self.name == 'ck.d6.black'
+   def is_ck_d6r_black (self):
+      return self.name == 'ck.d6r.black'
 
 
 

--- a/build-system/erbb/generators/detail/panel.py
+++ b/build-system/erbb/generators/detail/panel.py
@@ -239,7 +239,7 @@ class Panel:
          radius = 8.0 * 0.5
          return Panel.Box (radius, radius, radius, radius)
 
-      elif style.is_ck_d6_black:
+      elif style.is_ck_d6r_black:
          radius = 9.0 * 0.5
          return Panel.Box (radius, radius, radius, radius)
 

--- a/build-system/erbb/generators/front_panel/milling.py
+++ b/build-system/erbb/generators/front_panel/milling.py
@@ -138,7 +138,7 @@ class Milling:
       elif style.is_thonk_pj398sm:
          return 6.5
 
-      elif style.is_ck_d6:
+      elif style.is_ck_d6r:
          return 9.6
 
       elif style.is_tl1105:

--- a/build-system/erbb/generators/vcvrack/code.py
+++ b/build-system/erbb/generators/vcvrack/code.py
@@ -133,7 +133,7 @@ class Code:
          'led.3mm.green_red': 'MediumLight <GreenRedLight>',
          'thonk.pj398sm.knurled': 'erb::ThonkPj398SmKnurled',
          'thonk.pj398sm.hex': 'erb::ThonkPj398SmHex',
-         'ck.d6.black': 'CKD6',
+         'ck.d6r.black': 'CKD6',
          'tl1105': 'TL1105',
       }
 

--- a/build-system/erbb/grammar.py
+++ b/build-system/erbb/grammar.py
@@ -24,7 +24,7 @@ CONTROL_STYLES = (
    'dailywell.2ms1', 'dailywell.2ms3',
    'led.3mm.green_red', 'led.3mm.red', 'led.3mm.green', 'led.3mm.yellow', 'led.3mm.orange',
    'thonk.pj398sm.knurled', 'thonk.pj398sm.hex',
-   'tl1105', 'ck.d6.black',
+   'tl1105', 'ck.d6r.black',
 )
 
 SYMBOLS = (',', '{', '}', '(', ')')

--- a/samples/drop/Drop.erbui
+++ b/samples/drop/Drop.erbui
@@ -47,12 +47,12 @@ module Drop {
 
    control sync_button Button {
       position 7.11mm, 75.3mm
-      style ck.d6.black
+      style ck.d6r.black
    }
 
    control arm_button Button {
       position 19.2mm, 75.3mm
-      style ck.d6.black
+      style ck.d6r.black
    }
 
    control sync_led Led {

--- a/test/vcvrack/VcvRack.erbui
+++ b/test/vcvrack/VcvRack.erbui
@@ -213,8 +213,8 @@ module VcvRack {
 
    control ck_d6_black Button {
       position 110mm, 85mm
-      style ck.d6.black
-      label "ck.d6.black" { positioning bottom }
+      style ck.d6r.black
+      label "ck.d6r.black" { positioning bottom }
    }
 
    control dailywell_2ms1_90ccw Switch {


### PR DESCRIPTION
This PR fixes incorrect naming for the C&K D6 switch, as we are using the D6R variant for now.