### PR TITLE
Build system install script

### DIFF
--- a/.github/workflows/macos_10_15.yml
+++ b/.github/workflows/macos_10_15.yml
@@ -59,20 +59,26 @@ jobs:
       - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/Library/Fonts
       - run: python3 blocks/test/configure.py
       - run: python3 blocks/test/build.py
+      - run: python3 build-system/install.py
       - name: test/data
-        run: source ../../build-system/init.sh; erbb configure; erbb build
+        shell: bash -l {0} # Source profile
+        run: erbb configure; erbb build
         working-directory: test/data
       - name: samples/bypass
-        run: source ../../build-system/init.sh; erbb configure; erbb build; erbb build simulator
+        shell: bash -l {0}
+        run: erbb configure; erbb build; erbb build simulator
         working-directory: samples/bypass
       - name: samples/drop
-        run: source ../../build-system/init.sh; erbb configure; erbb build; erbb build simulator
+        shell: bash -l {0}
+        run: erbb configure; erbb build; erbb build simulator
         working-directory: samples/drop
       - name: samples/reverb
-        run: source ../../build-system/init.sh; erbb configure; erbb build; erbb build simulator
+        shell: bash -l {0}
+        run: erbb configure; erbb build; erbb build simulator
         working-directory: samples/reverb
       - name: erbb init
-        run: source ../build-system/init.sh; mkdir init; cd init; erbb init Init; erbb configure; erbb build; erbb build simulator
+        shell: bash -l {0}
+        run: mkdir init; cd init; erbb init Init; erbb configure; erbb build; erbb build simulator
         working-directory: samples
 
   unit_tests:

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -61,20 +61,26 @@ jobs:
       - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/.local/share/fonts
       - run: python blocks/test/configure.py
       - run: python blocks/test/build.py
+      - run: python build-system/install.py
       - name: test/data
-        run: source ../../build-system/init.sh; erbb configure; erbb build
+        shell: bash -l {0} # Source profile
+        run: erbb configure; erbb build
         working-directory: test/data
       - name: samples/bypass
-        run: source ../../build-system/init.sh; erbb configure; erbb build; erbb build simulator
+        shell: bash -l {0}
+        run: erbb configure; erbb build; erbb build simulator
         working-directory: samples/bypass
       - name: samples/drop
-        run: source ../../build-system/init.sh; erbb configure; erbb build; erbb build simulator
+        shell: bash -l {0}
+        run: erbb configure; erbb build; erbb build simulator
         working-directory: samples/drop
       - name: samples/reverb
-        run: source ../../build-system/init.sh; erbb configure; erbb build; erbb build simulator
+        shell: bash -l {0}
+        run: erbb configure; erbb build; erbb build simulator
         working-directory: samples/reverb
       - name: erbb init
-        run: source ../build-system/init.sh; mkdir init; cd init; erbb init Init; erbb configure; erbb build; erbb build simulator
+        shell: bash -l {0}
+        run: mkdir init; cd init; erbb init Init; erbb configure; erbb build; erbb build simulator
         working-directory: samples
 
   unit_tests:

--- a/build-system/install.py
+++ b/build-system/install.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+#
+#     install.py
+#     Copyright (c) 2020 Raphael DINGE
+#
+#Tab=3########################################################################
+
+
+##### IMPORT #################################################################
+
+from __future__ import print_function
+import os
+import platform
+import sys
+import subprocess
+
+PATH_THIS = os.path.abspath (os.path.dirname (__file__))
+
+
+
+##############################################################################
+
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
+   sys.exit (1)
+
+
+
+##############################################################################
+
+if __name__ == '__main__':
+   try:
+      init_path = os.path.join (PATH_THIS, 'init.sh')
+
+      if platform.system () == 'Darwin':
+         profile_path = '~/.bash_profile'
+
+      elif platform.system () == 'Linux':
+         profile_path = '~/.bash_profile'
+
+      else:
+         print ('Platform %s not supported' % platform.system ())
+         sys.exit (1)
+
+
+      # Add source init.sh to profile
+      subprocess.check_call ('echo "" >> %s' % profile_path, shell=True)
+      subprocess.check_call (
+         'echo "# Setting PATH for Eurorack-blocks/Erbb" >> %s' % profile_path,
+         shell=True
+      )
+      subprocess.check_call (
+         'echo "source %s" >> %s' % (init_path, profile_path),
+         shell=True
+      )
+
+   except subprocess.CalledProcessError as error:
+      print ('Configure command exited with %d' % error.returncode, file = sys.stderr)
+      sys.exit (1)


### PR DESCRIPTION
This PR adds the `build-system/install.py` script, which adds `script` to the `PATH`, to call the `erbb` script without having to enter its full path.