### PR TITLE
Erbui ide integration

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -63,6 +63,11 @@ def configure_native (name, path):
          if 'BuildIndependentTargetsInParallel' in line:
             print ('\t\t\t\tLastUpgradeCheck = 1000;')
 
+   shutil.copyfile (
+      os.path.join (PATH_THIS, 'generate_vcvrack.py'),
+      os.path.join (path_artifacts, 'generate_vcvrack.py')
+   )
+
 
 
 """

--- a/build-system/erbb/generate_vcvrack.py
+++ b/build-system/erbb/generate_vcvrack.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+#
+#     configure.py
+#     Copyright (c) 2020 Raphael Dinge
+#
+#Tab=3########################################################################
+
+
+##### IMPORT #################################################################
+
+from __future__ import print_function
+import os
+import subprocess
+import sys
+
+PATH_THIS = os.path.abspath (os.path.dirname (__file__))
+PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS))))
+
+sys.path.insert (0, os.path.join (PATH_ROOT, 'build-system'))
+import erbui
+
+
+
+##############################################################################
+
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
+   sys.exit (1)
+
+
+
+##############################################################################
+
+if __name__ == '__main__':
+   try:
+      filepath = sys.argv [1]
+      output_path = os.path.abspath (os.path.join (os.path.dirname (filepath), 'artifacts'))
+
+      ast = erbui.parse_ui (filepath)
+      erbui.generate_vcvrack (output_path, ast)
+
+   except subprocess.CalledProcessError as error:
+      print ('Configure command exited with %d' % error.returncode, file = sys.stderr)
+      sys.exit (1)

--- a/include/erb/erb.gypi
+++ b/include/erb/erb.gypi
@@ -232,6 +232,20 @@
                '../../submodules/vcv-rack-sdk/dep/include',
             ],
 
+            'rules': [
+               {
+                  'rule_name': 'Transpile Erbui',
+                  'extension': 'erbui',
+                  'outputs': [
+                     '<!(echo artifacts/deploy_vcvrack.py)',
+                     '<!(echo artifacts/panel_vcvrack.svg)',
+                     '<!(echo artifacts/plugin_vcvrack.cpp)',
+                     '<!(echo artifacts/plugin.json)',
+                  ],
+                  'action': [ 'python3', 'artifacts/generate_vcvrack.py', '<(RULE_INPUT_PATH)' ],
+               },
+            ],
+
             'copies': [
                {
                   'destination': '<(PRODUCT_DIR)',

--- a/samples/bypass/build.py
+++ b/samples/bypass/build.py
@@ -15,10 +15,12 @@ import subprocess
 import sys
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
+PATH_ARTIFACTS = os.path.join (PATH_THIS, 'artifacts')
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
 
 sys.path.insert (0, os.path.join (PATH_ROOT, 'build-system'))
 import erbb
+import erbui
 
 
 
@@ -55,7 +57,11 @@ def parse_args ():
 if __name__ == '__main__':
    try:
       args = parse_args ()
+
       if args.erb_target == 'daisy':
+         ast = erbui.parse_ui (os.path.join (PATH_THIS, 'Bypass.erbui'))
+         erbui.generate_front_panel (PATH_ARTIFACTS, ast)
+
          erbb.build_target ('bypass', 'bypass-daisy', PATH_THIS)
          erbb.objcopy ('bypass-daisy', PATH_THIS)
 

--- a/samples/bypass/configure.py
+++ b/samples/bypass/configure.py
@@ -39,7 +39,6 @@ if __name__ == '__main__':
 
       erbb.configure ('bypass', PATH_THIS)
       erbui.generate_vcvrack (PATH_ARTIFACTS, ast)
-      erbui.generate_front_panel (PATH_ARTIFACTS, ast)
 
    except subprocess.CalledProcessError as error:
       print ('Configure command exited with %d' % error.returncode, file = sys.stderr)

--- a/samples/drop/build.py
+++ b/samples/drop/build.py
@@ -15,10 +15,12 @@ import subprocess
 import sys
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
+PATH_ARTIFACTS = os.path.join (PATH_THIS, 'artifacts')
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
 
 sys.path.insert (0, os.path.join (PATH_ROOT, 'build-system'))
 import erbb
+import erbui
 
 
 
@@ -55,7 +57,11 @@ def parse_args ():
 if __name__ == '__main__':
    try:
       args = parse_args ()
+
       if args.erb_target == 'daisy':
+         ast = erbui.parse_ui (os.path.join (PATH_THIS, 'Drop.erbui'))
+         erbui.generate_front_panel (PATH_ARTIFACTS, ast)
+
          erbb.build_target ('drop', 'drop-daisy', PATH_THIS)
          erbb.objcopy ('drop-daisy', PATH_THIS)
 

--- a/samples/drop/configure.py
+++ b/samples/drop/configure.py
@@ -39,7 +39,6 @@ if __name__ == '__main__':
 
       erbb.configure ('drop', PATH_THIS)
       erbui.generate_vcvrack (PATH_ARTIFACTS, ast)
-      erbui.generate_front_panel (PATH_ARTIFACTS, ast)
 
    except subprocess.CalledProcessError as error:
       print ('Configure command exited with %d' % error.returncode, file = sys.stderr)


### PR DESCRIPTION
This PR allows to build the VCV Rack UI as a build rule in the native IDE, and build only Daisy related file when building the Daisy target. 

This allows to iterate UI directly from the IDE, and to reduce slightly `configure.py` execution time.
