### PR TITLE
Board kivu12 rev3 adapt codec levels

### DIFF
--- a/include/erb/daisy/SubmoduleDaisyPatchSm.h
+++ b/include/erb/daisy/SubmoduleDaisyPatchSm.h
@@ -119,7 +119,7 @@ public:
    // Onboard Daisy Codec and associated gain stage
    // eurorack audio level (-5V, 5V) to (-1.f, 1.f)
    static constexpr float
-                  gain_input_scaling = 2.3f;
+                  gain_input_scaling = 1.52f;
 
    // Onboard Daisy Codec and associated gain stage
    // Map (-1.f, 1.f) to eurorack audio level (-5V, 5V)


### PR DESCRIPTION
Adapt codec gain levels on input and output to match ±5V to bipolar values.