### PR TITLE
Fix cpp17 linux support

### DIFF
--- a/eurorack-blocks.gypi
+++ b/eurorack-blocks.gypi
@@ -18,7 +18,7 @@
       },
 
       'cflags_cc': [
-         '-std=c++14',
+         '-std=gnu++17',
       ],
 
       'cflags': [

--- a/eurorack-blocks.gypi
+++ b/eurorack-blocks.gypi
@@ -10,7 +10,7 @@
 {
    'target_defaults': {
       'xcode_settings': {
-         'CLANG_CXX_LANGUAGE_STANDARD': 'c++1y',
+         'CLANG_CXX_LANGUAGE_STANDARD': 'c++1z',
          'USE_HEADERMAP': 'NO',
          'WARNING_CFLAGS': [
             '-Wno-four-char-constants',

--- a/eurorack-blocks.gypi
+++ b/eurorack-blocks.gypi
@@ -19,10 +19,12 @@
 
       'cflags_cc': [
          '-std=gnu++17',
+         '-fPIC',
       ],
 
       'cflags': [
          '-Wno-multichar',
+         '-fPIC',
       ],
    },
 


### PR DESCRIPTION
This PR adds C++17 as a target default option, and position independent code on Linux.