### PR TITLE
Front pcb pad remove unused

### DIFF
--- a/build-system/erbui/analyser.py
+++ b/build-system/erbui/analyser.py
@@ -50,6 +50,8 @@ class Analyser:
       for control in module.controls:
          self.allocate_pin (control)
 
+      self.make_unused_pins (module)
+
       for control in module.controls:
          self.analyse_control (module, control)
 
@@ -321,6 +323,18 @@ class Analyser:
 
             pin_array = ast.Pins (identifiers)
             control.entities.append (pin_array)
+
+
+   #--------------------------------------------------------------------------
+
+   def make_unused_pins (self, module):
+      if 'pools' not in self._board_definition:
+         return # board doesn't support auto pin allocation
+
+      module.unused_pins = []
+      pools = self._board_definition ['pools']
+      for key, value in pools.items ():
+         module.unused_pins.extend (value)
 
 
    #--------------------------------------------------------------------------

--- a/build-system/erbui/ast.py
+++ b/build-system/erbui/ast.py
@@ -238,6 +238,7 @@ class Module (Scope):
       self.identifier = identifier
       self.super_identifier = super_identifier
       self.cascade_eval_list = []
+      self.unused_pins = []
 
    @staticmethod
    def typename (): return 'module'


### PR DESCRIPTION
This PR removed unused front PCB pads.

> Note: this won't remove SD pads, as SD pads are not yet part of the board definition.