### PR TITLE
Fix init sequence

### DIFF
--- a/include/erb/daisy/SubmoduleDaisyPatchSm.h
+++ b/include/erb/daisy/SubmoduleDaisyPatchSm.h
@@ -149,11 +149,6 @@ protected:
 
 private:
 
-   void           enable_fz ();
-   void           init ();
-   void           init_system ();
-   void           init_sdram ();
-   void           init_qspi ();
    void           init_audio ();
 
    void           do_run ();
@@ -164,11 +159,6 @@ private:
    static SubmoduleDaisyPatchSm *
                   _this_ptr;
 
-   daisy::System  _system;
-   dsy_sdram_handle
-                  _sdram;
-   daisy::QSPIHandle
-                  _qspi;
    daisy::AudioHandle
                   _audio;
    daisy::AdcHandle

--- a/include/erb/daisy/SubmoduleDaisySeed.h
+++ b/include/erb/daisy/SubmoduleDaisySeed.h
@@ -169,7 +169,7 @@ protected:
 
 private:
 
-   void           enable_fz ();
+   void           init_audio ();
 
    void           do_run ();
 

--- a/samples/reverb/Reverb.h
+++ b/samples/reverb/Reverb.h
@@ -20,8 +20,8 @@
 
 struct Reverb
 {
-   ReverbUi ui;
    ReverbDsp dsp { erb_SAMPLE_RATE };
+   ReverbUi ui;
 
    void  process ();
 };

--- a/src/daisy/SubmoduleDaisyPatchSm.cpp
+++ b/src/daisy/SubmoduleDaisyPatchSm.cpp
@@ -28,11 +28,9 @@ Name : ctor
 
 SubmoduleDaisyPatchSm::SubmoduleDaisyPatchSm ()
 {
-   enable_fz ();
-
    _this_ptr = this;
 
-   init ();
+   init_audio ();
 
    _audio.SetBlockSize (erb_BUFFER_SIZE);
 }
@@ -48,101 +46,6 @@ SubmoduleDaisyPatchSm::SubmoduleDaisyPatchSm ()
 
 
 /*\\\ PRIVATE \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
-
-/*
-==============================================================================
-Name : enable_fz
-Description :
-   Enable FZ (flush-to-zero) denormal behavior
-==============================================================================
-*/
-
-void  SubmoduleDaisyPatchSm::enable_fz ()
-{
-   uint32_t fpscr = __get_FPSCR ();
-   fpscr |= 0x01000000; // FZ bit
-   __set_FPSCR (fpscr);
-}
-
-
-
-/*
-==============================================================================
-Name : init
-==============================================================================
-*/
-
-void  SubmoduleDaisyPatchSm::init ()
-{
-   init_system ();
-   init_sdram ();
-   init_qspi ();
-   init_audio ();
-}
-
-
-
-/*
-==============================================================================
-Name : init_system
-==============================================================================
-*/
-
-void  SubmoduleDaisyPatchSm::init_system ()
-{
-   daisy::System::Config config;
-
-   config.Defaults ();
-   _system.Init (config);
-}
-
-
-
-/*
-==============================================================================
-Name : init_sdram
-==============================================================================
-*/
-
-void  SubmoduleDaisyPatchSm::init_sdram ()
-{
-   _sdram.state = DSY_SDRAM_STATE_ENABLE;
-   _sdram.pin_config [DSY_SDRAM_PIN_SDNWE] = {DSY_GPIOH, 5};
-
-   dsy_sdram_init (&_sdram);
-}
-
-
-
-/*
-==============================================================================
-Name : init_qspi
-==============================================================================
-*/
-
-void  SubmoduleDaisyPatchSm::init_qspi ()
-{
-   erb_DISABLE_WARNINGS_DAISY
-
-   using namespace daisy;
-
-   _qspi.Init (QSPIHandle::Config {
-      .pin_config = {
-         .io0 = {DSY_GPIOF, 8},
-         .io1 = {DSY_GPIOF, 9},
-         .io2 = {DSY_GPIOF, 7},
-         .io3 = {DSY_GPIOF, 6},
-         .clk = {DSY_GPIOF, 10},
-         .ncs = {DSY_GPIOG, 6}
-      },
-      .device = QSPIHandle::Config::Device::IS25LP064A,
-      .mode = QSPIHandle::Config::Mode::MEMORY_MAPPED
-   });
-
-   erb_RESTORE_WARNINGS
-}
-
-
 
 /*
 ==============================================================================


### PR DESCRIPTION
This PR fixes a potential bug where the order of construction in the module main structure could lead to a crash, if the DSP is using SDRAM but the UI is constructed after.

This is because the board itself is constructed as part of the UI, so the DSP could want to allocate to SDRAM (which could write to SDRAM), when the SDRAM chip is not yet configured.

This PR fixes the problem by moving all Daisy platform related initialization sequence first into `main`, before the module structure is instantiated.

- Fixes #210 