### PR TITLE
Module width board fallback

### DIFF
--- a/boards/kivu12/definition.py
+++ b/boards/kivu12/definition.py
@@ -9,6 +9,7 @@
 
 {
    'class': 'BoardKivu12',
+   'width': 12, # hp
    'pins': {
 
       #--- Bottom Header

--- a/build-system/erbui/analyser.py
+++ b/build-system/erbui/analyser.py
@@ -42,6 +42,8 @@ class Analyser:
 
       self._board_definition = self.load_board_definition (module)
 
+      self.set_auto_board_width (module)
+
       for control in module.controls:
          self.update_pools (control)
 
@@ -55,6 +57,28 @@ class Analyser:
          self.resolve_alias (module, alias)
 
       self.make_cascade_eval_list (module)
+
+
+   #--------------------------------------------------------------------------
+
+   def set_auto_board_width (self, module):
+      if 'width' not in self._board_definition:
+         return # board doesn't support fixed width
+
+      board_width = self._board_definition ['width']
+
+      def generate_literal (value):
+         node = lambda: None
+         node.value = value
+         node.position = None
+         return adapter.Literal (None, node)
+
+      entities = [e for e in module.entities if e.is_width]
+      if len (entities) == 0:
+         literal = generate_literal ('%shp' % board_width)
+         distance_literal = ast.DistanceLiteral (literal, 'hp')
+         width = ast.Width (distance_literal)
+         module.entities.append (width)
 
 
    #--------------------------------------------------------------------------

--- a/documentation/language/grammar.md
+++ b/documentation/language/grammar.md
@@ -108,7 +108,11 @@ See individual [boards](../boards/) reference for the available pins configurati
 
 ## `width`
 
-`width` defines the module width in HP. In general, it should follow the [board](#board) width.
+`width` defines the module width in HP.
+
+If a [board](#board) is defined but no width is defined, then the actual width will be inherited from
+the board width.
+
 Only a [specific set of integer HP widths](http://www.doepfer.de/a100_man/a100m_e.htm) are valid.
 
 ### Grammar

--- a/samples/reverb/Reverb.erbui
+++ b/samples/reverb/Reverb.erbui
@@ -9,7 +9,6 @@
 
 module Reverb {
    board kivu12
-   width 12hp
    material aluminum
    header { label "REVERB" }
 


### PR DESCRIPTION
This PR simplifies the `erbui` description further by allowing the build system to guess the module width based on the base board width.

Said differently, the `width` property is no longer required when a `board` is defined, which will become the default behavior.
