### PR TITLE
Change audio sample type from planar to interleaved

### DIFF
--- a/build-system/erbui/generators/data/code.py
+++ b/build-system/erbui/generators/data/code.py
@@ -221,16 +221,14 @@ class Code:
          samples = file.read ()
          content = 'const erb::AudioSample <float, %d, %d> %sData::%s = {\n' % (file.frames, file.channels, module.name, data.name);
          content += '   .sample_rate = %f,\n' % file.samplerate;
-         content += '   .channels = {{\n';
+         content += '   .frames = {{\n';
+         content += '      ';
          if file.channels == 1:
-            content += '      {{';
-            content += ', '.join (map (lambda frame: float.hex(frame), samples))
-            content += '}},\n';
+            to_channels = lambda frame: '{' + float.hex (frame) + '}'
          else:
-            for c in range (file.channels):
-               content += '      {{';
-               content += ', '.join (map (lambda frame: float.hex(frame [c]), samples))
-               content += '}},\n';
+            to_channels = lambda frame: '{'+ ', '.join (map (lambda channel: float.hex (channel), frame)) + '}'
+         content += ', '.join (map (lambda frame: to_channels (frame), samples))
+         content += '\n';
          content += '   }}\n';
          content += '};\n'
 

--- a/include/erb/AudioSample.h
+++ b/include/erb/AudioSample.h
@@ -28,12 +28,12 @@ struct AudioSample
 {
    struct Channel
    {
-      std::array <float, Length> samples;
+      std::array <float, NbrChannels> channels;
    };
 
    float          sample_rate;
-   std::array <Channel, NbrChannels>
-                  channels;
+   std::array <Channel, Length>
+                  frames;
 };
 
 

--- a/test/data/Kivu12.cpp
+++ b/test/data/Kivu12.cpp
@@ -36,9 +36,9 @@ void  Kivu12::process ()
 #elif 1
    for (size_t i = 0 ; i < erb_BUFFER_SIZE ; ++i)
    {
-      ui.audio_out1 [i] = data.sample_stereo.channels [0].samples [pos];
-      ui.audio_out2 [i] = data.sample_stereo.channels [1].samples [pos];
-      pos = (pos + 1) % data.sample_mono.channels [0].samples.size ();
+      ui.audio_out1 [i] = data.sample_stereo.frames [pos].channels [0];
+      ui.audio_out2 [i] = data.sample_stereo.frames [pos].channels [1];
+      pos = (pos + 1) % data.sample_mono.frames.size ();
    }
 #endif
 }


### PR DESCRIPTION
This PR changes the `AudioSample` type has one length concept instead of two. Conceptually, planar description has 2 lengths for each channels. Having an interleaved channel description allows to have a main length concept rather as many as there are channels.