### PR TITLE
Port drop to kivu12 board

### DIFF
--- a/samples/drop/Drop.erbui
+++ b/samples/drop/Drop.erbui
@@ -8,131 +8,115 @@
 
 
 module Drop {
-   width 10hp
+   board kivu12
    material aluminum
    header { label "DROP" }
 
    line {
-      position 43.4mm, 83.7mm
-      position 43.4mm, 88.1mm
+      position 10hp, 83.7mm
+      position 10hp, 88.1mm
    }
    line {
-      position 7.11mm, 80.7mm
-      position 7.11mm, 82.6mm
+      position 2hp, 80.7mm
+      position 2hp, 82.6mm
    }
    line {
-      position 19.2mm, 80.7mm
-      position 19.2mm, 82.6mm
+      position 4.66hp, 80.7mm
+      position 4.66hp, 82.6mm
    }
 
    control freq_pot Pot {
-      position 25.3mm, 34mm
+      position 6hp, 34mm
       style rogan.6ps
       label "FREQ"
-      pin AdcPin0
    }
 
    control mute_hp Switch {
-      position 25.3mm, 62mm
+      position 6hp, 62mm
       style dailywell.2ms1
       rotation 90°ccw
       label "MUTE" { positioning left }
       label "HP" { positioning right }
-      pins Pin0, Pin1
    }
 
    control freq_trim Trim {
       mode bipolar
-      position 43.4mm, 75.3mm
+      position 10hp, 75.3mm
       style songhuei.9mm
       label "–/+"
-      pin AdcPin2
    }
 
    control sync_button Button {
-      position 7.11mm, 75.3mm
+      position 2hp, 75.3mm
       style ck.d6r.black
-      pin Pin2
    }
 
    control arm_button Button {
-      position 19.2mm, 75.3mm
+      position 4.66hp, 75.3mm
       style ck.d6r.black
-      pin Pin3
    }
 
    control sync_led Led {
-      position 7.11mm, 85mm
+      position 2hp, 85mm
       style led.3mm.red
-      pin Pin26
    }
 
    control sync_gate GateIn {
-      position 7.11mm, 96.5mm
+      position 2hp, 96.5mm
       style thonk.pj398sm.knurled
       label "SYNC"
-      pin Pin5
    }
 
    control arm_led Led {
-      position 19.2mm, 85mm
+      position 4.66hp, 85mm
       style led.3mm.red
-      pin Pin27
    }
 
    control arm_gate GateIn {
-      position 19.2mm, 96.5mm
+      position 4.66hp, 96.5mm
       style thonk.pj398sm.knurled
       label "ARM"
-      pin Pin7
    }
 
    control state_led LedBi {
-      position 31.3mm, 85mm
+      position 7.33hp, 85mm
       style led.3mm.green_red
-      pins Pin12, Pin13
    }
 
    control state_gate GateOut {
-      position 31.3mm, 96.5mm
+      position 7.33hp, 96.5mm
       style thonk.pj398sm.knurled
       label "STATE"
-      pin Pin14
    }
 
    control freq_cv CvIn {
-      position 43.4mm, 96.5mm
+      position 10hp, 96.5mm
       style thonk.pj398sm.knurled
       label "FREQ"
-      pin AdcPin1
    }
 
    control audio_in_left AudioIn {
-      position 7.11mm, 111mm
+      position 2hp, 111mm
       style thonk.pj398sm.knurled
       label "IN L"
       cascade audio_in_right
-      pin AudioInPinLeft
    }
 
    control audio_in_right AudioIn {
-      position 19.2mm, 111mm
+      position 4.66hp, 111mm
       style thonk.pj398sm.knurled
       label "IN R"
-      pin AudioInPinRight
    }
 
    control audio_out_left AudioOut {
-      position 31.3mm, 111mm
+      position 7.33hp, 111mm
       style thonk.pj398sm.knurled
       label "OUT L"
-      pin AudioOutPinLeft
    }
 
    control audio_out_right AudioOut {
-      position 43.4mm, 111mm
+      position 10hp, 111mm
       style thonk.pj398sm.knurled
       label "OUT R"
-      pin AudioOutPinRight
    }
 }


### PR DESCRIPTION
This PR ports the `drop` sample to the `kivu12` board.