### PR TITLE
Sample stream modes

### DIFF
--- a/build-system/erbb/analyser.py
+++ b/build-system/erbb/analyser.py
@@ -76,3 +76,18 @@ class Analyser:
          raise error.missing_required (data, ast.File)
       elif nbr_files > 1:
          raise error.multiple_definition (data, files)
+
+      streams = [e for e in data.entities if e.is_stream]
+      nbr_streams = len (streams)
+
+      if nbr_streams == 1:
+         stream = streams [0]
+         if data.type_ != 'AudioSample':
+            err = error.Error ()
+            context = stream.source_context
+            err.add_error ("stream format in only available for AudioSample data type", context)
+            err.add_context (context)
+            raise err
+
+      elif nbr_streams > 1:
+         raise error.multiple_definition (data, streams)

--- a/build-system/erbb/ast.py
+++ b/build-system/erbb/ast.py
@@ -67,6 +67,9 @@ class Node:
    def is_data (self): return isinstance (self, Data)
 
    @property
+   def is_stream (self): return isinstance (self, Stream)
+
+   @property
    def is_base (self): return isinstance (self, Base)
 
 
@@ -431,3 +434,35 @@ class Data (Scope):
       entities = [e for e in self.entities if e.is_file]
       assert (len (entities) == 1)
       return entities [0]
+
+   @property
+   def stream (self):
+      entities = [e for e in self.entities if e.is_stream]
+      assert (len (entities) <= 1)
+      if entities:
+         return entities [0]
+      else:
+         return None
+
+
+
+# -- Stream ------------------------------------------------------------------
+
+class Stream (Node):
+   def __init__ (self, format):
+      assert isinstance (format, adapter.Keyword)
+      super (Stream, self).__init__ ()
+      self.format_keyword = format
+
+   @property
+   def format (self): return self.format_keyword.value
+
+   @property
+   def source_context (self):
+      return self.source_context_part ('format')
+
+   def source_context_part (self, part):
+      if part == 'format':
+         return adapter.SourceContext.from_token (self.format_keyword)
+
+      return super (Stream, self).source_context_part (part) # pragma: no cover

--- a/build-system/erbb/ast.py
+++ b/build-system/erbb/ast.py
@@ -411,7 +411,7 @@ class Data (Scope):
       self.type_identifier = type_identifier
 
    @staticmethod
-   def typename (): return 'module'
+   def typename (): return 'data'
 
    @property
    def name (self): return self.name_identifier.name

--- a/build-system/erbb/grammar.py
+++ b/build-system/erbb/grammar.py
@@ -13,7 +13,7 @@ from .arpeggio import Optional, ZeroOrMore, EOF, Combine, And
 KEYWORDS = (
    'module',
    'import', 'define', 'sources', 'resources', 'section',
-   'file', 'data', 'flash', 'qspi'
+   'file', 'data', 'flash', 'qspi', 'stream', 'mono', 'interleaved', 'planar'
 )
 
 SYMBOLS = (',', '{', '}', '=')
@@ -42,9 +42,13 @@ def sources_entities ():               return ZeroOrMore (file_declaration)
 def sources_body ():                   return '{', sources_entities, '}'
 def sources_declaration ():            return 'sources', sources_body
 
+# Stream
+def stream_format ():                  return ['mono', 'interleaved', 'planar']
+def stream_declaration ():             return 'stream', stream_format
+
 # Data
 
-def data_entities ():                  return ZeroOrMore (file_declaration)
+def data_entities ():                  return ZeroOrMore ([file_declaration, stream_declaration])
 def data_body ():                      return '{', data_entities, '}'
 def data_name ():                      return name
 def data_type ():                      return name

--- a/build-system/erbb/visitor.py
+++ b/build-system/erbb/visitor.py
@@ -163,6 +163,17 @@ class Visitor (PTNodeVisitor):
       return list (children)
 
 
+   #-- Stream ----------------------------------------------------------------
+
+   def visit_stream_declaration (self, node, children):
+      stream_format = children.stream_format [0]
+      stream = ast.Stream (stream_format)
+      return stream
+
+   def visit_stream_format (self, node, children):
+      return self.to_keyword (node)
+
+
    #-- Data ------------------------------------------------------------------
 
    def visit_data_declaration (self, node, children):

--- a/build-system/xcode/Erbb.xclangspec
+++ b/build-system/xcode/Erbb.xclangspec
@@ -14,6 +14,7 @@
             Words = (
                 "module", "import", "define", "sources", "file", "resources", "data",
                 "section", "flash", "qspi",
+                "stream", "mono", "interleaved", "planar",
             );
             Type = "xcode.syntax.keyword";
         };

--- a/documentation/erbb/grammar.md
+++ b/documentation/erbb/grammar.md
@@ -155,7 +155,8 @@ A `data` is an element of the module that represents a resource.
 > _data-declaration_ → **`data`** data-name data-type<sub>_opt_</sub> **`{`** data-entity<sub>_0+_</sub> **`}`** \
 > _data-name_ → [identifier](./lexical.md#identifiers) \
 > _data-type_ → [identifier](./lexical.md#identifiers) \
-> _data-entity_ → [file-declaration](#file)
+> _data-entity_ → [file-declaration](#file) \
+> _data-entity_ → [stream-declaration](#stream)
 
 ### Language Bindings
 
@@ -204,3 +205,29 @@ module Foo {
 ### Supported Types
 
 - **`AudioSample`**: Creates a `erb::AudioSample` value from an audio sample file.
+
+
+## `stream`
+
+A `stream` defines the representation of frames, channels and samples for an `AudioSample`
+`data` type. When not specified, mono audio samples are assumed `mono` and multi-channels
+audio samples are assumed `interleaved`, to maximize cache coherency and simplify
+processing using SIMD instructions.
+
+### Grammar
+
+> _stream-declaration_ → **`stream`** stream-format \
+> _stream-format_ → **`mono`** \
+> _stream-format_ → **`interleaved`** \
+> _stream-format_ → **`planar`**
+
+### Language Bindings
+
+The generated instance will have the types `AudioSampleMono`, `AudioSampleInterleaved`
+and `AudioSamplePlanar`.
+
+- `AudioSampleMono` stores the sample as a single array for floating point values,
+- `AudioSampleInterleaved` stores the sample as an array of frames, each frame
+   being an array of channels,
+- `AudioSamplePlanar` stores the sample as an array of channels, each channel
+   being an array of samples.

--- a/include/erb/AudioSample.h
+++ b/include/erb/AudioSample.h
@@ -24,16 +24,41 @@ namespace erb
 
 
 template <class T, size_t Length, size_t NbrChannels>
-struct AudioSample
+struct AudioSampleInterleaved
 {
-   struct Channel
+   struct Frame
    {
       std::array <float, NbrChannels> channels;
    };
 
    float          sample_rate;
-   std::array <Channel, Length>
+   std::array <Frame, Length>
                   frames;
+};
+
+
+
+template <class T, size_t Length, size_t NbrChannels>
+struct AudioSamplePlanar
+{
+   struct Channel
+   {
+      std::array <float, Length> samples;
+   };
+
+   float          sample_rate;
+   std::array <Channel, NbrChannels>
+                  channels;
+};
+
+
+
+template <class T, size_t Length>
+struct AudioSampleMono
+{
+   float          sample_rate;
+   std::array <float, Length>
+                  samples;
 };
 
 

--- a/samples/kick/VoiceBody.hpp
+++ b/samples/kick/VoiceBody.hpp
@@ -34,15 +34,15 @@ float VoiceBody::process (const T & sample)
    float mix = std::modf (_pos, &integral);
    size_t pos = size_t (_pos);
 
-   float ret_1 = sample.frames [pos].channels [0];
-   float ret_2 = sample.frames [pos + 1].channels [0];
+   float ret_1 = sample.samples [pos];
+   float ret_2 = sample.samples [pos + 1];
    float ret = ret_1 + (ret_2 - ret_1) * mix;
 
    float r = _ramp.process ();
    ret *= (3.f - 2.f * r) * r * r;
 
    _pos += _step_spl;
-   if (_pos + 2.f >= float (sample.frames.size ()))
+   if (_pos + 2.f >= float (sample.samples.size ()))
    {
       _active_flag = false;
    }

--- a/samples/kick/VoiceTransient.hpp
+++ b/samples/kick/VoiceTransient.hpp
@@ -34,12 +34,12 @@ float VoiceTransient::process (const T & sample_1, const T & sample_2, float mix
    float mix_pos = std::modf (_pos, &integral);
    size_t pos = size_t (_pos);
 
-   float ret_a1 = sample_1.frames [pos].channels [0];
-   float ret_a2 = sample_2.frames [pos].channels [0];
+   float ret_a1 = sample_1.samples [pos];
+   float ret_a2 = sample_2.samples [pos];
    float ret_a = ret_a1 + (ret_a2 - ret_a1) * mix;
 
-   float ret_b1 = sample_1.frames [pos + 1].channels [0];
-   float ret_b2 = sample_2.frames [pos + 1].channels [0];
+   float ret_b1 = sample_1.samples [pos + 1];
+   float ret_b2 = sample_2.samples [pos + 1];
    float ret_b = ret_b1 + (ret_b2 - ret_b1) * mix;
 
    float ret = ret_a + (ret_b - ret_a) * mix_pos;
@@ -48,7 +48,7 @@ float VoiceTransient::process (const T & sample_1, const T & sample_2, float mix
    ret *= (3.f - 2.f * r) * r * r;
 
    _pos += _step_spl;
-   if (_pos + 2.f >= float (sample_1.frames.size ()))
+   if (_pos + 2.f >= float (sample_1.samples.size ()))
    {
       _active_flag = false;
    }

--- a/samples/kick/VoicesTransient.cpp
+++ b/samples/kick/VoicesTransient.cpp
@@ -107,7 +107,7 @@ Name : get_sample
 ==============================================================================
 */
 
-const erb::AudioSample <float, 38400, 1> &   VoicesTransient::get_sample (size_t index)
+const erb::AudioSampleMono <float, 38400> &  VoicesTransient::get_sample (size_t index)
 {
    index = index % 18;
 

--- a/samples/kick/VoicesTransient.h
+++ b/samples/kick/VoicesTransient.h
@@ -35,7 +35,7 @@ public:
 
    float          process ();
 
-   const erb::AudioSample <float, 38400, 1> &
+   const erb::AudioSampleMono <float, 38400> &
                   get_sample (size_t index);
 
 

--- a/test/data/Kivu12.cpp
+++ b/test/data/Kivu12.cpp
@@ -23,22 +23,42 @@ Name : process
 
 void  Kivu12::process ()
 {
-#if 0
    for (size_t i = 0 ; i < erb_BUFFER_SIZE ; ++i)
    {
-      auto val = data.sample_mono.frames [pos].channels [0];
-      pos = (pos + 1) % data.sample_mono.frames.size ();
+      auto val = data.sample_mono.samples [pos];
+      pos = (pos + 1) % data.sample_mono.samples.size ();
 
       ui.audio_out1 [i] = val;
       ui.audio_out2 [i] = val;
    }
 
-#elif 1
    for (size_t i = 0 ; i < erb_BUFFER_SIZE ; ++i)
    {
       ui.audio_out1 [i] = data.sample_stereo.frames [pos].channels [0];
       ui.audio_out2 [i] = data.sample_stereo.frames [pos].channels [1];
       pos = (pos + 1) % data.sample_stereo.frames.size ();
    }
-#endif
+
+   for (size_t i = 0 ; i < erb_BUFFER_SIZE ; ++i)
+   {
+      auto val = data.sample_mono_mono.samples [pos];
+      pos = (pos + 1) % data.sample_mono_mono.samples.size ();
+
+      ui.audio_out1 [i] = val;
+      ui.audio_out2 [i] = val;
+   }
+
+   for (size_t i = 0 ; i < erb_BUFFER_SIZE ; ++i)
+   {
+      ui.audio_out1 [i] = data.sample_stereo_interleaved.frames [pos].channels [0];
+      ui.audio_out2 [i] = data.sample_stereo_interleaved.frames [pos].channels [1];
+      pos = (pos + 1) % data.sample_stereo_interleaved.frames.size ();
+   }
+
+   for (size_t i = 0 ; i < erb_BUFFER_SIZE ; ++i)
+   {
+      ui.audio_out1 [i] = data.sample_stereo_planar.channels [0].samples [pos];
+      ui.audio_out2 [i] = data.sample_stereo_planar.channels [1].samples [pos];
+      pos = (pos + 1) % data.sample_stereo_planar.channels [0].samples.size ();
+   }
 }

--- a/test/data/Kivu12.erbb
+++ b/test/data/Kivu12.erbb
@@ -18,5 +18,9 @@ module Kivu12 {
       data raw { file "raw.bin" }
       data sample_mono AudioSample { file "mono.wav" }
       data sample_stereo AudioSample { file "stereo.wav" }
+
+      data sample_mono_mono AudioSample { file "mono.wav" stream mono }
+      data sample_stereo_interleaved AudioSample { file "stereo.wav" stream interleaved }
+      data sample_stereo_planar AudioSample { file "stereo.wav" stream planar }
    }
 }


### PR DESCRIPTION
This PR adds different representations of sample's streams, on top of our interleaved one:
- Mono
- Planar

This PR is preparation work for the FAUST Integration #260 as FAUST supports only planar stream representations natively for now.