### PR TITLE
Detect and regenerate ui and main when erbui file changes

### DIFF
--- a/build-system/build-system.gyp
+++ b/build-system/build-system.gyp
@@ -25,6 +25,7 @@
             'erbb/analyser.py',
             'erbb/ast.py',
             'erbb/error.py',
+            'erbb/generate_daisy_template.py',
             'erbb/generate_vcvrack_template.py',
             'erbb/grammar.py',
             'erbb/parser.py',

--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -201,6 +201,17 @@ def configure_daisy (path):
    gyp.main (gyp_args + ['project_daisy.gyp'])
    os.chdir (cwd)
 
+   path_py = os.path.join (path_artifacts, 'generate_daisy.py')
+   path_template = os.path.join (PATH_THIS, 'generate_daisy_template.py')
+
+   with open (path_template, 'r') as file:
+      template = file.read ()
+
+   template = template.replace ('%PATH_ROOT%', PATH_ROOT)
+
+   with open (path_py, 'w') as file:
+      file.write (template)
+
 
 
 """

--- a/build-system/erbb/generate_daisy_template.py
+++ b/build-system/erbb/generate_daisy_template.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+#
+#     generate_daisy.py
+#     Copyright (c) 2020 Raphael Dinge
+#
+#Tab=3########################################################################
+
+
+##### IMPORT #################################################################
+
+from __future__ import print_function
+import os
+import subprocess
+import sys
+
+PATH_ROOT = '%PATH_ROOT%'
+
+sys.path.insert (0, os.path.join (PATH_ROOT, 'build-system'))
+import erbui
+
+
+
+##############################################################################
+
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
+   sys.exit (1)
+
+
+
+##############################################################################
+
+if __name__ == '__main__':
+   try:
+      filepath = sys.argv [1]
+      output_path = os.path.abspath (os.path.join (os.path.dirname (filepath), 'artifacts'))
+
+      ast = erbui.parse (filepath)
+      erbui.generate_ui (output_path, ast)
+      erbui.generate_daisy (output_path, ast)
+
+   except subprocess.CalledProcessError as error:
+      print ('Configure command exited with %d' % error.returncode, file = sys.stderr)
+      sys.exit (1)

--- a/include/erb/erb-daisy.gypi
+++ b/include/erb/erb-daisy.gypi
@@ -58,4 +58,15 @@
    'export_dependent_settings': [
       'libdaisy',
    ],
+
+   'rules': [
+      {
+         'rule_name': 'Transpile Erbui',
+         'extension': 'erbui',
+         'outputs': [
+            '<!(echo artifacts/main_daisy.cpp)',
+         ],
+         'action': [ '<!(which python3)', 'artifacts/generate_daisy.py', '<(RULE_INPUT_PATH)' ],
+      },
+   ],
 }


### PR DESCRIPTION
This PR fixes a bug when the `erbui` file is changed and a `erbb build` command is issued after.

For the simulator, we regenerate the board support file correctly (that is `plugin_vcvrack.cpp`), but we don't regenerate it for the daisy target (that is `main_daisy.cpp`).
