### PR TITLE
Add erbb init to github actions workflows

### DIFF
--- a/.github/workflows/macos_10_15.yml
+++ b/.github/workflows/macos_10_15.yml
@@ -69,6 +69,9 @@ jobs:
       - name: samples/reverb
         run: source ../../build-system/init.sh; erbb configure; erbb build; erbb build simulator
         working-directory: samples/reverb
+      - name: erbb init
+        run: source ../build-system/init.sh; mkdir init; cd init; erbb init Init; erbb configure; erbb build; erbb build simulator
+        working-directory: samples
 
   unit_tests:
     name: Unit Tests

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -73,6 +73,9 @@ jobs:
       - name: samples/reverb
         run: source ../../build-system/init.sh; erbb configure; erbb build; erbb build simulator
         working-directory: samples/reverb
+      - name: erbb init
+        run: source ../build-system/init.sh; mkdir init; cd init; erbb init Init; erbb configure; erbb build; erbb build simulator
+        working-directory: samples
 
   unit_tests:
     name: Unit Tests


### PR DESCRIPTION
This PR adds CI check for the project generated by a `erbb init` call.

- Resolves #253 