### PR TITLE
Enhance erbb vcvrack conf

### DIFF
--- a/build-system/erbb/generators/vcvrack/code_template.cpp
+++ b/build-system/erbb/generators/vcvrack/code_template.cpp
@@ -152,7 +152,7 @@ ErbWidget::ErbWidget (ErbModule * module_)
    // panel
 
    setPanel (APP->window->loadSvg (
-      asset::plugin (plugin_instance, "res/%name%.svg"))
+      asset::plugin (plugin_instance, "res/panel_vcvrack.svg"))
    );
 
    // screws

--- a/build-system/erbb/generators/vcvrack/panel.py
+++ b/build-system/erbb/generators/vcvrack/panel.py
@@ -33,8 +33,8 @@ class Panel:
 
    def generate_module (self, name, path, module):
       path_artifacts = os.path.join (path, 'artifacts')
-      path_svg_pp = os.path.join (path_artifacts, '%s-preprocess.svg' % name)
-      path_svg = os.path.join (path_artifacts, '%s.svg' % name)
+      path_svg_pp = os.path.join (path_artifacts, 'panel_vcvrack-preprocess.svg')
+      path_svg = os.path.join (path_artifacts, 'panel_vcvrack.svg')
 
       surface = cairocffi.SVGSurface (path_svg_pp, module.width.pt, MODULE_HEIGHT * MM_TO_PT)
       context = cairocffi.Context (surface)

--- a/include/erb/erb.gypi
+++ b/include/erb/erb.gypi
@@ -253,6 +253,8 @@
                      'vcvrack/resource/dailywell.2ms.1.svg',
                      'vcvrack/resource/dailywell.2ms.2.svg',
                      'vcvrack/resource/dailywell.2ms.3.svg',
+
+                     '<!(echo artifacts/panel_vcvrack.svg)',
                   ],
                },
             ],

--- a/samples/bypass/bypass.gyp
+++ b/samples/bypass/bypass.gyp
@@ -46,11 +46,6 @@
          'type': 'shared_library',
 
          'dependencies': [ 'bypass', 'erb-vcvrack' ],
-
-         'copies': [{
-            'destination': '<(PRODUCT_DIR)/res',
-            'files': [ 'artifacts/bypass.svg' ],
-         }],
       },
    ],
 }

--- a/samples/drop/drop.gyp
+++ b/samples/drop/drop.gyp
@@ -48,11 +48,6 @@
          'type': 'shared_library',
 
          'dependencies': [ 'drop', 'erb-vcvrack' ],
-
-         'copies': [{
-            'destination': '<(PRODUCT_DIR)/res',
-            'files': [ 'artifacts/drop.svg' ],
-         }],
       },
    ],
 }

--- a/test/vcvrack/vcvrack.gyp
+++ b/test/vcvrack/vcvrack.gyp
@@ -28,11 +28,6 @@
             'VcvRack.h',
             'VcvRack.erbui',
          ],
-
-         'copies': [{
-            'destination': '<(PRODUCT_DIR)/res',
-            'files': [ 'artifacts/vcvrack.svg' ],
-         }],
       },
    ],
 }


### PR DESCRIPTION
This PR simplifies the modules `gyp` files by moving the VCV Rack SVG copy file phase to the `erb-vcvrack` target dependency.