### PR TITLE
Add guard clause for generated headers

### DIFF
--- a/build-system/erbui/generators/data/code_template.h
+++ b/build-system/erbui/generators/data/code_template.h
@@ -7,6 +7,10 @@
 
 
 
+#pragma once
+
+
+
 // !!! THIS FILE WAS AUTOMATICALLY GENERATED. DO NOT MODIFY !!!
 
 

--- a/build-system/erbui/generators/ui/code_template.h
+++ b/build-system/erbui/generators/ui/code_template.h
@@ -7,6 +7,10 @@
 
 
 
+#pragma once
+
+
+
 // !!! THIS FILE WAS AUTOMATICALLY GENERATED. DO NOT MODIFY !!!
 
 


### PR DESCRIPTION
This PR fixes a bug where generated headers didn't have a proper guard clause, to be able to include them multiple times.

- Fixes #231