### PR TITLE
Build system pip requirements

### DIFF
--- a/.github/workflows/macos_10_15.yml
+++ b/.github/workflows/macos_10_15.yml
@@ -53,7 +53,7 @@ jobs:
       - run: brew install dfu-util  # using USB
       - run: brew install openocd   # using JTAG
 
-      - run: python3 -m pip install cairosvg cairocffi ezdxf soundfile numpy
+      - run: pip3 install -r requirements.txt
       - run: mkdir -p ~/Library/Fonts
       - run: cp include/erb/vcvrack/design/d-din/*.otf ~/Library/Fonts
       - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/Library/Fonts
@@ -97,7 +97,7 @@ jobs:
       - run: brew install cairo libffi
       - run: curl -O -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/bb55b3dfaa91b1f4ce9ea94c8251f04a71dced12/Casks/kicad.rb
       - run: brew install --cask kicad.rb
-      - run: python3 -m pip install cairosvg cairocffi ezdxf coverage soundfile numpy
+      - run: pip3 install -r requirements.txt
       - run: mkdir -p ~/Library/Fonts
       - run: cp include/erb/vcvrack/design/d-din/*.otf ~/Library/Fonts
       - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/Library/Fonts

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -55,7 +55,7 @@ jobs:
       - run: sudo apt install dfu-util  # using USB
       - run: sudo apt install openocd   # using JTAG
 
-      - run: python -m pip install cairosvg cairocffi ezdxf soundfile numpy
+      - run: pip3 install -r requirements.txt
       - run: mkdir -p ~/.local/share/fonts/
       - run: cp include/erb/vcvrack/design/d-din/*.otf ~/.local/share/fonts
       - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/.local/share/fonts
@@ -102,7 +102,7 @@ jobs:
       - run: sudo apt install libcairo2-dev libffi-dev python3-dev
       - run: sudo apt-get install kicad
       - run: sudo apt-get install libsndfile1
-      - run: python -m pip install cairosvg cairocffi ezdxf coverage soundfile numpy
+      - run: pip3 install -r requirements.txt
       - run: mkdir -p ~/.local/share/fonts/
       - run: cp include/erb/vcvrack/design/d-din/*.otf ~/.local/share/fonts
       - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/.local/share/fonts

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r requirements/build-system.txt

--- a/requirements/build-system.txt
+++ b/requirements/build-system.txt
@@ -1,0 +1,19 @@
+# Packages required to user erbb and erbui
+
+# SVG & PDF generation
+
+cairocffi
+cairosvg
+
+# DXF generation
+
+ezdxf
+
+# AudioSample generation
+
+soundfile
+numpy
+
+# Coverage
+
+coverage


### PR DESCRIPTION
This PR adds the `pip` requirements for `build-system` using the standard syntax:
```
pip install -r requirements.txt
```
