### PR TITLE
Enhance gate in state read

### DIFF
--- a/blocks/test/gate-in.cpp
+++ b/blocks/test/gate-in.cpp
@@ -31,10 +31,10 @@ int main ()
 
    // Pins are the same as the GATE IN 1/2 on Daisy Patch
    GateIn gate_in_1 (module, Pin20);
-   GateIn gate_in_2 (module, Pin19, GateIn::Mode::Gate);
+   GateIn gate_in_2 (module, Pin19);
 
    module.run ([&](){
-      auto out_val = (gate_in_1 || gate_in_2) ? 1.f : 0.f;
+      auto out_val = (gate_in_1.triggered () || gate_in_2) ? 1.f : 0.f;
 
       audio_out0.fill (out_val);
       audio_out1.fill (out_val);

--- a/include/erb/daisy/DaisyGateIn.h
+++ b/include/erb/daisy/DaisyGateIn.h
@@ -35,22 +35,17 @@ class DaisyGateIn
 
 public:
 
-   enum class Mode
-   {
-      Trigger, Gate
-   };
-
-                  DaisyGateIn (DaisyModule & module, const Pin & pin, Mode mode = Mode::Trigger);
+                  DaisyGateIn (DaisyModule & module, const Pin & pin);
    virtual        ~DaisyGateIn () override = default;
 
-   void           set_mode (Mode mode);
+   bool           triggered () const;
                   operator bool () const;
 
 
 
 /*\\\ INTERNAL \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-                  DaisyGateIn (const Pin & pin, Mode mode);
+                  DaisyGateIn (const Pin & pin);
 
    // DaisyModuleListener
    virtual void   impl_notify_audio_buffer_start () override;
@@ -72,7 +67,6 @@ private:
 
    const dsy_gpio _gpio;
 
-   Mode           _mode;
    bool           _previous = false;
    bool           _current = false;
 

--- a/include/erb/daisy/DaisySwitch.h
+++ b/include/erb/daisy/DaisySwitch.h
@@ -62,8 +62,8 @@ protected:
 
 private:
 
-   DaisyGateIn         _gate_0;
-   DaisyGateIn         _gate_1;
+   DaisyGateIn    _gate_0;
+   DaisyGateIn    _gate_1;
    Position       _position = Position::Center;
 
 

--- a/include/erb/vcvrack/VcvGateIn.h
+++ b/include/erb/vcvrack/VcvGateIn.h
@@ -33,22 +33,15 @@ class VcvGateIn
 
 public:
 
-   enum class Mode
-   {
-      Trigger, Gate
-   };
-
-                  VcvGateIn (VcvModule & module, const VcvPin & pin, Mode mode = Mode::Trigger);
+                  VcvGateIn (VcvModule & module, const VcvPin & pin);
    virtual        ~VcvGateIn () override = default;
 
-   void           set_mode (Mode mode);
+   bool           triggered () const;
                   operator bool () const;
 
 
 
 /*\\\ INTERNAL \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
-
-   /*               VcvGateIn (const VcvPin & pin, Mode mode);*/
 
    // VcvModuleListener
    virtual void   impl_notify_audio_buffer_start () override;
@@ -65,7 +58,6 @@ protected:
 
 private:
 
-   Mode           _mode;
    bool           _previous = false;
    bool           _current = false;
 

--- a/samples/drop/Drop.cpp
+++ b/samples/drop/Drop.cpp
@@ -23,13 +23,13 @@ Name : process
 
 void  Drop::process ()
 {
-   if (arm_button.pressed () || arm_gate)
+   if (arm_button.pressed () || arm_gate.triggered ())
    {
       drop_dsp.toggle_arm ();
       arm_led.pulse ();
    }
 
-   if (sync_button.pressed () || sync_gate)
+   if (sync_button.pressed () || sync_gate.triggered ())
    {
       drop_dsp.sync ();
       sync_led.pulse ();

--- a/src/daisy/DaisyGateIn.cpp
+++ b/src/daisy/DaisyGateIn.cpp
@@ -31,9 +31,8 @@ Name : ctor
 ==============================================================================
 */
 
-DaisyGateIn::DaisyGateIn (DaisyModule & module, const Pin & pin, Mode mode)
+DaisyGateIn::DaisyGateIn (DaisyModule & module, const Pin & pin)
 :  _gpio (to_gpio (pin))
-,  _mode (mode)
 {
    module.add (*this);
 }
@@ -42,13 +41,13 @@ DaisyGateIn::DaisyGateIn (DaisyModule & module, const Pin & pin, Mode mode)
 
 /*
 ==============================================================================
-Name : set_mode
+Name : triggered
 ==============================================================================
 */
 
-void  DaisyGateIn::set_mode (Mode mode)
+bool  DaisyGateIn::triggered () const
 {
-   _mode = mode;
+   return _current && !_previous;
 }
 
 
@@ -61,19 +60,7 @@ Name : operator bool
 
 DaisyGateIn::operator bool () const
 {
-   switch (_mode)
-   {
-   case Mode::Trigger:
-      return _current && !_previous;
-
-   case Mode::Gate:
-      return _current;
-
-#if erb_GNUC_SWITCH_COVERAGE_FIX
-   default:
-      return false;
-#endif
-   }
+   return _current;
 }
 
 
@@ -86,9 +73,8 @@ Name : ctor
 ==============================================================================
 */
 
-DaisyGateIn::DaisyGateIn (const Pin & pin, Mode mode)
+DaisyGateIn::DaisyGateIn (const Pin & pin)
 :  _gpio (to_gpio (pin))
-,  _mode (mode)
 {
 }
 

--- a/src/daisy/DaisySwitch.cpp
+++ b/src/daisy/DaisySwitch.cpp
@@ -31,8 +31,8 @@ Name : ctor
 */
 
 DaisySwitch::DaisySwitch (DaisyModule & module, const Pin & pin_0, const Pin & pin_1)
-:  _gate_0 (pin_0, DaisyGateIn::Mode::Gate)
-,  _gate_1 (pin_1, DaisyGateIn::Mode::Gate)
+:  _gate_0 (pin_0)
+,  _gate_1 (pin_1)
 {
    module.add (*this);
 }

--- a/src/vcvrack/VcvGateIn.cpp
+++ b/src/vcvrack/VcvGateIn.cpp
@@ -28,9 +28,8 @@ Name : ctor
 ==============================================================================
 */
 
-VcvGateIn::VcvGateIn (VcvModule & module, const VcvPin & /* pin */, Mode mode)
+VcvGateIn::VcvGateIn (VcvModule & module, const VcvPin & /* pin */)
 :  VcvInputBase (module)
-,  _mode (mode)
 {
 }
 
@@ -38,13 +37,13 @@ VcvGateIn::VcvGateIn (VcvModule & module, const VcvPin & /* pin */, Mode mode)
 
 /*
 ==============================================================================
-Name : set_mode
+Name : triggered
 ==============================================================================
 */
 
-void  VcvGateIn::set_mode (Mode mode)
+bool  VcvGateIn::triggered () const
 {
-   _mode = mode;
+   return _current && !_previous;
 }
 
 
@@ -57,37 +56,12 @@ Name : operator bool
 
 VcvGateIn::operator bool () const
 {
-   switch (_mode)
-   {
-   case Mode::Trigger:
-      return _current && !_previous;
-
-   case Mode::Gate:
-      return _current;
-
-#if defined (__GNUC__) && ! defined (__clang__)
-   default:
-      return false;
-#endif
-   }
+   return _current;
 }
 
 
 
 /*\\\ INTERNAL \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
-
-/*
-==============================================================================
-Name : ctor
-==============================================================================
-*/
-
-/*VcvGateIn::VcvGateIn (const VcvPin & pin, Mode mode)
-:  _mode (mode)
-{
-}*/
-
-
 
 /*
 ==============================================================================


### PR DESCRIPTION
This PR changes the `GateIn` state reading:
- By removing modes to allow different type or readings dynamically,
- To enhance the readability of the client code.
