### PR TITLE
Fix adc pin orders

### DIFF
--- a/include/erb/daisy/AdcDaisy.hpp
+++ b/include/erb/daisy/AdcDaisy.hpp
@@ -72,12 +72,10 @@ AdcDaisy <MaxNbrData>::AdcDaisy (daisy::AdcHandle & adc, std::initializer_list <
       }
       else
       {
-         constexpr size_t pot_order [] = {0, 3, 1, 4, 2, 5, 6, 7};
-
          for (size_t i = 0 ; i < channel.nbr_channels ; ++i)
          {
             _data [channel_nbr]
-               = adc.GetMuxPtr (uint8_t (config_nbr), pot_order [i]);
+               = adc.GetMuxPtr (uint8_t (config_nbr), i);
             ++channel_nbr;
          }
       }

--- a/include/erb/daisy/BoardDaisyField.hpp
+++ b/include/erb/daisy/BoardDaisyField.hpp
@@ -68,7 +68,24 @@ Name : impl_preprocess
 
 void  BoardDaisyField::impl_preprocess (AdcPin pin)
 {
-   _analog_inputs [pin.index] = to_float_norm (_adc.read (pin.index));
+   if ((pin.index >= CI1.index) && (pin.index <= CI4.index))
+   {
+      const auto norm_val = to_float_norm (_adc.read (pin.index));
+      // OpAmp in non-inverting amplifier
+      _analog_inputs [pin.index] = norm_val;
+   }
+   else if ((pin.index >= P1.index) && (pin.index <= P8.index))
+   {
+      constexpr size_t pot_order [] = {
+         4+0, 4+3, 4+1, 4+4, 4+2, 4+5, 4+6, 4+7, // P1..8
+      };
+
+      const auto norm_val = to_float_norm (
+         _adc.read (pot_order [pin.index - P1.index])
+      );
+
+      _analog_inputs [pin.index] = norm_val;
+   }
 }
 
 

--- a/include/erb/daisy/BoardKivu12.hpp
+++ b/include/erb/daisy/BoardKivu12.hpp
@@ -81,15 +81,27 @@ Name : impl_preprocess
 
 void  BoardKivu12::impl_preprocess (AdcPin pin)
 {
-   const auto norm_val = to_float_norm (_adc.read (pin.index));
-
    if ((pin.index >= CI1.index) && (pin.index <= CI8.index))
    {
+      const auto norm_val = to_float_norm (_adc.read (pin.index));
       // OpAmp in inverter adder with voltage reference
       _analog_inputs [pin.index] = 1.f - norm_val;
    }
-   else
+   else if ((pin.index >= P1.index) && (pin.index <= P12.index))
    {
+      // IN1-X4, IN2-X6, IN3-X7, IN4-X5
+      // IN5-X2, IN6-X1, IN7-X0, IN8-X3
+      // IN9-X2, IN10-X1, IN11-X0, IN12-X3
+
+      constexpr size_t pot_order [] = {
+         8+4, 8+6, 8+7, 8+5, 8+2, 8+1, 8+0, 8+3, // P1..8
+         16+2, 16+1, 16+0, 16+3                  // P9..12
+      };
+
+      const auto norm_val = to_float_norm (
+         _adc.read (pot_order [pin.index - P1.index])
+      );
+
       _analog_inputs [pin.index] = norm_val;
    }
 }

--- a/test/kivu12_adc/Kivu12.cpp
+++ b/test/kivu12_adc/Kivu12.cpp
@@ -1,0 +1,61 @@
+/*****************************************************************************
+
+      Kivu12.cpp
+      Copyright (c) 2020 Raphael DINGE
+
+*Tab=3***********************************************************************/
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#include "Kivu12.h"
+
+#include <cmath>
+
+
+
+/*
+==============================================================================
+Name : process
+==============================================================================
+*/
+
+void  Kivu12::process ()
+{
+#if 0
+   // Basic: check if audio output works
+   osc1.set_freq (440.f);
+   osc2.set_freq (880.f);
+
+   for (size_t i = 0 ; i < erb_BUFFER_SIZE ; ++i)
+   {
+      ui.audio_out1 [i] = osc1.process ();
+      ui.audio_out2 [i] = osc2.process ();
+   }
+
+#elif 1
+   // Change pot pin assignment in erbui file to check every input
+   osc1.set_freq_norm (ui.freq_pot);
+
+   for (size_t i = 0 ; i < erb_BUFFER_SIZE ; ++i)
+   {
+      auto val = osc1.process ();
+      ui.audio_out1 [i] = val;
+      ui.audio_out2 [i] = val;
+   }
+
+#elif 0
+   // Check for one input influencing the other
+   osc1.set_freq_norm (ui.freq_pot);
+   osc2.set_freq_norm (ui.freq2_pot);
+
+   for (size_t i = 0 ; i < erb_BUFFER_SIZE ; ++i)
+   {
+      auto val = (osc1.process () + osc2.process ()) * 0.5f;
+      ui.audio_out1 [i] = val;
+      ui.audio_out2 [i] = val;
+   }
+
+#endif
+}

--- a/test/kivu12_adc/Kivu12.erbui
+++ b/test/kivu12_adc/Kivu12.erbui
@@ -1,0 +1,42 @@
+/*****************************************************************************
+
+      Kivu12.erbui
+      Copyright (c) 2020 Raphael DINGE
+
+*Tab=3***********************************************************************/
+
+
+
+module Kivu12 {
+   board kivu12
+   material aluminum
+   header { label "Kivu12" }
+
+   control freq_pot Pot {
+      position 7.33hp, 111mm
+      style thonk.pj398sm.knurled
+      label "FREQ"
+      pin P1
+   }
+
+   control freq2_pot Pot {
+      position 7.33hp, 111mm
+      style thonk.pj398sm.knurled
+      label "FREQ"
+      pin P2
+   }
+
+   control audio_out1 AudioOut {
+      position 7.33hp, 111mm
+      style thonk.pj398sm.knurled
+      label "OUT L"
+      pin AO1
+   }
+
+   control audio_out2 AudioOut {
+      position 10hp, 111mm
+      style thonk.pj398sm.knurled
+      label "OUT R"
+      pin AO2
+   }
+}

--- a/test/kivu12_adc/Kivu12.h
+++ b/test/kivu12_adc/Kivu12.h
@@ -1,0 +1,67 @@
+/*****************************************************************************
+
+      Kivu12.h
+      Copyright (c) 2020 Raphael DINGE
+
+*Tab=3***********************************************************************/
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#include "artifacts/Kivu12Ui.h"
+
+#include "erb/erb.h"
+
+
+
+/*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+constexpr double pim2 = 2.f * M_PI;
+
+class OscSin
+{
+public:
+   void           set_freq_norm (float freq_norm)
+   {
+      float freq = 20.f * std::pow (500.f, std::abs (freq_norm));
+      set_freq (freq);
+   }
+
+   void           set_freq (float freq)
+   {
+      const double phase_step = pim2 * freq / erb_SAMPLE_RATE;
+      _step_cos = std::cos (phase_step);
+      _step_sin = std::sin (phase_step);
+   }
+
+   float          process ()
+   {
+      const double old_cos = _pos_cos;
+      const double old_sin = _pos_sin;
+      _pos_cos = old_cos * _step_cos - old_sin * _step_sin;
+      _pos_sin = old_cos * _step_sin + old_sin * _step_cos;
+
+      return float (_pos_sin);
+   }
+
+private:
+   double         _step_cos = 1.f;
+   double         _step_sin = 0.f;
+
+   double         _pos_cos = 1.f;
+   double         _pos_sin = 0.f;
+};
+
+
+
+struct Kivu12
+{
+   Kivu12Ui ui;
+   OscSin osc1;
+   OscSin osc2;
+   OscSin osc3;
+   OscSin osc4;
+
+   void  process ();
+};

--- a/test/kivu12_adc/build.py
+++ b/test/kivu12_adc/build.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+#
+#     build.py
+#     Copyright (c) 2020 Raphael Dinge
+#
+#Tab=3########################################################################
+
+
+##### IMPORT #################################################################
+
+from __future__ import print_function
+import argparse
+import os
+import subprocess
+import sys
+
+PATH_THIS = os.path.abspath (os.path.dirname (__file__))
+PATH_ARTIFACTS = os.path.join (PATH_THIS, 'artifacts')
+PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
+
+sys.path.insert (0, os.path.join (PATH_ROOT, 'build-system'))
+import erbb
+import erbui
+
+PROJECT = 'kivu12'
+CLASS = 'Kivu12'
+
+
+
+##############################################################################
+
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
+   sys.exit (1)
+
+
+
+"""
+==============================================================================
+Name : parse_args
+==============================================================================
+"""
+
+def parse_args ():
+   arg_parser = argparse.ArgumentParser ()
+
+   arg_parser.add_argument(
+      '--erb-target',
+      default = 'daisy',
+      choices = ['daisy', 'vcvrack'],
+      help = 'The erb target to use. Defaults to daisy'
+   )
+
+   arg_parser.add_argument(
+      '-c', '--configuration',
+      default = 'Release',
+      choices = ['Debug', 'Release'],
+      help = 'The build configuration to use. Defaults to Release'
+   )
+
+   return arg_parser.parse_args (sys.argv[1:])
+
+
+
+##############################################################################
+
+if __name__ == '__main__':
+   try:
+      args = parse_args ()
+
+      if args.erb_target == 'daisy':
+         ast = erbui.parse (os.path.join (PATH_THIS, '%s.erbui' % CLASS))
+
+         erbb.build_target (
+            PROJECT, '%s-daisy' % PROJECT, PATH_THIS, args.configuration
+         )
+         erbb.objcopy ('%s-daisy' % PROJECT, PATH_THIS, args.configuration)
+
+      elif args.erb_target == 'vcvrack':
+         erbb.build_native_target (
+            PROJECT, '%s-vcvrack' % PROJECT, PATH_THIS, args.configuration
+         )
+
+   except subprocess.CalledProcessError as error:
+      print ('Build command exited with %d' % error.returncode, file = sys.stderr)
+      sys.exit (1)

--- a/test/kivu12_adc/configure.py
+++ b/test/kivu12_adc/configure.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+#
+#     configure.py
+#     Copyright (c) 2020 Raphael Dinge
+#
+#Tab=3########################################################################
+
+
+##### IMPORT #################################################################
+
+from __future__ import print_function
+import os
+import subprocess
+import sys
+
+PATH_THIS = os.path.abspath (os.path.dirname (__file__))
+PATH_ARTIFACTS = os.path.join (PATH_THIS, 'artifacts')
+PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
+
+sys.path.insert (0, os.path.join (PATH_ROOT, 'build-system'))
+import erbb
+import erbui
+
+
+
+##############################################################################
+
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
+   sys.exit (1)
+
+
+
+##############################################################################
+
+if __name__ == '__main__':
+   try:
+      ast = erbui.parse (os.path.join (PATH_THIS, 'Kivu12.erbui'))
+
+      erbb.configure ('kivu12', PATH_THIS)
+      erbui.generate_ui (PATH_ARTIFACTS, ast)
+      erbui.generate_daisy (PATH_ARTIFACTS, ast)
+      erbui.generate_vcvrack (PATH_ARTIFACTS, ast)
+
+   except subprocess.CalledProcessError as error:
+      print ('Configure command exited with %d' % error.returncode, file = sys.stderr)
+      sys.exit (1)

--- a/test/kivu12_adc/deploy.py
+++ b/test/kivu12_adc/deploy.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+#
+#     deploy.py
+#     Copyright (c) 2020 Raphael Dinge
+#
+#Tab=3########################################################################
+
+
+##### IMPORT #################################################################
+
+from __future__ import print_function
+import argparse
+import os
+import subprocess
+import sys
+
+PATH_THIS = os.path.abspath (os.path.dirname (__file__))
+PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
+
+sys.path.insert (0, os.path.join (PATH_ROOT, 'build-system'))
+import erbb
+
+PROJECT = 'kivu12'
+
+
+
+##############################################################################
+
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
+   sys.exit (1)
+
+
+
+"""
+==============================================================================
+Name : parse_args
+==============================================================================
+"""
+
+def parse_args ():
+   arg_parser = argparse.ArgumentParser ()
+
+   arg_parser.add_argument(
+      '-c', '--configuration',
+      default = 'Release',
+      choices = ['Debug', 'Release'],
+      help = 'The build configuration to use. Defaults to Release'
+   )
+
+   arg_parser.add_argument(
+      '--dfu',
+      action = 'store_true',
+      help = 'Force dfu-util usage over openocd.'
+   )
+
+   return arg_parser.parse_args (sys.argv[1:])
+
+
+
+##############################################################################
+
+if __name__ == '__main__':
+   try:
+      args = parse_args ()
+
+      erbb.deploy ('%s-daisy' % PROJECT, PATH_THIS, args.configuration, force_dfu_util=args.dfu)
+
+   except subprocess.CalledProcessError as error:
+      print ('Deploy command exited with %d' % error.returncode, file = sys.stderr)
+      sys.exit (1)

--- a/test/kivu12_adc/kivu12.gyp
+++ b/test/kivu12_adc/kivu12.gyp
@@ -1,0 +1,51 @@
+##############################################################################
+#
+#     kivu12.gyp
+#     Copyright (c) 2020 Raphael DINGE
+#
+#Tab=3########################################################################
+
+
+
+{
+   'variables': {
+      'erbb_flash_lds': '../../../../../submodules/libDaisy/core/STM32H750IB_flash.lds',
+   },
+
+   'includes': [
+      '../../eurorack-blocks.gypi',
+   ],
+
+   'targets' : [
+      {
+         'target_name': 'kivu12',
+         'type': 'none',
+
+         'direct_dependent_settings': {
+            'sources': [
+               'Kivu12.cpp',
+               'Kivu12.h',
+               'Kivu12.erbui',
+            ],
+
+            'include_dirs': [
+               '..',
+            ],
+         },
+      },
+
+      {
+         'target_name': 'kivu12-daisy',
+         'type': 'executable',
+
+         'dependencies': [ 'kivu12', 'erb-daisy' ],
+      },
+
+      {
+         'target_name': 'kivu12-vcvrack',
+         'type': 'shared_library',
+
+         'dependencies': [ 'kivu12', 'erb-vcvrack' ],
+      },
+   ],
+}


### PR DESCRIPTION
This PR fixes the ADC mux order system:
- The common implementation in the ADC has been moved to the board implementation because the ADC pin order is dependent on the layout chosen respective to the pot name,
- `kivu12` and `field` boards have been updated to reflect this change,
- The other boards don't use a 4051 multiplexer, and so are not affected by this change.

This has been manually tested for both `kivu12` board (only first 8 pots) and `field` board (all pots).
