### PR TITLE
Fix loadable module

### DIFF
--- a/build-system/erbui/generators/vcvrack/manifest.py
+++ b/build-system/erbui/generators/vcvrack/manifest.py
@@ -23,7 +23,7 @@ class Manifest:
 
       with open (path_json, 'w') as file:
          file.write ('{\n')
-         file.write ('   "slug": "ErbPlugin",\n')
+         file.write ('   "slug": "ErbPlugin%s",\n' % root.modules [0].name)
          file.write ('   "name": "Erb Plugin",\n')
          file.write ('   "version": "1.0.0",\n')
          file.write ('   "license": "proprietary",\n')

--- a/include/erb/erb.gypi
+++ b/include/erb/erb.gypi
@@ -55,6 +55,8 @@
          ],
 
          'direct_dependent_settings': {
+            'type': 'executable',
+
             'defines': [
                'erb_TARGET_DAISY',
             ],
@@ -142,6 +144,8 @@
          ],
 
          'direct_dependent_settings': {
+            'type': 'loadable_module',
+
             'defines': [
                'erb_TARGET_VCV_RACK',
             ],
@@ -180,6 +184,7 @@
                ],
 
                'EXECUTABLE_PREFIX': '',
+               'EXECUTABLE_EXTENSION': 'dylib',
                'PRODUCT_NAME': 'plugin',
             },
 

--- a/samples/bypass/bypass.gyp
+++ b/samples/bypass/bypass.gyp
@@ -32,14 +32,12 @@
 
       {
          'target_name': 'bypass-daisy',
-         'type': 'executable',
 
          'dependencies': [ 'bypass', 'erb-daisy' ],
       },
 
       {
          'target_name': 'bypass-vcvrack',
-         'type': 'shared_library',
 
          'dependencies': [ 'bypass', 'erb-vcvrack' ],
       },

--- a/samples/drop/drop.gyp
+++ b/samples/drop/drop.gyp
@@ -45,14 +45,12 @@
 
       {
          'target_name': 'drop-daisy',
-         'type': 'executable',
 
          'dependencies': [ 'drop', 'erb-daisy' ],
       },
 
       {
          'target_name': 'drop-vcvrack',
-         'type': 'shared_library',
 
          'dependencies': [ 'drop', 'erb-vcvrack' ],
       },

--- a/samples/reverb/reverb.gyp
+++ b/samples/reverb/reverb.gyp
@@ -47,14 +47,12 @@
 
       {
          'target_name': 'reverb-daisy',
-         'type': 'executable',
 
          'dependencies': [ 'reverb', 'erb-daisy' ],
       },
 
       {
          'target_name': 'reverb-vcvrack',
-         'type': 'shared_library',
 
          'dependencies': [ 'reverb', 'erb-vcvrack' ],
       },

--- a/test/field/field.gyp
+++ b/test/field/field.gyp
@@ -36,14 +36,12 @@
 
       {
          'target_name': 'field-daisy',
-         'type': 'executable',
 
          'dependencies': [ 'field', 'erb-daisy' ],
       },
 
       {
          'target_name': 'field-vcvrack',
-         'type': 'shared_library',
 
          'dependencies': [ 'field', 'erb-vcvrack' ],
       },

--- a/test/micropatch/micropatch.gyp
+++ b/test/micropatch/micropatch.gyp
@@ -36,14 +36,12 @@
 
       {
          'target_name': 'micropatch-daisy',
-         'type': 'executable',
 
          'dependencies': [ 'micropatch', 'erb-daisy' ],
       },
 
       {
          'target_name': 'micropatch-vcvrack',
-         'type': 'shared_library',
 
          'dependencies': [ 'micropatch', 'erb-vcvrack' ],
       },

--- a/test/vcvrack/vcvrack.gyp
+++ b/test/vcvrack/vcvrack.gyp
@@ -19,7 +19,6 @@
    'targets' : [
       {
          'target_name': 'vcvrack',
-         'type': 'shared_library',
 
          'dependencies': [ 'erb-vcvrack' ],
 


### PR DESCRIPTION
This PR fixes a bug where it was not possible to load 2 plug-ins made using ERB.

While the issue is not fully understood, we found out that VCV Rack is using dylibs instead of loadable modules (or bundle), like conventionally used in VSTs, AUs, etc.

The bug manifested itself by loading twice the same `init` function, but for a different plug-in.

For example, if Drop and Reverb are both plug-in modules, Drop will be first called with the plugin path for Drop, but then it will be called a second time with the Reverb plugin path.

For some reason, the Reverb `init` function is mapped to the Drop `init` function:

```
DYLD_PRINT_APIS=YES ./Rack
dlopen_internal(/Users/raf/Documents/Rack/plugins-v1/Drop/plugin.dylib, 0x00000006)
dyld_image_path_containing_address(0x84e3000)
_dyld_is_memory_immutable(0x84e3000, 28)
  dlopen_internal(/Users/raf/Documents/Rack/plugins-v1/Drop/plugin.dylib) ==> 0x7fa83d41dda0
dlsym_internal(0x7fa83d41dda0, init)
  dlsym_internal(0x7fa83d41dda0, init) ==> 0x84e64f0
Drop
/Users/raf/Documents/Rack/plugins-v1/Drop
dlopen_internal(/Users/raf/Documents/Rack/plugins-v1/Fundamental/plugin.dylib, 0x00000006)
dyld_image_path_containing_address(0x855a000)
_dyld_is_memory_immutable(0x855a000, 28)
  dlopen_internal(/Users/raf/Documents/Rack/plugins-v1/Fundamental/plugin.dylib) ==> 0x7fa83d425980
dlsym_internal(0x7fa83d425980, init)
  dlsym_internal(0x7fa83d425980, init) ==> 0x855e650
dlopen_internal(/Users/raf/Documents/Rack/plugins-v1/Reverb/plugin.dylib, 0x00000006)
  dlopen_internal(/Users/raf/Documents/Rack/plugins-v1/Reverb/plugin.dylib) ==> 0x7fa83d41dda0
dlsym_internal(0x7fa83d41dda0, init)
  dlsym_internal(0x7fa83d41dda0, init) ==> 0x84e64f0
```

We changed the build system to use bundle types (`loadable_module` in gyp) instead, and this seems to fix this issue.

`Wait for executable to be launched` launch option is still required.

All in all, this is not a satisfactory fix as we don't really understand what is happening, but this bug was such a blocker for the project that this fix is seen as acceptable for merge.

- Fixes #93