### PR TITLE
Erbb option force dfu util

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -275,8 +275,8 @@ Name : deploy
 ==============================================================================
 """
 
-def deploy (name, path, configuration):
-   if shutil.which ('openocd') is not None:
+def deploy (name, path, configuration, force_dfu_util=False):
+   if shutil.which ('openocd') is not None and not force_dfu_util:
       deploy_openocd (name, path, configuration)
    else:
       deploy_dfu_util (name, path, configuration)

--- a/samples/bypass/deploy.py
+++ b/samples/bypass/deploy.py
@@ -48,6 +48,12 @@ def parse_args ():
       help = 'The build configuration to use. Defaults to Release'
    )
 
+   arg_parser.add_argument(
+      '--dfu',
+      action = 'store_true',
+      help = 'Force dfu-util usage over openocd.'
+   )
+
    return arg_parser.parse_args (sys.argv[1:])
 
 
@@ -58,7 +64,7 @@ if __name__ == '__main__':
    try:
       args = parse_args ()
 
-      erbb.deploy ('%s-daisy' % PROJECT, PATH_THIS, args.configuration)
+      erbb.deploy ('%s-daisy' % PROJECT, PATH_THIS, args.configuration, force_dfu_util=args.dfu)
 
    except subprocess.CalledProcessError as error:
       print ('Deploy command exited with %d' % error.returncode, file = sys.stderr)

--- a/samples/drop/deploy.py
+++ b/samples/drop/deploy.py
@@ -48,6 +48,12 @@ def parse_args ():
       help = 'The build configuration to use. Defaults to Release'
    )
 
+   arg_parser.add_argument(
+      '--dfu',
+      action = 'store_true',
+      help = 'Force dfu-util usage over openocd.'
+   )
+
    return arg_parser.parse_args (sys.argv[1:])
 
 
@@ -58,7 +64,7 @@ if __name__ == '__main__':
    try:
       args = parse_args ()
 
-      erbb.deploy ('%s-daisy' % PROJECT, PATH_THIS, args.configuration)
+      erbb.deploy ('%s-daisy' % PROJECT, PATH_THIS, args.configuration, force_dfu_util=args.dfu)
 
    except subprocess.CalledProcessError as error:
       print ('Deploy command exited with %d' % error.returncode, file = sys.stderr)

--- a/samples/reverb/deploy.py
+++ b/samples/reverb/deploy.py
@@ -48,6 +48,12 @@ def parse_args ():
       help = 'The build configuration to use. Defaults to Release'
    )
 
+   arg_parser.add_argument(
+      '--dfu',
+      action = 'store_true',
+      help = 'Force dfu-util usage over openocd.'
+   )
+
    return arg_parser.parse_args (sys.argv[1:])
 
 
@@ -58,7 +64,7 @@ if __name__ == '__main__':
    try:
       args = parse_args ()
 
-      erbb.deploy ('%s-daisy' % PROJECT, PATH_THIS, args.configuration)
+      erbb.deploy ('%s-daisy' % PROJECT, PATH_THIS, args.configuration, force_dfu_util=args.dfu)
 
    except subprocess.CalledProcessError as error:
       print ('Deploy command exited with %d' % error.returncode, file = sys.stderr)

--- a/test/field/deploy.py
+++ b/test/field/deploy.py
@@ -48,6 +48,12 @@ def parse_args ():
       help = 'The build configuration to use. Defaults to Release'
    )
 
+   arg_parser.add_argument(
+      '--dfu',
+      action = 'store_true',
+      help = 'Force dfu-util usage over openocd.'
+   )
+
    return arg_parser.parse_args (sys.argv[1:])
 
 
@@ -58,7 +64,7 @@ if __name__ == '__main__':
    try:
       args = parse_args ()
 
-      erbb.deploy ('%s-daisy' % PROJECT, PATH_THIS, args.configuration)
+      erbb.deploy ('%s-daisy' % PROJECT, PATH_THIS, args.configuration, force_dfu_util=args.dfu)
 
    except subprocess.CalledProcessError as error:
       print ('Deploy command exited with %d' % error.returncode, file = sys.stderr)

--- a/test/micropatch/deploy.py
+++ b/test/micropatch/deploy.py
@@ -48,6 +48,12 @@ def parse_args ():
       help = 'The build configuration to use. Defaults to Release'
    )
 
+   arg_parser.add_argument(
+      '--dfu',
+      action = 'store_true',
+      help = 'Force dfu-util usage over openocd.'
+   )
+
    return arg_parser.parse_args (sys.argv[1:])
 
 
@@ -58,7 +64,7 @@ if __name__ == '__main__':
    try:
       args = parse_args ()
 
-      erbb.deploy ('%s-daisy' % PROJECT, PATH_THIS, args.configuration)
+      erbb.deploy ('%s-daisy' % PROJECT, PATH_THIS, args.configuration, force_dfu_util=args.dfu)
 
    except subprocess.CalledProcessError as error:
       print ('Deploy command exited with %d' % error.returncode, file = sys.stderr)


### PR DESCRIPTION
This PR allows to force the use of `dfu-util` even if `openocd` is installed.

It allows to still to download the firmware using USB even if a more convenient JTAG adapter is available, which happens when the JTAG header is damaged or just not present.

The `--dfu` option was added to all deploy scripts in tests and samples.
