### PR TITLE
Fix generate vcvrack paths

### DIFF
--- a/build-system/build-system.gyp
+++ b/build-system/build-system.gyp
@@ -20,7 +20,7 @@
 
             # erbb
             'erbb/__init__.py',
-            'erbb/generate_vcvrack.py',
+            'erbb/generate_vcvrack_template.py',
             'erbb/vscode/launch.json',
             'erbb/vscode/tasks.json',
 

--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -64,10 +64,28 @@ def configure_native (name, path):
          if 'BuildIndependentTargetsInParallel' in line:
             print ('\t\t\t\tLastUpgradeCheck = 1000;')
 
-   shutil.copyfile (
-      os.path.join (PATH_THIS, 'generate_vcvrack.py'),
-      os.path.join (path_artifacts, 'generate_vcvrack.py')
-   )
+   configure_native_vcvrack (path)
+
+
+
+"""
+==============================================================================
+Name: configure_native_vcvrack
+==============================================================================
+"""
+
+def configure_native_vcvrack (path):
+   path_artifacts = os.path.join (path, 'artifacts')
+   path_py = os.path.join (path_artifacts, 'generate_vcvrack.py')
+   path_template = os.path.join (PATH_THIS, 'generate_vcvrack_template.py')
+
+   with open (path_template, 'r') as file:
+      template = file.read ()
+
+   template = template.replace ('%PATH_ROOT%', PATH_ROOT)
+
+   with open (path_py, 'w') as file:
+      file.write (template)
 
 
 

--- a/build-system/erbb/generate_vcvrack_template.py
+++ b/build-system/erbb/generate_vcvrack_template.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-#     configure.py
+#     generate_vcvrack.py
 #     Copyright (c) 2020 Raphael Dinge
 #
 #Tab=3########################################################################
@@ -13,8 +13,7 @@ import os
 import subprocess
 import sys
 
-PATH_THIS = os.path.abspath (os.path.dirname (__file__))
-PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS))))
+PATH_ROOT = '%PATH_ROOT%'
 
 sys.path.insert (0, os.path.join (PATH_ROOT, 'build-system'))
 import erbui

--- a/include/erb/erb.gypi
+++ b/include/erb/erb.gypi
@@ -212,7 +212,7 @@
                      '<!(echo artifacts/plugin_vcvrack.cpp)',
                      '<!(echo artifacts/plugin.json)',
                   ],
-                  'action': [ 'python3', 'artifacts/generate_vcvrack.py', '<(RULE_INPUT_PATH)' ],
+                  'action': [ '<!(which python3)', 'artifacts/generate_vcvrack.py', '<(RULE_INPUT_PATH)' ],
                },
             ],
 
@@ -247,7 +247,7 @@
                {
                   'postbuild_name': 'Copy to VCV Rack plug-ins folder',
                   'action': [
-                     'python3', 'artifacts/deploy_vcvrack.py'
+                     '<!(which python3)', 'artifacts/deploy_vcvrack.py'
                   ],
                },
             ],


### PR DESCRIPTION
This PR fixes the paths in the generated vcvrack UI generator script.

The path to the build system (`erbb` and `erbui`) was hardcoded in to the generated script. This PR fixes that, by using an absolute path.

Additionally this PR fixes a problem where the IDE could provide its own version of `python3`, which is a problem as we might have specific required python modules (such as `soundfile` and `numpy`) which might not be accessible from the IDE provided Python environment. This was corrected by specifying explicitely which `python3` to use.

- Fixes #224 
