### PR TITLE
Add erbb xcode syntax highlighter to install script

### DIFF
--- a/build-system/xcode/README.md
+++ b/build-system/xcode/README.md
@@ -19,6 +19,8 @@ To install, run the `install.py` script.
 The script will copy the required files into your user Xcode folder:
 
 ```
+~/Library/Developer/Xcode/Plug-ins/Erbb.ideplugin
+~/Library/Developer/Xcode/Specifications/Erbb.xclangspec
 ~/Library/Developer/Xcode/Plug-ins/Erbui.ideplugin
 ~/Library/Developer/Xcode/Specifications/Erbui.xclangspec
 ```
@@ -36,7 +38,7 @@ Since some parts will modify your installation of Xcode, this is probably better
 - Copy `Erbb.xclangspec` and `Erbui.xclangspec` to `/Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageSpecifications`
 - Copy `Xcode.SourceCodeLanguage.Erbb.plist` and `Xcode.SourceCodeLanguage.Erbui.plist` to `/Applications/Xcode.app/Contents/SharedFrameworks/SourceModel.framework/Versions/A/Resources/LanguageMetadata`
 
-Using the command line (use `sudo` if permission are denied):
+Using the command line (use `sudo` if permissions are denied):
 
 ```
 cp -r Erbb.ideplugin ~/Library/Developer/Xcode/Plug-ins/

--- a/build-system/xcode/install.py
+++ b/build-system/xcode/install.py
@@ -30,6 +30,22 @@ if __name__ == '__main__':
    if not os.path.exists (PATH_XCODE_SPECS):
       os.makedirs (PATH_XCODE_SPECS)
 
+   print ('Copying Erbb.ideplugin')
+
+   shutil.rmtree (os.path.join (PATH_XCODE_PLUGINS, 'Erbb.ideplugin'), ignore_errors = True)
+
+   shutil.copytree (
+      os.path.join (PATH_THIS, 'Erbb.ideplugin'),
+      os.path.join (PATH_XCODE_PLUGINS, 'Erbb.ideplugin')
+   )
+
+   print ('Copying Erbb.xclangspec')
+
+   shutil.copyfile (
+      os.path.join (PATH_THIS, 'Erbb.xclangspec'),
+      os.path.join (PATH_XCODE_SPECS, 'Erbb.xclangspec')
+   )
+
    print ('Copying Erbui.ideplugin')
 
    shutil.rmtree (os.path.join (PATH_XCODE_PLUGINS, 'Erbui.ideplugin'), ignore_errors = True)


### PR DESCRIPTION
This PR adds the Xcode syntax highlighter Erbb `ideplugin` and `xclangspec` to the proper location.

> Note: this won't work on Xcode 11, but the README file contains already a workaround for that.