### PR TITLE
Add macos desktop services store files to git ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS generated files
+.DS_Store
+
 # Kicad temporary files
 # Format documentation: http://kicad-pcb.org/help/file-formats/
 


### PR DESCRIPTION
This PR makes git ignore `.DS_Store` macOS generated files.

- Resolves #228