### PR TITLE
Fix pip install

### DIFF
--- a/.github/workflows/macos_10_15.yml
+++ b/.github/workflows/macos_10_15.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: pip2 install future
       - run: brew install --cask kicad
       - run: ./blocks/audio-in-daisy/build.py
       - run: ./blocks/audio-out-daisy/build.py

--- a/.github/workflows/macos_10_15.yml
+++ b/.github/workflows/macos_10_15.yml
@@ -51,8 +51,7 @@ jobs:
       - run: brew install dfu-util  # using USB
       - run: brew install openocd   # using JTAG
 
-      - run: pip3 install cairosvg cairocffi
-      - run: pip3 install ezdxf
+      - run: python3 -m pip install cairosvg cairocffi ezdxf
       - run: mkdir -p ~/Library/Fonts
       - run: cp include/erb/vcvrack/design/d-din/*.otf ~/Library/Fonts
       - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/Library/Fonts
@@ -87,9 +86,7 @@ jobs:
           submodules: recursive
       - run: brew install cairo libffi
       - run: brew install --cask kicad
-      - run: pip3 install cairosvg cairocffi
-      - run: pip3 install ezdxf
-      - run: pip3 install coverage
+      - run: python3 -m pip install cairosvg cairocffi ezdxf coverage
       - run: mkdir -p ~/Library/Fonts
       - run: cp include/erb/vcvrack/design/d-din/*.otf ~/Library/Fonts
       - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/Library/Fonts

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -54,8 +54,7 @@ jobs:
       - run: sudo apt install dfu-util  # using USB
       - run: sudo apt install openocd   # using JTAG
 
-      - run: pip install cairosvg cairocffi
-      - run: pip install ezdxf
+      - run: python -m pip install cairosvg cairocffi ezdxf
       - run: mkdir -p ~/.local/share/fonts/
       - run: cp include/erb/vcvrack/design/d-din/*.otf ~/.local/share/fonts
       - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/.local/share/fonts
@@ -93,9 +92,7 @@ jobs:
       - run: sudo apt-get install libglu1-mesa-dev
       - run: sudo apt install libcairo2-dev libffi-dev python3-dev
       - run: sudo apt-get install kicad
-      - run: pip install cairosvg cairocffi
-      - run: pip install ezdxf
-      - run: pip install coverage
+      - run: python -m pip install cairosvg cairocffi ezdxf coverage
       - run: mkdir -p ~/.local/share/fonts/
       - run: cp include/erb/vcvrack/design/d-din/*.otf ~/.local/share/fonts
       - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/.local/share/fonts

--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ The eurorack-block project requires the following to be installed:
 
 - [Homebrew](https://brew.sh), up-to-date,
 - [Xcode](https://developer.apple.com/xcode/), with minimum version 10 on macOS,
-- [All the package dependencies](.github/workflows/macos_10_15.yml#L43-L59).
+- [All the package dependencies](.github/workflows/macos_10_15.yml#L42-L57).
 
 ### Debian/Ubuntu
 
-- [All the package dependencies](.github/workflows/ubuntu_20_04.yml#L43-L61).
+- [All the package dependencies](.github/workflows/ubuntu_20_04.yml#L43-L60).
 
 ### STLink probe
 


### PR DESCRIPTION
This PR fixes an install problem where `pip3 install` could install modules at a different place than `python3 -m pip install`.