### PR TITLE
Prevent dfu-util exception raising for non-errors

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -456,7 +456,7 @@ def deploy_dfu_util (name, section, file_bin):
       '-d', '0483:df11',
    ]
 
-   subprocess.check_call (cmd)
+   subprocess.call (cmd)
 
    print ('OK.')
 


### PR DESCRIPTION
This PR ignores all the errors returned by DFU, in particular this one:

```
File downloaded successfully
Error during download get_status
Error 74
```

This problem is discussed [here](https://forum.electro-smith.com/t/make-program-dfu-error/1063).