### PR TITLE
Add extend keyword support

### DIFF
--- a/build-system/erbui/ast.py
+++ b/build-system/erbui/ast.py
@@ -228,10 +228,12 @@ class GlobalNamespace (Scope):
 # -- Module ------------------------------------------------------------------
 
 class Module (Scope):
-   def __init__ (self, identifier):
+   def __init__ (self, identifier, super_identifier):
       assert isinstance (identifier, adapter.Identifier)
+      assert super_identifier is None or isinstance (super_identifier, adapter.Identifier)
       super (Module, self).__init__ ()
       self.identifier = identifier
+      self.super_identifier = super_identifier
 
    @staticmethod
    def typename (): return 'module'
@@ -246,6 +248,8 @@ class Module (Scope):
    def source_context_part (self, part):
       if part == 'name':
          return adapter.SourceContext.from_token (self.identifier)
+      elif part == 'extends':
+         return adapter.SourceContext.from_token (self.super_identifier)
 
       return super (Module, self).source_context_part (part) # pragma: no cover
 
@@ -255,6 +259,8 @@ class Module (Scope):
       assert (len (entities) <= 1)
       if entities:
          return entities [0]
+      elif self.super_identifier:
+         return self.super_identifier
       else:
          return None
 

--- a/build-system/erbui/grammar.py
+++ b/build-system/erbui/grammar.py
@@ -136,6 +136,7 @@ def material_declaration ():           return 'material', material_name, Optiona
 def module_entities ():                return ZeroOrMore ([board_declaration, width_declaration, material_declaration, header_declaration, footer_declaration, line_declaration, label_declaration, sticker_declaration, image_declaration, control_declaration, alias_declaration, multiplexer_declaration])
 def module_body ():                    return '{', module_entities, '}'
 def module_name ():                    return name
-def module_declaration ():             return 'module', module_name, module_body, EOF
+def module_inheritance_clause ():      return 'extends', board_name
+def module_declaration ():             return 'module', module_name, Optional (module_inheritance_clause), module_body, EOF
 
 GRAMMAR_ROOT = module_declaration

--- a/build-system/erbui/parser.py
+++ b/build-system/erbui/parser.py
@@ -14,6 +14,12 @@ from .grammar import GRAMMAR_ROOT, comment
 from .visitor import Visitor
 from .analyser import Analyser
 
+import os
+
+PATH_THIS = os.path.abspath (os.path.dirname (__file__))
+PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
+PATH_BOARDS = os.path.join (PATH_ROOT, 'boards')
+
 
 
 class Parser:
@@ -23,7 +29,35 @@ class Parser:
    def parse (self, input_text, file_name):
       parse_tree = self._get_parse_tree (input_text, file_name)
       ast = self._get_ast (parse_tree)
+
+      for module in ast.modules:
+         self._merge_super (module)
+
       return self._analyse_ast (ast)
+
+   def _merge_super (self, module):
+      if module.super_identifier is None:
+         return
+
+      path_layout = os.path.join (PATH_BOARDS, module.super_identifier.name, 'layout.erbui')
+
+      try:
+         file = open (path_layout, 'r')
+      except OSError:
+         err = error.Error ()
+         context = module.super_identifier
+         err.add_error ("Undefined board layout for '%s'" % context, context)
+         err.add_context (context)
+         raise err
+
+      with file:
+         input_text = file.read ()
+
+      file_name = os.path.basename (path_layout)
+
+      parse_tree = self._get_parse_tree (input_text, file_name)
+      ast = self._get_ast (parse_tree)
+      module.entities.extend (ast.modules [0].entities)
 
    def _get_parse_tree (self, input_text, file_name):
       try:

--- a/build-system/erbui/tests/test_generator_front_pcb.py
+++ b/build-system/erbui/tests/test_generator_front_pcb.py
@@ -70,7 +70,7 @@ class TestGeneratorFrontPcb (unittest.TestCase):
       writer.write (component, os.path.join (PATH_ARTIFACTS, 'alpha.9mm.move.kicad_pcb'))
 
    def test_003 (self):
-      module = ast.Module (mock.identifier ('test_generator_front_pcb_003'))
+      module = ast.Module (mock.identifier ('test_generator_front_pcb_003'), None)
       module.entities.append (ast.Width (ast.DistanceLiteral (mock.literal ('10hp'), 'hp')))
 
       control = ast.Control (

--- a/build-system/erbui/tests/test_generators.py
+++ b/build-system/erbui/tests/test_generators.py
@@ -36,7 +36,7 @@ class TestGenerators (unittest.TestCase):
    def make_ast_001 (self):
       global_namespace = ast.GlobalNamespace ()
 
-      module = ast.Module (mock.identifier ('Test'))
+      module = ast.Module (mock.identifier ('Test'), None)
       module.entities.append (ast.Width (ast.DistanceLiteral (mock.literal ('10hp'), 'hp')))
       module.entities.append (ast.Material (mock.keyword ('aluminum'), None))
 

--- a/build-system/erbui/visitor.py
+++ b/build-system/erbui/visitor.py
@@ -73,7 +73,11 @@ class Visitor (PTNodeVisitor):
 
       module_identifier = children.module_name [0]
 
-      module = ast.Module (module_identifier)
+      module_base_identifier = None
+      if children.module_inheritance_clause:
+         module_base_identifier = children.module_inheritance_clause [0]
+
+      module = ast.Module (module_identifier, module_base_identifier)
       global_namespace.add (module)
 
       if children.module_body:

--- a/build-system/xcode/Erbui.xclangspec
+++ b/build-system/xcode/Erbui.xclangspec
@@ -12,7 +12,7 @@
             StartChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_";
             Chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
             Words = (
-                "module", "board", "width", "material", "header", "footer", "line", "multiplexer", "alias",
+                "module", "extends", "board", "width", "material", "header", "footer", "line", "multiplexer", "alias",
                 "control", "label", "positioning", "sticker", "image", "pin", "pins", "mode",
                 "position", "rotation", "offset", "style",
 


### PR DESCRIPTION
This PR adds the `extends` keyword to `erbui`, which allows to derive a design from a base design.

This PR is preparation work for the upcoming Daisy Field board.
