### PR TITLE
Signal cascade vcvrack support

### DIFF
--- a/build-system/build-system.gyp
+++ b/build-system/build-system.gyp
@@ -74,6 +74,7 @@
 
             # tests
             'erbui/tests/mock.py',
+            'erbui/tests/test_analyser.py',
             'erbui/tests/test_generator_front_pcb.py',
             'erbui/tests/test_generators.py',
             'erbui/tests/test_parser.py',

--- a/build-system/erbui/ast.py
+++ b/build-system/erbui/ast.py
@@ -237,6 +237,7 @@ class Module (Scope):
       super (Module, self).__init__ ()
       self.identifier = identifier
       self.super_identifier = super_identifier
+      self.cascade_eval_list = []
 
    @staticmethod
    def typename (): return 'module'
@@ -608,6 +609,10 @@ class Control (Scope):
    @property
    def is_output (self):
       return self.kind in ['AudioOut', 'CvOut','GateOut', 'Led', 'LedBi', 'LedRgb']
+
+   @property
+   def is_kind_in (self):
+      return self.kind in ['AudioIn', 'CvIn', 'GateIn']
 
    @property
    def is_kind_out (self):

--- a/build-system/erbui/generators/vcvrack/code_template.cpp
+++ b/build-system/erbui/generators/vcvrack/code_template.cpp
@@ -122,6 +122,7 @@ void  ErbModule::process (const ProcessArgs & /* args */)
 {
    bool process_flag = module.ui.board.impl_need_process ();
 
+%  cascade_process%
    module.ui.board.impl_pull_audio_inputs ();
 
    if (process_flag)

--- a/build-system/erbui/tests/test_analyser.py
+++ b/build-system/erbui/tests/test_analyser.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python
+#
+#     test_analyser.py
+#     Copyright (c) 2020 Raphael DINGE
+#
+#Tab=3########################################################################
+
+
+
+import os
+import unittest
+import traceback
+
+from .. import ast
+from ..analyser import Analyser
+from . import mock
+
+
+
+class TestAnalyser (unittest.TestCase):
+
+   def test_cascade_000 (self):
+      module = ast.Module (mock.identifier ('test_analyser_cascade_000'), None)
+
+      analyser = Analyser ()
+      analyser.make_cascade_eval_list (module)
+
+      self.assertEqual (len (module.cascade_eval_list), 0)
+
+
+   def test_cascade_001 (self):
+      module = ast.Module (mock.identifier ('test_analyser_cascade_001'), None)
+
+      control = ast.Control (
+         mock.identifier ('cv_in1'),
+         mock.keyword ('CvIn')
+      )
+      module.entities.append (control)
+
+      analyser = Analyser ()
+      analyser.make_cascade_eval_list (module)
+
+      self.assertEqual (len (module.cascade_eval_list), 1)
+      self.assertEqual (module.cascade_eval_list [0].name, 'cv_in1')
+
+
+   def test_cascade_002 (self):
+      module = ast.Module (mock.identifier ('test_analyser_cascade_001'), None)
+
+      control = ast.Control (
+         mock.identifier ('cv_in1'),
+         mock.keyword ('CvIn')
+      )
+      cascade_to = ast.CascadeTo (mock.identifier ('cv_in2'))
+      control.entities.append (cascade_to)
+      module.entities.append (control)
+
+      control = ast.Control (
+         mock.identifier ('cv_in2'),
+         mock.keyword ('CvIn')
+      )
+      module.entities.append (control)
+
+      analyser = Analyser ()
+      for control in module.controls:
+         if control.cascade_to is not None:
+            analyser.resolve_cascade (module, control, control.cascade_to)
+
+      analyser.make_cascade_eval_list (module)
+
+      self.assertEqual (len (module.cascade_eval_list), 2)
+      self.assertEqual (module.cascade_eval_list [0].name, 'cv_in1')
+      self.assertEqual (module.cascade_eval_list [1].name, 'cv_in2')
+
+
+   def test_cascade_002b (self):
+      module = ast.Module (mock.identifier ('test_analyser_cascade_001'), None)
+
+      control = ast.Control (
+         mock.identifier ('cv_in2'),
+         mock.keyword ('CvIn')
+      )
+      module.entities.append (control)
+
+      control = ast.Control (
+         mock.identifier ('cv_in1'),
+         mock.keyword ('CvIn')
+      )
+      cascade_to = ast.CascadeTo (mock.identifier ('cv_in2'))
+      control.entities.append (cascade_to)
+      module.entities.append (control)
+
+      analyser = Analyser ()
+      for control in module.controls:
+         if control.cascade_to is not None:
+            analyser.resolve_cascade (module, control, control.cascade_to)
+
+      analyser.make_cascade_eval_list (module)
+
+      self.assertEqual (len (module.cascade_eval_list), 2)
+      self.assertEqual (module.cascade_eval_list [0].name, 'cv_in1')
+      self.assertEqual (module.cascade_eval_list [1].name, 'cv_in2')
+
+
+   def test_cascade_003 (self):
+      module = ast.Module (mock.identifier ('test_analyser_cascade_001'), None)
+
+      control = ast.Control (
+         mock.identifier ('cv_in1'),
+         mock.keyword ('CvIn')
+      )
+      cascade_to = ast.CascadeTo (mock.identifier ('cv_in2'))
+      control.entities.append (cascade_to)
+      module.entities.append (control)
+
+      control = ast.Control (
+         mock.identifier ('cv_in2'),
+         mock.keyword ('CvIn')
+      )
+      cascade_to = ast.CascadeTo (mock.identifier ('cv_in3'))
+      control.entities.append (cascade_to)
+      module.entities.append (control)
+
+      control = ast.Control (
+         mock.identifier ('cv_in3'),
+         mock.keyword ('CvIn')
+      )
+      cascade_to = ast.CascadeTo (mock.identifier ('cv_in4'))
+      control.entities.append (cascade_to)
+      module.entities.append (control)
+
+      control = ast.Control (
+         mock.identifier ('cv_in4'),
+         mock.keyword ('CvIn')
+      )
+      module.entities.append (control)
+
+      analyser = Analyser ()
+      for control in module.controls:
+         if control.cascade_to is not None:
+            analyser.resolve_cascade (module, control, control.cascade_to)
+
+      analyser.make_cascade_eval_list (module)
+
+      self.assertEqual (len (module.cascade_eval_list), 4)
+      self.assertEqual (module.cascade_eval_list [0].name, 'cv_in1')
+      self.assertEqual (module.cascade_eval_list [1].name, 'cv_in2')
+      self.assertEqual (module.cascade_eval_list [2].name, 'cv_in3')
+      self.assertEqual (module.cascade_eval_list [3].name, 'cv_in4')
+
+
+   def test_cascade_003b (self):
+      module = ast.Module (mock.identifier ('test_analyser_cascade_001'), None)
+
+      control = ast.Control (
+         mock.identifier ('cv_in4'),
+         mock.keyword ('CvIn')
+      )
+      module.entities.append (control)
+
+      control = ast.Control (
+         mock.identifier ('cv_in3'),
+         mock.keyword ('CvIn')
+      )
+      cascade_to = ast.CascadeTo (mock.identifier ('cv_in4'))
+      control.entities.append (cascade_to)
+      module.entities.append (control)
+
+      control = ast.Control (
+         mock.identifier ('cv_in2'),
+         mock.keyword ('CvIn')
+      )
+      cascade_to = ast.CascadeTo (mock.identifier ('cv_in3'))
+      control.entities.append (cascade_to)
+      module.entities.append (control)
+
+      control = ast.Control (
+         mock.identifier ('cv_in1'),
+         mock.keyword ('CvIn')
+      )
+      cascade_to = ast.CascadeTo (mock.identifier ('cv_in2'))
+      control.entities.append (cascade_to)
+      module.entities.append (control)
+
+      analyser = Analyser ()
+      for control in module.controls:
+         if control.cascade_to is not None:
+            analyser.resolve_cascade (module, control, control.cascade_to)
+
+      analyser.make_cascade_eval_list (module)
+
+      self.assertEqual (len (module.cascade_eval_list), 4)
+      self.assertEqual (module.cascade_eval_list [0].name, 'cv_in1')
+      self.assertEqual (module.cascade_eval_list [1].name, 'cv_in2')
+      self.assertEqual (module.cascade_eval_list [2].name, 'cv_in3')
+      self.assertEqual (module.cascade_eval_list [3].name, 'cv_in4')
+
+
+   def test_cascade_003c (self):
+      module = ast.Module (mock.identifier ('test_analyser_cascade_001'), None)
+
+      control = ast.Control (
+         mock.identifier ('cv_in3'),
+         mock.keyword ('CvIn')
+      )
+      cascade_to = ast.CascadeTo (mock.identifier ('cv_in4'))
+      control.entities.append (cascade_to)
+      module.entities.append (control)
+
+      control = ast.Control (
+         mock.identifier ('cv_in2'),
+         mock.keyword ('CvIn')
+      )
+      cascade_to = ast.CascadeTo (mock.identifier ('cv_in3'))
+      control.entities.append (cascade_to)
+      module.entities.append (control)
+
+      control = ast.Control (
+         mock.identifier ('cv_in4'),
+         mock.keyword ('CvIn')
+      )
+      module.entities.append (control)
+
+      control = ast.Control (
+         mock.identifier ('cv_in1'),
+         mock.keyword ('CvIn')
+      )
+      cascade_to = ast.CascadeTo (mock.identifier ('cv_in2'))
+      control.entities.append (cascade_to)
+      module.entities.append (control)
+
+      analyser = Analyser ()
+      for control in module.controls:
+         if control.cascade_to is not None:
+            analyser.resolve_cascade (module, control, control.cascade_to)
+
+      analyser.make_cascade_eval_list (module)
+
+      self.assertEqual (len (module.cascade_eval_list), 4)
+      self.assertEqual (module.cascade_eval_list [0].name, 'cv_in1')
+      self.assertEqual (module.cascade_eval_list [1].name, 'cv_in2')
+      self.assertEqual (module.cascade_eval_list [2].name, 'cv_in3')
+      self.assertEqual (module.cascade_eval_list [3].name, 'cv_in4')
+
+
+if __name__ == '__main__':
+   unittest.main ()


### PR DESCRIPTION
This PR adds `cascade` support to the simulator, by setting the appropriate voltage to each cascaded pins.