### PR TITLE
DROPME Check content of homebrew cache on macos 10.15 image

### DIFF
--- a/.github/workflows/macos_10_15.yml
+++ b/.github/workflows/macos_10_15.yml
@@ -14,6 +14,7 @@ jobs:
           submodules: recursive
       - run: pip2 install future
       - run: brew install --cask kicad
+      - run: ls -laR ~/Library/Caches/Homebrew
       - run: ./blocks/audio-in-daisy/build.py
       - run: ./blocks/audio-out-daisy/build.py
       - run: ./blocks/button/build.py


### PR DESCRIPTION
This PR caches the Kicad brew cask to speedup and avoid failed builds.