### PR TITLE
Fix daisy build by not compiling with position independent code

### DIFF
--- a/eurorack-blocks.gypi
+++ b/eurorack-blocks.gypi
@@ -19,12 +19,10 @@
 
       'cflags_cc': [
          '-std=gnu++17',
-         '-fPIC',
       ],
 
       'cflags': [
          '-Wno-multichar',
-         '-fPIC',
       ],
    },
 

--- a/include/erb/erb-src.gypi
+++ b/include/erb/erb-src.gypi
@@ -1,0 +1,78 @@
+##############################################################################
+#
+#     erb-src.gypi
+#     Copyright (c) 2020 Raphael DINGE
+#
+#Tab=3########################################################################
+
+
+
+{
+   'defines': [
+      'erb_BUFFER_SIZE=48',
+      'erb_SAMPLE_RATE=48014',
+   ],
+
+   'all_dependent_settings': {
+      'defines': [
+         'erb_BUFFER_SIZE=48',
+         'erb_SAMPLE_RATE=48014',
+      ],
+   },
+
+   'sources': [
+      'AudioIn.h',
+      'AudioIn.hpp',
+      'AudioOut.h',
+      'AudioOut.hpp',
+      'Buffer.h',
+      'Button.h',
+      'Button.hpp',
+      'CvIn.h',
+      'CvIn.hpp',
+      'CvOut.h',
+      'CvOut.hpp',
+      'FloatRange.h',
+      'GateIn.h',
+      'GateIn.hpp',
+      'GateOut.h',
+      'Led.h',
+      'Led.hpp',
+      'LedBi.h',
+      'LedBi.hpp',
+      'LedRgb.h',
+      'LedRgb.hpp',
+      'PinType.h',
+      'Pot.h',
+      'Pot.hpp',
+      'SdramObject.h',
+      'SdramObject.hpp',
+      'Switch.h',
+      'Switch.hpp',
+      'def.h',
+      'erb.h',
+      'module_init.h',
+
+      'detail/Animation.h',
+      'detail/Animation.hpp',
+      'detail/Clock.h',
+      'detail/Clock.hpp',
+      'detail/Debounce.h',
+      'detail/DoubleBuffer.h',
+      'detail/DoubleBuffer.hpp',
+      'detail/GateGenerator.h',
+      'detail/GateGenerator.hpp',
+      'detail/fnc.h',
+      'detail/fnc.hpp',
+
+      '../../src/Button.cpp',
+      '../../src/GateOut.cpp',
+
+      '../../src/detail/Animation.cpp',
+      '../../src/detail/Debounce.cpp',
+   ],
+
+   'include_dirs': [
+      '..',
+   ],
+}

--- a/include/erb/erb.gypi
+++ b/include/erb/erb.gypi
@@ -10,83 +10,11 @@
 {
    'targets' : [
       {
-         'target_name': 'erb',
-         'type': 'static_library',
-
-         'defines': [
-            'erb_BUFFER_SIZE=48',
-            'erb_SAMPLE_RATE=48014',
-         ],
-
-         'all_dependent_settings': {
-            'defines': [
-               'erb_BUFFER_SIZE=48',
-               'erb_SAMPLE_RATE=48014',
-            ],
-         },
-
-         'sources': [
-            'AudioIn.h',
-            'AudioIn.hpp',
-            'AudioOut.h',
-            'AudioOut.hpp',
-            'Buffer.h',
-            'Button.h',
-            'Button.hpp',
-            'CvIn.h',
-            'CvIn.hpp',
-            'CvOut.h',
-            'CvOut.hpp',
-            'FloatRange.h',
-            'GateIn.h',
-            'GateIn.hpp',
-            'GateOut.h',
-            'Led.h',
-            'Led.hpp',
-            'LedBi.h',
-            'LedBi.hpp',
-            'LedRgb.h',
-            'LedRgb.hpp',
-            'PinType.h',
-            'Pot.h',
-            'Pot.hpp',
-            'SdramObject.h',
-            'SdramObject.hpp',
-            'Switch.h',
-            'Switch.hpp',
-            'def.h',
-            'erb.h',
-            'module_init.h',
-
-            'detail/Animation.h',
-            'detail/Animation.hpp',
-            'detail/Clock.h',
-            'detail/Clock.hpp',
-            'detail/Debounce.h',
-            'detail/DoubleBuffer.h',
-            'detail/DoubleBuffer.hpp',
-            'detail/GateGenerator.h',
-            'detail/GateGenerator.hpp',
-            'detail/fnc.h',
-            'detail/fnc.hpp',
-
-            '../../src/Button.cpp',
-            '../../src/GateOut.cpp',
-
-            '../../src/detail/Animation.cpp',
-            '../../src/detail/Debounce.cpp',
-         ],
-
-         'include_dirs': [
-            '..',
-         ],
-      },
-
-      {
          'target_name': 'erb-daisy',
          'type': 'static_library',
 
-         'dependencies': [ 'erb', 'libdaisy' ],
+         'includes' : ['erb-src.gypi'],
+         'dependencies': [ 'libdaisy' ],
 
          'defines': [
             'erb_TARGET_DAISY',
@@ -128,7 +56,7 @@
          'target_name': 'erb-vcvrack',
          'type': 'static_library',
 
-         'dependencies': [ 'erb' ],
+         'includes' : ['erb-src.gypi'],
 
          'defines': [
             'erb_TARGET_VCV_RACK',
@@ -172,6 +100,10 @@
          },
 
          'cflags': [
+            '-fPIC',
+         ],
+
+         'cflags_cc': [
             '-fPIC',
          ],
 
@@ -224,6 +156,10 @@
             },
 
             'cflags': [
+               '-fPIC',
+            ],
+
+            'cflags_cc': [
                '-fPIC',
             ],
 


### PR DESCRIPTION
This PR fixes a build problem introduced late in the `erb-refactor` merge where position independent code was set for all targets instead of activating it only for the simulator targets.