### PR TITLE
Drop daisy suffix from audio in/out

### DIFF
--- a/blocks/test/audio-in-daisy.cpp
+++ b/blocks/test/audio-in-daisy.cpp
@@ -27,11 +27,11 @@ int main ()
 
    Module module;
 
-   AudioInDaisy audio_in_left (module, AudioInDaisyPinLeft);
-   AudioInDaisy audio_in_right (module, AudioInDaisyPinRight);
+   AudioIn audio_in_left (module, AudioInPinLeft);
+   AudioIn audio_in_right (module, AudioInPinRight);
 
-   AudioOutDaisy audio_out_left (module, AudioOutDaisyPinLeft);
-   AudioOutDaisy audio_out_right (module, AudioOutDaisyPinRight);
+   AudioOut audio_out_left (module, AudioOutPinLeft);
+   AudioOut audio_out_right (module, AudioOutPinRight);
 
    module.run ([&](){
       audio_out_left = audio_in_left;

--- a/blocks/test/audio-out-daisy.cpp
+++ b/blocks/test/audio-out-daisy.cpp
@@ -28,8 +28,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out_left (module, AudioOutDaisyPinLeft);
-   AudioOutDaisy audio_out_right (module, AudioOutDaisyPinRight);
+   AudioOut audio_out_left (module, AudioOutPinLeft);
+   AudioOut audio_out_right (module, AudioOutPinRight);
 
    constexpr double pim2 = 2.f * M_PI;
    constexpr double phase_step = pim2 * 440.f / erb::sample_rate;

--- a/blocks/test/button.cpp
+++ b/blocks/test/button.cpp
@@ -26,8 +26,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out_left (module, AudioOutDaisyPinLeft);
-   AudioOutDaisy audio_out_right (module, AudioOutDaisyPinRight);
+   AudioOut audio_out_left (module, AudioOutPinLeft);
+   AudioOut audio_out_right (module, AudioOutPinRight);
 
    // Pins are the same as the GATE IN 1/2 on Daisy Patch
    Button button_1 (module, Pin20);

--- a/blocks/test/cv-in.cpp
+++ b/blocks/test/cv-in.cpp
@@ -62,8 +62,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out_left (module, AudioOutDaisyPinLeft);
-   AudioOutDaisy audio_out_right (module, AudioOutDaisyPinRight);
+   AudioOut audio_out_left (module, AudioOutPinLeft);
+   AudioOut audio_out_right (module, AudioOutPinRight);
 
    // Pins are the same as the CTRL 1..4 on Daisy Patch
    CvIn ctrl_1 (module, AdcPin0); // osc1 amplitude

--- a/blocks/test/cv-in2.cpp
+++ b/blocks/test/cv-in2.cpp
@@ -26,8 +26,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out_left (module, AudioOutDaisyPinLeft);
-   AudioOutDaisy audio_out_right (module, AudioOutDaisyPinRight);
+   AudioOut audio_out_left (module, AudioOutPinLeft);
+   AudioOut audio_out_right (module, AudioOutPinRight);
 
    CvIn ctrl (module, AdcPin0);
 

--- a/blocks/test/gate-in.cpp
+++ b/blocks/test/gate-in.cpp
@@ -26,8 +26,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out0 (module, AudioOutDaisyPin0);
-   AudioOutDaisy audio_out1 (module, AudioOutDaisyPin1);
+   AudioOut audio_out0 (module, AudioOutPin0);
+   AudioOut audio_out1 (module, AudioOutPin1);
 
    // Pins are the same as the GATE IN 1/2 on Daisy Patch
    GateIn gate_in_1 (module, Pin20);

--- a/blocks/test/gate-out.cpp
+++ b/blocks/test/gate-out.cpp
@@ -26,10 +26,10 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioInDaisy audio_in0 (module, AudioInDaisyPin0);
-   AudioInDaisy audio_in1 (module, AudioInDaisyPin1);
-   AudioOutDaisy audio_out0 (module, AudioOutDaisyPin0);
-   AudioOutDaisy audio_out1 (module, AudioOutDaisyPin1);
+   AudioIn audio_in0 (module, AudioInPin0);
+   AudioIn audio_in1 (module, AudioInPin1);
+   AudioOut audio_out0 (module, AudioOutPin0);
+   AudioOut audio_out1 (module, AudioOutPin1);
 
    // Pin is the same as the GATE OUT on Daisy Patch
    GateOut gate_out (module, Pin17);

--- a/blocks/test/multiplexer.cpp
+++ b/blocks/test/multiplexer.cpp
@@ -62,8 +62,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out0 (module, AudioOutDaisyPin0);
-   AudioOutDaisy audio_out1 (module, AudioOutDaisyPin1);
+   AudioOut audio_out0 (module, AudioOutPin0);
+   AudioOut audio_out1 (module, AudioOutPin1);
 
    Multiplexer multiplexer (module, AdcPin1, Pin23, Pin24, Pin25);
 

--- a/blocks/test/pot.cpp
+++ b/blocks/test/pot.cpp
@@ -62,8 +62,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out0 (module, AudioOutDaisyPin0);
-   AudioOutDaisy audio_out1 (module, AudioOutDaisyPin1);
+   AudioOut audio_out0 (module, AudioOutPin0);
+   AudioOut audio_out1 (module, AudioOutPin1);
 
    // Pins are the same as the CTRL 1..4 on Daisy Patch
    Pot ctrl_1 (module, AdcPin0); // osc1 amplitude

--- a/blocks/test/switch.cpp
+++ b/blocks/test/switch.cpp
@@ -28,8 +28,8 @@ int main ()
    using namespace erb;
 
    Module module;
-   AudioOutDaisy audio_out0 (module, AudioOutDaisyPin0);
-   AudioOutDaisy audio_out1 (module, AudioOutDaisyPin1);
+   AudioOut audio_out0 (module, AudioOutPin0);
+   AudioOut audio_out1 (module, AudioOutPin1);
    Switch switch_ (module, Pin19, Pin20);
 
    constexpr float pim2 = 2.f * float (M_PI);

--- a/boards/daisy_seed/definition.py
+++ b/boards/daisy_seed/definition.py
@@ -135,37 +135,37 @@
       },
 
 
-      'AudioInDaisyPinLeft': {
+      'AudioInPinLeft': {
          'physical': 16,
-         'accept': ['AudioInDaisy'],
+         'accept': ['AudioIn'],
       },
-      'AudioInDaisyPin0': {
+      'AudioInPin0': {
          'physical': 16,
-         'accept': ['AudioInDaisy'],
+         'accept': ['AudioIn'],
       },
-      'AudioInDaisyPinRight': {
+      'AudioInPinRight': {
          'physical': 17,
-         'accept': ['AudioInDaisy'],
+         'accept': ['AudioIn'],
       },
-      'AudioInDaisyPin1': {
+      'AudioInPin1': {
          'physical': 17,
-         'accept': ['AudioInDaisy'],
+         'accept': ['AudioIn'],
       },
-      'AudioOutDaisyPinLeft': {
+      'AudioOutPinLeft': {
          'physical': 18,
-         'accept': ['AudioOutDaisy'],
+         'accept': ['AudioOut'],
       },
-      'AudioOutDaisyPin0': {
+      'AudioOutPin0': {
          'physical': 18,
-         'accept': ['AudioOutDaisy'],
+         'accept': ['AudioOut'],
       },
-      'AudioOutDaisyPinRight': {
+      'AudioOutPinRight': {
          'physical': 19,
-         'accept': ['AudioOutDaisy'],
+         'accept': ['AudioOut'],
       },
-      'AudioOutDaisyPin1': {
+      'AudioOutPin1': {
          'physical': 19,
-         'accept': ['AudioOutDaisy'],
+         'accept': ['AudioOut'],
       },
 
       'AdcPin0': {
@@ -231,11 +231,11 @@
       'PinNC': {
          'accept': ['Button', 'GateIn', 'GateOut', 'Led', 'LedBi', 'LedRgb', 'Switch'],
       },
-      'AudioInDaisyPinNC': {
-         'accept': ['AudioInDaisy'],
+      'AudioInPinNC': {
+         'accept': ['AudioIn'],
       },
-      'AudioOutDaisyPinNC': {
-         'accept': ['AudioOutDaisy'],
+      'AudioOutPinNC': {
+         'accept': ['AudioOut'],
       },
       'AdcPinNC': {
          'accept': ['CvIn', 'Pot', 'Trim'],

--- a/build-system/erbui/ast.py
+++ b/build-system/erbui/ast.py
@@ -617,7 +617,7 @@ class Control (Scope):
 
    @property
    def is_kind_out (self):
-      return self.kind == 'AudioOutDaisy' or self.kind == 'GateOut'
+      return self.kind == 'AudioOut' or self.kind == 'GateOut'
 
 
 # -- Mode --------------------------------------------------------------------

--- a/build-system/erbui/generators/vcvrack/code.py
+++ b/build-system/erbui/generators/vcvrack/code.py
@@ -92,8 +92,8 @@ class Code:
    def generate_control (self, control):
 
       type_func_category_map = {
-         'AudioInDaisy': 'Input',
-         'AudioOutDaisy': 'Output',
+         'AudioIn': 'Input',
+         'AudioOut': 'Output',
          'Button': 'Param',
          'CvIn': 'Input',
          'GateIn': 'Input',
@@ -109,8 +109,8 @@ class Code:
       func_category = type_func_category_map [control.kind]
 
       type_category_map = {
-         'AudioInDaisy': 'Input',
-         'AudioOutDaisy': 'Output',
+         'AudioIn': 'Input',
+         'AudioOut': 'Output',
          'Button': 'Param',
          'CvIn': 'Input',
          'GateIn': 'Input',

--- a/build-system/erbui/grammar.py
+++ b/build-system/erbui/grammar.py
@@ -18,7 +18,7 @@ KEYWORDS = (
    'aluminum', 'brushed_aluminum', 'aluminum_coated', 'natural', 'white', 'black',
 )
 UNITS = ('mm', 'cm', 'hp', '°CCW', '°CW')
-CONTROL_KINDS = ('AudioInDaisy', 'AudioOutDaisy', 'Button', 'CvIn', 'GateIn', 'GateOut', 'Led', 'LedBi', 'LedRgb', 'Pot', 'Switch', 'Trim')
+CONTROL_KINDS = ('AudioIn', 'AudioOut', 'Button', 'CvIn', 'GateIn', 'GateOut', 'Led', 'LedBi', 'LedRgb', 'Pot', 'Switch', 'Trim')
 CONTROL_STYLES = (
    'rogan.6ps', 'rogan.5ps', 'rogan.3ps', 'rogan.2ps', 'rogan.1ps',
    'songhuei.9mm',

--- a/build-system/xcode/Erbui.xclangspec
+++ b/build-system/xcode/Erbui.xclangspec
@@ -32,7 +32,7 @@
             StartChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_";
             Chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.";
             Words = (
-                "AudioInDaisy", "AudioOutDaisy", "Button", "CvIn", "GateIn", "GateOut", "Led", "LedBi", "LedRgb", "Pot", "Switch", "Trim",
+                "AudioIn", "AudioOut", "Button", "CvIn", "GateIn", "GateOut", "Led", "LedBi", "LedRgb", "Pot", "Switch", "Trim",
                 "aluminum", "brushed_aluminum", "aluminum_coated", "natural", "white", "black",
                 "center", "left", "top", "right", "bottom",
                 "normalized", "bipolar",

--- a/include/erb/daisy/DaisyAudioIn.h
+++ b/include/erb/daisy/DaisyAudioIn.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 
-      DaisyAudioOutDaisy.h
+      DaisyAudioIn.h
       Copyright (c) 2020 Raphael DINGE
 
 *Tab=3***********************************************************************/
@@ -28,7 +28,7 @@ namespace erb
 
 class DaisyModule;
 
-class DaisyAudioOutDaisy
+class DaisyAudioIn
 :  public DaisyModuleListener
 {
 
@@ -37,15 +37,13 @@ class DaisyAudioOutDaisy
 public:
    using Buffer = std::array <float, buffer_size>;
 
-                  DaisyAudioOutDaisy (DaisyModule & module, AudioOutDaisyPin pin);
-   virtual        ~DaisyAudioOutDaisy () override = default;
+                  DaisyAudioIn (DaisyModule & module, AudioInPin pin);
+   virtual        ~DaisyAudioIn () override = default;
 
-   DaisyAudioOutDaisy &
-                  operator = (const Buffer & buffer);
+                  operator Buffer () const;
 
    size_t         size () const;
-   float &        operator [] (size_t index);
-   void           fill (float val);
+   const float &  operator [] (size_t index);
 
 
 
@@ -53,7 +51,6 @@ public:
 
    // DaisyModuleListener
    virtual void   impl_notify_audio_buffer_start () override;
-   virtual void   impl_notify_audio_buffer_end () override;
 
 
 
@@ -77,19 +74,17 @@ private:
 /*\\\ FORBIDDEN MEMBER FUNCTIONS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 private:
-                  DaisyAudioOutDaisy () = delete;
-                  DaisyAudioOutDaisy (const DaisyAudioOutDaisy & rhs) = delete;
-                  DaisyAudioOutDaisy (DaisyAudioOutDaisy && rhs) = delete;
-   DaisyAudioOutDaisy &
-                  operator = (const DaisyAudioOutDaisy & rhs) = delete;
-   DaisyAudioOutDaisy &
-                  operator = (DaisyAudioOutDaisy && rhs) = delete;
-   bool           operator == (const DaisyAudioOutDaisy & rhs) const = delete;
-   bool           operator != (const DaisyAudioOutDaisy & rhs) const = delete;
+                  DaisyAudioIn () = delete;
+                  DaisyAudioIn (const DaisyAudioIn & rhs) = delete;
+                  DaisyAudioIn (DaisyAudioIn && rhs) = delete;
+   DaisyAudioIn & operator = (const DaisyAudioIn & rhs) = delete;
+   DaisyAudioIn & operator = (DaisyAudioIn && rhs) = delete;
+   bool           operator == (const DaisyAudioIn & rhs) const = delete;
+   bool           operator != (const DaisyAudioIn & rhs) const = delete;
 
 
 
-}; // class DaisyAudioOutDaisy
+}; // class DaisyAudioIn
 
 
 

--- a/include/erb/daisy/DaisyAudioOut.h
+++ b/include/erb/daisy/DaisyAudioOut.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 
-      DaisyAudioInDaisy.h
+      DaisyAudioOut.h
       Copyright (c) 2020 Raphael DINGE
 
 *Tab=3***********************************************************************/
@@ -28,7 +28,7 @@ namespace erb
 
 class DaisyModule;
 
-class DaisyAudioInDaisy
+class DaisyAudioOut
 :  public DaisyModuleListener
 {
 
@@ -37,13 +37,15 @@ class DaisyAudioInDaisy
 public:
    using Buffer = std::array <float, buffer_size>;
 
-                  DaisyAudioInDaisy (DaisyModule & module, AudioInDaisyPin pin);
-   virtual        ~DaisyAudioInDaisy () override = default;
+                  DaisyAudioOut (DaisyModule & module, AudioOutPin pin);
+   virtual        ~DaisyAudioOut () override = default;
 
-                  operator Buffer () const;
+   DaisyAudioOut &
+                  operator = (const Buffer & buffer);
 
    size_t         size () const;
-   const float &  operator [] (size_t index);
+   float &        operator [] (size_t index);
+   void           fill (float val);
 
 
 
@@ -51,6 +53,7 @@ public:
 
    // DaisyModuleListener
    virtual void   impl_notify_audio_buffer_start () override;
+   virtual void   impl_notify_audio_buffer_end () override;
 
 
 
@@ -74,19 +77,17 @@ private:
 /*\\\ FORBIDDEN MEMBER FUNCTIONS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 private:
-                  DaisyAudioInDaisy () = delete;
-                  DaisyAudioInDaisy (const DaisyAudioInDaisy & rhs) = delete;
-                  DaisyAudioInDaisy (DaisyAudioInDaisy && rhs) = delete;
-   DaisyAudioInDaisy &
-                  operator = (const DaisyAudioInDaisy & rhs) = delete;
-   DaisyAudioInDaisy &
-                  operator = (DaisyAudioInDaisy && rhs) = delete;
-   bool           operator == (const DaisyAudioInDaisy & rhs) const = delete;
-   bool           operator != (const DaisyAudioInDaisy & rhs) const = delete;
+                  DaisyAudioOut () = delete;
+                  DaisyAudioOut (const DaisyAudioOut & rhs) = delete;
+                  DaisyAudioOut (DaisyAudioOut && rhs) = delete;
+   DaisyAudioOut &operator = (const DaisyAudioOut & rhs) = delete;
+   DaisyAudioOut &operator = (DaisyAudioOut && rhs) = delete;
+   bool           operator == (const DaisyAudioOut & rhs) const = delete;
+   bool           operator != (const DaisyAudioOut & rhs) const = delete;
 
 
 
-}; // class DaisyAudioInDaisy
+}; // class DaisyAudioOut
 
 
 

--- a/include/erb/daisy/DaisyPins.h
+++ b/include/erb/daisy/DaisyPins.h
@@ -113,27 +113,27 @@ struct DaisyMultiplexerAddressPins
 
 
 
-struct AudioInDaisyPin
+struct AudioInPin
 {
    size_t pin;
 };
 
-static constexpr AudioInDaisyPin AudioInDaisyPinLeft =  {0};
-static constexpr AudioInDaisyPin AudioInDaisyPinRight = {1};
-static constexpr AudioInDaisyPin AudioInDaisyPin0 =     {0};
-static constexpr AudioInDaisyPin AudioInDaisyPin1 =     {1};
+static constexpr AudioInPin AudioInPinLeft =  {0};
+static constexpr AudioInPin AudioInPinRight = {1};
+static constexpr AudioInPin AudioInPin0 =     {0};
+static constexpr AudioInPin AudioInPin1 =     {1};
 
 
 
-struct AudioOutDaisyPin
+struct AudioOutPin
 {
    size_t pin;
 };
 
-static constexpr AudioOutDaisyPin AudioOutDaisyPinLeft =  {0};
-static constexpr AudioOutDaisyPin AudioOutDaisyPinRight = {1};
-static constexpr AudioOutDaisyPin AudioOutDaisyPin0 =     {0};
-static constexpr AudioOutDaisyPin AudioOutDaisyPin1 =     {1};
+static constexpr AudioOutPin AudioOutPinLeft =  {0};
+static constexpr AudioOutPin AudioOutPinRight = {1};
+static constexpr AudioOutPin AudioOutPin0 =     {0};
+static constexpr AudioOutPin AudioOutPin1 =     {1};
 
 
 

--- a/include/erb/erb.gypi
+++ b/include/erb/erb.gypi
@@ -29,8 +29,8 @@
 
             'daisy/DaisyAdcChannels.h',
             'daisy/DaisyAnalogControlBase.h',
-            'daisy/DaisyAudioInDaisy.h',
-            'daisy/DaisyAudioOutDaisy.h',
+            'daisy/DaisyAudioIn.h',
+            'daisy/DaisyAudioOut.h',
             'daisy/DaisyButton.h',
             'daisy/DaisyConstants.h',
             'daisy/DaisyCvIn.h',
@@ -55,8 +55,8 @@
             # sources
             '../../src/daisy/DaisyAdcChannels.cpp',
             '../../src/daisy/DaisyAnalogControlBase.cpp',
-            '../../src/daisy/DaisyAudioInDaisy.cpp',
-            '../../src/daisy/DaisyAudioOutDaisy.cpp',
+            '../../src/daisy/DaisyAudioIn.cpp',
+            '../../src/daisy/DaisyAudioOut.cpp',
             '../../src/daisy/DaisyButton.cpp',
             '../../src/daisy/DaisyCvIn.cpp',
             '../../src/daisy/DaisyGateIn.cpp',
@@ -112,8 +112,8 @@
             'erb.h',
             'module_init.h',
 
-            'vcvrack/VcvAudioInDaisy.h',
-            'vcvrack/VcvAudioOutDaisy.h',
+            'vcvrack/VcvAudioIn.h',
+            'vcvrack/VcvAudioOut.h',
             'vcvrack/VcvButton.h',
             'vcvrack/VcvConstants.h',
             'vcvrack/VcvCvIn.h',
@@ -141,8 +141,8 @@
             'detail/Debounce.h',
 
             # sources
-            '../../src/vcvrack/VcvAudioInDaisy.cpp',
-            '../../src/vcvrack/VcvAudioOutDaisy.cpp',
+            '../../src/vcvrack/VcvAudioIn.cpp',
+            '../../src/vcvrack/VcvAudioOut.cpp',
             '../../src/vcvrack/VcvButton.cpp',
             '../../src/vcvrack/VcvCvIn.cpp',
             '../../src/vcvrack/VcvGateIn.cpp',

--- a/include/erb/erb.h
+++ b/include/erb/erb.h
@@ -17,8 +17,8 @@
 
 
 #if defined (erb_TARGET_DAISY)
-   #include "erb/daisy/DaisyAudioInDaisy.h"
-   #include "erb/daisy/DaisyAudioOutDaisy.h"
+   #include "erb/daisy/DaisyAudioIn.h"
+   #include "erb/daisy/DaisyAudioOut.h"
    #include "erb/daisy/DaisyButton.h"
    #include "erb/daisy/DaisyConstants.h"
    #include "erb/daisy/DaisyCvIn.h"
@@ -35,8 +35,8 @@
 
    namespace erb
    {
-      using AudioInDaisy = DaisyAudioInDaisy;
-      using AudioOutDaisy = DaisyAudioOutDaisy;
+      using AudioIn = DaisyAudioIn;
+      using AudioOut = DaisyAudioOut;
       using Button = DaisyButton;
       using CvIn = DaisyCvIn;
       using GateIn = DaisyGateIn;
@@ -52,8 +52,8 @@
    }
 
 #elif defined (erb_TARGET_VCV_RACK)
-   #include "erb/vcvrack/VcvAudioInDaisy.h"
-   #include "erb/vcvrack/VcvAudioOutDaisy.h"
+   #include "erb/vcvrack/VcvAudioIn.h"
+   #include "erb/vcvrack/VcvAudioOut.h"
    #include "erb/vcvrack/VcvButton.h"
    #include "erb/vcvrack/VcvConstants.h"
    #include "erb/vcvrack/VcvCvIn.h"
@@ -70,8 +70,8 @@
 
    namespace erb
    {
-      using AudioInDaisy = VcvAudioInDaisy;
-      using AudioOutDaisy = VcvAudioOutDaisy;
+      using AudioIn = VcvAudioIn;
+      using AudioOut = VcvAudioOut;
       using Button = VcvButton;
       using CvIn = VcvCvIn;
       using GateIn = VcvGateIn;

--- a/include/erb/vcvrack/VcvAudioIn.h
+++ b/include/erb/vcvrack/VcvAudioIn.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 
-      VcvAudioOutDaisy.h
+      VcvAudioIn.h
       Copyright (c) 2020 Raphael DINGE
 
 *Tab=3***********************************************************************/
@@ -14,20 +14,10 @@
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 #include "erb/vcvrack/VcvConstants.h"
-#include "erb/vcvrack/VcvOutputBase.h"
+#include "erb/vcvrack/VcvInputBase.h"
 #include "erb/vcvrack/VcvPins.h"
 
 #include <array>
-
-
-
-namespace rack
-{
-namespace engine
-{
-struct Output;
-}
-}
 
 
 
@@ -38,8 +28,8 @@ namespace erb
 
 class VcvModule;
 
-class VcvAudioOutDaisy
-:  public VcvOutputBase
+class VcvAudioIn
+:  public VcvInputBase
 {
 
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
@@ -47,25 +37,22 @@ class VcvAudioOutDaisy
 public:
    using Buffer = std::array <float, buffer_size>;
 
-                  VcvAudioOutDaisy (VcvModule & module, VcvAudioOutDaisyPin pin);
-   virtual        ~VcvAudioOutDaisy () override = default;
+                  VcvAudioIn (VcvModule & module, VcvAudioInPin pin);
+   virtual        ~VcvAudioIn () override = default;
 
-   VcvAudioOutDaisy &
-                  operator = (const Buffer & buffer);
+                  operator Buffer () const;
 
    size_t         size () const;
-   float &        operator [] (size_t index);
-   void           fill (float val);
+   const float &  operator [] (size_t index);
 
 
 
 /*\\\ INTERNAL \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-   void           impl_push_sample ();
+   void           impl_pull_sample ();
 
    // VcvModuleListener
    virtual void   impl_notify_audio_buffer_start () override;
-   virtual void   impl_notify_audio_buffer_end () override;
 
 
 
@@ -89,19 +76,17 @@ private:
 /*\\\ FORBIDDEN MEMBER FUNCTIONS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 private:
-                  VcvAudioOutDaisy () = delete;
-                  VcvAudioOutDaisy (const VcvAudioOutDaisy & rhs) = delete;
-                  VcvAudioOutDaisy (VcvAudioOutDaisy && rhs) = delete;
-   VcvAudioOutDaisy &
-                  operator = (const VcvAudioOutDaisy & rhs) = delete;
-   VcvAudioOutDaisy &
-                  operator = (VcvAudioOutDaisy && rhs) = delete;
-   bool           operator == (const VcvAudioOutDaisy & rhs) const = delete;
-   bool           operator != (const VcvAudioOutDaisy & rhs) const = delete;
+                  VcvAudioIn () = delete;
+                  VcvAudioIn (const VcvAudioIn & rhs) = delete;
+                  VcvAudioIn (VcvAudioIn && rhs) = delete;
+   VcvAudioIn &   operator = (const VcvAudioIn & rhs) = delete;
+   VcvAudioIn &   operator = (VcvAudioIn && rhs) = delete;
+   bool           operator == (const VcvAudioIn & rhs) const = delete;
+   bool           operator != (const VcvAudioIn & rhs) const = delete;
 
 
 
-}; // class VcvAudioOutDaisy
+}; // class VcvAudioIn
 
 
 

--- a/include/erb/vcvrack/VcvAudioOut.h
+++ b/include/erb/vcvrack/VcvAudioOut.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 
-      VcvAudioInDaisy.h
+      VcvAudioOut.h
       Copyright (c) 2020 Raphael DINGE
 
 *Tab=3***********************************************************************/
@@ -14,10 +14,20 @@
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 #include "erb/vcvrack/VcvConstants.h"
-#include "erb/vcvrack/VcvInputBase.h"
+#include "erb/vcvrack/VcvOutputBase.h"
 #include "erb/vcvrack/VcvPins.h"
 
 #include <array>
+
+
+
+namespace rack
+{
+namespace engine
+{
+struct Output;
+}
+}
 
 
 
@@ -28,8 +38,8 @@ namespace erb
 
 class VcvModule;
 
-class VcvAudioInDaisy
-:  public VcvInputBase
+class VcvAudioOut
+:  public VcvOutputBase
 {
 
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
@@ -37,22 +47,25 @@ class VcvAudioInDaisy
 public:
    using Buffer = std::array <float, buffer_size>;
 
-                  VcvAudioInDaisy (VcvModule & module, VcvAudioInDaisyPin pin);
-   virtual        ~VcvAudioInDaisy () override = default;
+                  VcvAudioOut (VcvModule & module, VcvAudioOutPin pin);
+   virtual        ~VcvAudioOut () override = default;
 
-                  operator Buffer () const;
+   VcvAudioOut &
+                  operator = (const Buffer & buffer);
 
    size_t         size () const;
-   const float &  operator [] (size_t index);
+   float &        operator [] (size_t index);
+   void           fill (float val);
 
 
 
 /*\\\ INTERNAL \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-   void           impl_pull_sample ();
+   void           impl_push_sample ();
 
    // VcvModuleListener
    virtual void   impl_notify_audio_buffer_start () override;
+   virtual void   impl_notify_audio_buffer_end () override;
 
 
 
@@ -76,19 +89,17 @@ private:
 /*\\\ FORBIDDEN MEMBER FUNCTIONS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 private:
-                  VcvAudioInDaisy () = delete;
-                  VcvAudioInDaisy (const VcvAudioInDaisy & rhs) = delete;
-                  VcvAudioInDaisy (VcvAudioInDaisy && rhs) = delete;
-   VcvAudioInDaisy &
-                  operator = (const VcvAudioInDaisy & rhs) = delete;
-   VcvAudioInDaisy &
-                  operator = (VcvAudioInDaisy && rhs) = delete;
-   bool           operator == (const VcvAudioInDaisy & rhs) const = delete;
-   bool           operator != (const VcvAudioInDaisy & rhs) const = delete;
+                  VcvAudioOut () = delete;
+                  VcvAudioOut (const VcvAudioOut & rhs) = delete;
+                  VcvAudioOut (VcvAudioOut && rhs) = delete;
+   VcvAudioOut &  operator = (const VcvAudioOut & rhs) = delete;
+   VcvAudioOut &  operator = (VcvAudioOut && rhs) = delete;
+   bool           operator == (const VcvAudioOut & rhs) const = delete;
+   bool           operator != (const VcvAudioOut & rhs) const = delete;
 
 
 
-}; // class VcvAudioInDaisy
+}; // class VcvAudioOut
 
 
 

--- a/include/erb/vcvrack/VcvModule.h
+++ b/include/erb/vcvrack/VcvModule.h
@@ -43,8 +43,8 @@ class VcvInputBase;
 class VcvOutputBase;
 class VcvLightBase;
 
-class VcvAudioInDaisy;
-class VcvAudioOutDaisy;
+class VcvAudioIn;
+class VcvAudioOut;
 
 struct VcvPin;
 
@@ -81,8 +81,8 @@ public:
    void           add (VcvOutputBase & output);
    void           add (VcvLightBase & light);
 
-   void           add (VcvAudioInDaisy & input);
-   void           add (VcvAudioOutDaisy & output);
+   void           add (VcvAudioIn & input);
+   void           add (VcvAudioOut & output);
 
    void           impl_process ();
 
@@ -102,8 +102,8 @@ private:
    using VcvOutputs = std::vector <VcvOutputBase *>;
    using VcvLights = std::vector <VcvLightBase *>;
 
-   using VcvAudioInputs = std::vector <VcvAudioInDaisy *>;
-   using VcvAudioOutputs = std::vector <VcvAudioOutDaisy *>;
+   using VcvAudioInputs = std::vector <VcvAudioIn *>;
+   using VcvAudioOutputs = std::vector <VcvAudioOut *>;
 
    std::function <void ()>
                   _buffer_callback;

--- a/include/erb/vcvrack/VcvPins.h
+++ b/include/erb/vcvrack/VcvPins.h
@@ -116,30 +116,30 @@ static constexpr VcvMultiplexerPin MultiplexerPinNC =  {size_t (-1)};
 
 
 
-struct VcvAudioInDaisyPin
+struct VcvAudioInPin
 {
    size_t pin;
 };
 
-static constexpr VcvAudioInDaisyPin AudioInDaisyPinLeft =  {0};
-static constexpr VcvAudioInDaisyPin AudioInDaisyPinRight = {1};
-static constexpr VcvAudioInDaisyPin AudioInDaisyPin0 =     {0};
-static constexpr VcvAudioInDaisyPin AudioInDaisyPin1 =     {1};
+static constexpr VcvAudioInPin AudioInPinLeft =  {0};
+static constexpr VcvAudioInPin AudioInPinRight = {1};
+static constexpr VcvAudioInPin AudioInPin0 =     {0};
+static constexpr VcvAudioInPin AudioInPin1 =     {1};
 
-static constexpr VcvAudioInDaisyPin AudioInDaisyPinNC =     {size_t (-1)};
+static constexpr VcvAudioInPin AudioInPinNC =     {size_t (-1)};
 
 
-struct VcvAudioOutDaisyPin
+struct VcvAudioOutPin
 {
    size_t pin;
 };
 
-static constexpr VcvAudioOutDaisyPin AudioOutDaisyPinLeft =  {0};
-static constexpr VcvAudioOutDaisyPin AudioOutDaisyPinRight = {1};
-static constexpr VcvAudioOutDaisyPin AudioOutDaisyPin0 =     {0};
-static constexpr VcvAudioOutDaisyPin AudioOutDaisyPin1 =     {1};
+static constexpr VcvAudioOutPin AudioOutPinLeft =  {0};
+static constexpr VcvAudioOutPin AudioOutPinRight = {1};
+static constexpr VcvAudioOutPin AudioOutPin0 =     {0};
+static constexpr VcvAudioOutPin AudioOutPin1 =     {1};
 
-static constexpr VcvAudioOutDaisyPin AudioOutDaisyPinNC =     {size_t (-1)};
+static constexpr VcvAudioOutPin AudioOutPinNC =     {size_t (-1)};
 
 
 

--- a/samples/drop/Drop.erbui
+++ b/samples/drop/Drop.erbui
@@ -107,31 +107,31 @@ module Drop {
       pin AdcPin1
    }
 
-   control audio_in_left AudioInDaisy {
+   control audio_in_left AudioIn {
       position 7.11mm, 111mm
       style thonk.pj398sm.knurled
       label "IN L"
-      pin AudioInDaisyPinLeft
+      pin AudioInPinLeft
    }
 
-   control audio_in_right AudioInDaisy {
+   control audio_in_right AudioIn {
       position 19.2mm, 111mm
       style thonk.pj398sm.knurled
       label "IN R"
-      pin AudioInDaisyPinRight
+      pin AudioInPinRight
    }
 
-   control audio_out_left AudioOutDaisy {
+   control audio_out_left AudioOut {
       position 31.3mm, 111mm
       style thonk.pj398sm.knurled
       label "OUT L"
-      pin AudioOutDaisyPinLeft
+      pin AudioOutPinLeft
    }
 
-   control audio_out_right AudioOutDaisy {
+   control audio_out_right AudioOut {
       position 43.4mm, 111mm
       style thonk.pj398sm.knurled
       label "OUT R"
-      pin AudioOutDaisyPinRight
+      pin AudioOutPinRight
    }
 }

--- a/samples/reverb/Reverb.erbui
+++ b/samples/reverb/Reverb.erbui
@@ -100,31 +100,31 @@ module Reverb {
       pin AdcPin3
    }
 
-   control audio_in_left AudioInDaisy {
+   control audio_in_left AudioIn {
       position 7.11mm, 111mm
       style thonk.pj398sm.knurled
       label "IN L"
-      pin AudioInDaisyPinLeft
+      pin AudioInPinLeft
    }
 
-   control audio_in_right AudioInDaisy {
+   control audio_in_right AudioIn {
       position 19.2mm, 111mm
       style thonk.pj398sm.knurled
       label "IN R"
-      pin AudioInDaisyPinRight
+      pin AudioInPinRight
    }
 
-   control audio_out_left AudioOutDaisy {
+   control audio_out_left AudioOut {
       position 31.3mm, 111mm
       style thonk.pj398sm.knurled
       label "OUT L"
-      pin AudioOutDaisyPinLeft
+      pin AudioOutPinLeft
    }
 
-   control audio_out_right AudioOutDaisy {
+   control audio_out_right AudioOut {
       position 43.4mm, 111mm
       style thonk.pj398sm.knurled
       label "OUT R"
-      pin AudioOutDaisyPinRight
+      pin AudioOutPinRight
    }
 }

--- a/src/daisy/DaisyAudioIn.cpp
+++ b/src/daisy/DaisyAudioIn.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 
-      DaisyAudioInDaisy.cpp
+      DaisyAudioIn.cpp
       Copyright (c) 2020 Raphael DINGE
 
 *Tab=3***********************************************************************/
@@ -9,7 +9,7 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-#include "erb/daisy/DaisyAudioInDaisy.h"
+#include "erb/daisy/DaisyAudioIn.h"
 
 #include "erb/daisy/DaisyModule.h"
 
@@ -30,7 +30,7 @@ Name : ctor
 ==============================================================================
 */
 
-DaisyAudioInDaisy::DaisyAudioInDaisy (DaisyModule & module, AudioInDaisyPin pin)
+DaisyAudioIn::DaisyAudioIn (DaisyModule & module, AudioInPin pin)
 :  _module (module)
 ,  _channel (pin.pin)
 {
@@ -45,7 +45,7 @@ Name : size
 ==============================================================================
 */
 
-DaisyAudioInDaisy::operator Buffer () const
+DaisyAudioIn::operator Buffer () const
 {
    return _buffer;
 }
@@ -58,7 +58,7 @@ Name : size
 ==============================================================================
 */
 
-size_t   DaisyAudioInDaisy::size () const
+size_t   DaisyAudioIn::size () const
 {
    return _buffer.size ();
 }
@@ -71,7 +71,7 @@ Name : operator []
 ==============================================================================
 */
 
-const float &  DaisyAudioInDaisy::operator [] (size_t index)
+const float &  DaisyAudioIn::operator [] (size_t index)
 {
    return _buffer [index];
 }
@@ -86,7 +86,7 @@ Name : impl_notify_audio_buffer_start
 ==============================================================================
 */
 
-void  DaisyAudioInDaisy::impl_notify_audio_buffer_start ()
+void  DaisyAudioIn::impl_notify_audio_buffer_start ()
 {
    const auto & buffer = _module.impl_onboard_codec_buffer_input ();
 

--- a/src/daisy/DaisyAudioOut.cpp
+++ b/src/daisy/DaisyAudioOut.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 
-      DaisyAudioOutDaisy.cpp
+      DaisyAudioOut.cpp
       Copyright (c) 2020 Raphael DINGE
 
 *Tab=3***********************************************************************/
@@ -9,7 +9,7 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-#include "erb/daisy/DaisyAudioOutDaisy.h"
+#include "erb/daisy/DaisyAudioOut.h"
 
 #include "erb/daisy/DaisyModule.h"
 
@@ -30,7 +30,7 @@ Name : ctor
 ==============================================================================
 */
 
-DaisyAudioOutDaisy::DaisyAudioOutDaisy (DaisyModule & module, AudioOutDaisyPin pin)
+DaisyAudioOut::DaisyAudioOut (DaisyModule & module, AudioOutPin pin)
 :  _module (module)
 ,  _channel (pin.pin)
 {
@@ -45,7 +45,7 @@ Name : operator =
 ==============================================================================
 */
 
-DaisyAudioOutDaisy &   DaisyAudioOutDaisy::operator = (const Buffer & buffer)
+DaisyAudioOut &   DaisyAudioOut::operator = (const Buffer & buffer)
 {
    _buffer = buffer;
 
@@ -60,7 +60,7 @@ Name : size
 ==============================================================================
 */
 
-size_t   DaisyAudioOutDaisy::size () const
+size_t   DaisyAudioOut::size () const
 {
    return _buffer.size ();
 }
@@ -73,7 +73,7 @@ Name : operator []
 ==============================================================================
 */
 
-float &  DaisyAudioOutDaisy::operator [] (size_t index)
+float &  DaisyAudioOut::operator [] (size_t index)
 {
    return _buffer [index];
 }
@@ -86,7 +86,7 @@ Name : fill
 ==============================================================================
 */
 
-void  DaisyAudioOutDaisy::fill (float val)
+void  DaisyAudioOut::fill (float val)
 {
    _buffer.fill (val);
 }
@@ -101,7 +101,7 @@ Name : impl_notify_audio_buffer_start
 ==============================================================================
 */
 
-void  DaisyAudioOutDaisy::impl_notify_audio_buffer_start ()
+void  DaisyAudioOut::impl_notify_audio_buffer_start ()
 {
    // nothing
 }
@@ -114,7 +114,7 @@ Name : impl_notify_audio_buffer_end
 ==============================================================================
 */
 
-void  DaisyAudioOutDaisy::impl_notify_audio_buffer_end ()
+void  DaisyAudioOut::impl_notify_audio_buffer_end ()
 {
    auto & buffer = _module.impl_onboard_codec_buffer_output ();
 

--- a/src/vcvrack/VcvAudioIn.cpp
+++ b/src/vcvrack/VcvAudioIn.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
 
-      VcvAudioOutDaisy.cpp
+      VcvAudioIn.cpp
       Copyright (c) 2020 Raphael DINGE
 
 *Tab=3***********************************************************************/
@@ -9,11 +9,9 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-#include "erb/vcvrack/VcvAudioOutDaisy.h"
+#include "erb/vcvrack/VcvAudioIn.h"
 
 #include "erb/vcvrack/VcvModule.h"
-
-#include <rack.hpp>
 
 
 
@@ -30,8 +28,8 @@ Name : ctor
 ==============================================================================
 */
 
-VcvAudioOutDaisy::VcvAudioOutDaisy (VcvModule & module, VcvAudioOutDaisyPin /* pin */)
-:  VcvOutputBase ()
+VcvAudioIn::VcvAudioIn (VcvModule & module, VcvAudioInPin /* pin */)
+:  VcvInputBase ()
 {
    module.add (*this);
 
@@ -42,15 +40,13 @@ VcvAudioOutDaisy::VcvAudioOutDaisy (VcvModule & module, VcvAudioOutDaisyPin /* p
 
 /*
 ==============================================================================
-Name : operator =
+Name : size
 ==============================================================================
 */
 
-VcvAudioOutDaisy &   VcvAudioOutDaisy::operator = (const Buffer & buffer)
+VcvAudioIn::operator Buffer () const
 {
-   _buffers [_cur_buf] = buffer;
-
-   return *this;
+   return _buffers [_cur_buf];
 }
 
 
@@ -61,7 +57,7 @@ Name : size
 ==============================================================================
 */
 
-size_t   VcvAudioOutDaisy::size () const
+size_t   VcvAudioIn::size () const
 {
    return _buffers [_cur_buf].size ();
 }
@@ -74,22 +70,9 @@ Name : operator []
 ==============================================================================
 */
 
-float &  VcvAudioOutDaisy::operator [] (size_t index)
+const float &  VcvAudioIn::operator [] (size_t index)
 {
    return _buffers [_cur_buf][index];
-}
-
-
-
-/*
-==============================================================================
-Name : fill
-==============================================================================
-*/
-
-void  VcvAudioOutDaisy::fill (float val)
-{
-   _buffers [_cur_buf].fill (val);
 }
 
 
@@ -102,12 +85,14 @@ Name : impl_pull_sample
 ==============================================================================
 */
 
-void  VcvAudioOutDaisy::impl_push_sample ()
+void  VcvAudioIn::impl_pull_sample ()
 {
-   float sample = _buffers [1 - _cur_buf][_cur_index];
-   ++_cur_index;
+   VcvInputBase::impl_notify_audio_buffer_start ();
 
-   set_norm_val (sample);
+   float sample = norm_val ();
+
+   _buffers [1 - _cur_buf][_cur_index] = sample;
+   ++_cur_index;
 }
 
 
@@ -118,21 +103,10 @@ Name : impl_notify_audio_buffer_start
 ==============================================================================
 */
 
-void  VcvAudioOutDaisy::impl_notify_audio_buffer_start ()
+void  VcvAudioIn::impl_notify_audio_buffer_start ()
 {
-   // nothing
-}
+   // we don't need to call-in the base class method
 
-
-
-/*
-==============================================================================
-Name : impl_notify_audio_buffer_end
-==============================================================================
-*/
-
-void  VcvAudioOutDaisy::impl_notify_audio_buffer_end ()
-{
    // switch buffer
    _cur_buf = 1 - _cur_buf;
    _cur_index = 0;

--- a/src/vcvrack/VcvModule.cpp
+++ b/src/vcvrack/VcvModule.cpp
@@ -11,8 +11,8 @@
 
 #include "erb/vcvrack/VcvModule.h"
 
-#include "erb/vcvrack/VcvAudioInDaisy.h"
-#include "erb/vcvrack/VcvAudioOutDaisy.h"
+#include "erb/vcvrack/VcvAudioIn.h"
+#include "erb/vcvrack/VcvAudioOut.h"
 #include "erb/vcvrack/VcvInputBase.h"
 #include "erb/vcvrack/VcvLightBase.h"
 #include "erb/vcvrack/VcvOutputBase.h"
@@ -208,7 +208,7 @@ Name : add
 ==============================================================================
 */
 
-void  VcvModule::add (VcvAudioInDaisy & input)
+void  VcvModule::add (VcvAudioIn & input)
 {
    _audio_inputs.push_back (&input);
    _inputs.push_back (&input);
@@ -223,7 +223,7 @@ Name : add
 ==============================================================================
 */
 
-void  VcvModule::add (VcvAudioOutDaisy & output)
+void  VcvModule::add (VcvAudioOut & output)
 {
    _audio_outputs.push_back (&output);
    _outputs.push_back (&output);

--- a/test/vcvrack/VcvRack.erbui
+++ b/test/vcvrack/VcvRack.erbui
@@ -44,34 +44,34 @@ module VcvRack {
    alias button_alias button
    alias led_alias led
 
-   control audio_in AudioInDaisy {
+   control audio_in AudioIn {
       position 10mm, 20mm
       style thonk.pj398sm.knurled
       label "L" { positioning left }
       label "T" { positioning top }
       label "R" { positioning right }
       label "B" { positioning bottom }
-      pin AudioInDaisyPinNC
+      pin AudioInPinNC
    }
 
-   control audio_in2 AudioInDaisy {
+   control audio_in2 AudioIn {
       position 30mm, 20mm
       style thonk.pj398sm.hex
       label "L" { positioning left }
       label "T" { positioning top }
       label "R" { positioning right }
       label "B" { positioning bottom }
-      pin AudioInDaisyPinNC
+      pin AudioInPinNC
    }
 
-   control audio_out AudioOutDaisy {
+   control audio_out AudioOut {
       position 50mm, 20mm
       style thonk.pj398sm.hex
       label "L" { positioning left }
       label "T" { positioning top }
       label "R" { positioning right }
       label "B" { positioning bottom }
-      pin AudioOutDaisyPinNC
+      pin AudioOutPinNC
    }
 
    control button Button {


### PR DESCRIPTION
This PR drops `Daisy` suffix from `AudioIn` and `AudioOut`, as there is no need now to
make it specific to daisy.

This was done initially to allow specific daisy related processing (such as applying proper gains).
The upcoming architecture doesn't need that anymore, at this kind of processing is moved to the board concept, which emcompasses the hardware topology, and so the information to properly process the audio signal.
