### PR TITLE
Fix erbb lds

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -80,12 +80,17 @@ Name: configure_daisy
 def configure_daisy (name, path):
    path_artifacts = os.path.join (path, 'artifacts')
 
+   libdaisy_flash_lds_path = os.path.join (
+      PATH_ROOT, 'submodules', 'libDaisy', 'core', 'STM32H750IB_flash.lds'
+   )
+
    gyp_args = [
       '--depth=.',
       '--generator-output=%s' % path_artifacts,
       '--format', 'ninja-linux',
       '-D', 'OS=daisy',
       '-D', 'GYP_CROSSCOMPILE',
+      '-D', 'erbb_flash_lds=%s' % libdaisy_flash_lds_path,
    ]
 
    os.environ.update ({

--- a/samples/bypass/bypass.gyp
+++ b/samples/bypass/bypass.gyp
@@ -8,10 +8,6 @@
 
 
 {
-   'variables': {
-      'erbb_flash_lds': '../../../../../submodules/libDaisy/core/STM32H750IB_flash.lds',
-   },
-
    'includes': [
       '../../eurorack-blocks.gypi',
    ],

--- a/samples/drop/drop.gyp
+++ b/samples/drop/drop.gyp
@@ -8,10 +8,6 @@
 
 
 {
-   'variables': {
-      'erbb_flash_lds': '../../../../../submodules/libDaisy/core/STM32H750IB_flash.lds',
-   },
-
    'includes': [
       '../../eurorack-blocks.gypi',
    ],

--- a/samples/reverb/reverb.gyp
+++ b/samples/reverb/reverb.gyp
@@ -8,10 +8,6 @@
 
 
 {
-   'variables': {
-      'erbb_flash_lds': '../../../../../submodules/libDaisy/core/STM32H750IB_flash.lds',
-   },
-
    'includes': [
       '../../eurorack-blocks.gypi',
    ],

--- a/test/data/kivu12.gyp
+++ b/test/data/kivu12.gyp
@@ -8,10 +8,6 @@
 
 
 {
-   'variables': {
-      'erbb_flash_lds': '../../../../../submodules/libDaisy/core/STM32H750IB_flash.lds',
-   },
-
    'includes': [
       '../../eurorack-blocks.gypi',
    ],

--- a/test/field/field.gyp
+++ b/test/field/field.gyp
@@ -8,10 +8,6 @@
 
 
 {
-   'variables': {
-      'erbb_flash_lds': '../../../../../submodules/libDaisy/core/STM32H750IB_flash.lds',
-   },
-
    'includes': [
       '../../eurorack-blocks.gypi',
    ],

--- a/test/kivu12_adc/kivu12.gyp
+++ b/test/kivu12_adc/kivu12.gyp
@@ -8,10 +8,6 @@
 
 
 {
-   'variables': {
-      'erbb_flash_lds': '../../../../../submodules/libDaisy/core/STM32H750IB_flash.lds',
-   },
-
    'includes': [
       '../../eurorack-blocks.gypi',
    ],

--- a/test/kivu12_gi/kivu12.gyp
+++ b/test/kivu12_gi/kivu12.gyp
@@ -8,10 +8,6 @@
 
 
 {
-   'variables': {
-      'erbb_flash_lds': '../../../../../submodules/libDaisy/core/STM32H750IB_flash.lds',
-   },
-
    'includes': [
       '../../eurorack-blocks.gypi',
    ],

--- a/test/kivu12_go/kivu12.gyp
+++ b/test/kivu12_go/kivu12.gyp
@@ -8,10 +8,6 @@
 
 
 {
-   'variables': {
-      'erbb_flash_lds': '../../../../../submodules/libDaisy/core/STM32H750IB_flash.lds',
-   },
-
    'includes': [
       '../../eurorack-blocks.gypi',
    ],

--- a/test/micropatch/micropatch.gyp
+++ b/test/micropatch/micropatch.gyp
@@ -8,10 +8,6 @@
 
 
 {
-   'variables': {
-      'erbb_flash_lds': '../../../../../submodules/libDaisy/core/STM32H750IB_flash.lds',
-   },
-
    'includes': [
       '../../eurorack-blocks.gypi',
    ],

--- a/test/vcvrack/vcvrack.gyp
+++ b/test/vcvrack/vcvrack.gyp
@@ -8,10 +8,6 @@
 
 
 {
-   'variables': {
-      'erbb_flash_lds': '../../../../../submodules/libDaisy/core/STM32H750IB_flash.lds',
-   },
-
    'includes': [
       '../../eurorack-blocks.gypi',
    ],


### PR DESCRIPTION
This PR simplifies the `gyp` file setup by removing the obscure `erbb_flash_lds` global `gyp` variable.

- Solves #222 