### PR TITLE
Pin kicad to 5.1.12

### DIFF
--- a/.github/workflows/macos_10_15.yml
+++ b/.github/workflows/macos_10_15.yml
@@ -12,7 +12,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: brew install --cask kicad
+      - run: curl -O -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/bb55b3dfaa91b1f4ce9ea94c8251f04a71dced12/Casks/kicad.rb
+      - run: brew install --cask kicad.rb
       - run: ./blocks/audio-in-daisy/build.py
       - run: ./blocks/audio-out-daisy/build.py
       - run: ./blocks/button/build.py
@@ -42,7 +43,8 @@ jobs:
       - run: brew install armmbed/formulae/arm-none-eabi-gcc
       - run: brew install ninja
       - run: brew install cairo libffi
-      - run: brew install --cask kicad
+      - run: curl -O -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/bb55b3dfaa91b1f4ce9ea94c8251f04a71dced12/Casks/kicad.rb
+      - run: brew install --cask kicad.rb
 
       # Install either dfu-util or openocd:
       # - dfu-util allows to upload firmware by connecting Daisy with a USB cable
@@ -93,7 +95,8 @@ jobs:
         with:
           submodules: recursive
       - run: brew install cairo libffi
-      - run: brew install --cask kicad
+      - run: curl -O -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/bb55b3dfaa91b1f4ce9ea94c8251f04a71dced12/Casks/kicad.rb
+      - run: brew install --cask kicad.rb
       - run: python3 -m pip install cairosvg cairocffi ezdxf coverage soundfile numpy
       - run: mkdir -p ~/Library/Fonts
       - run: cp include/erb/vcvrack/design/d-din/*.otf ~/Library/Fonts


### PR DESCRIPTION
This PR pins the version of KiCad to 5.1.12 to fix GitHub worflows build errors, as our code is not yet compatible with KiCad 6.
