### PR TITLE
Use ninja for build on linux

### DIFF
--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -88,6 +88,7 @@ jobs:
         with:
           submodules: recursive
       - run: sudo apt-get update
+      - run: sudo apt-get install -y ninja-build
       - run: sudo apt-get install libglu1-mesa-dev
       - run: sudo apt install libcairo2-dev libffi-dev python3-dev
       - run: sudo apt-get install kicad

--- a/blocks/test/build.py
+++ b/blocks/test/build.py
@@ -33,8 +33,8 @@ if sys.version_info < (3, 7):
 
 if __name__ == '__main__':
    try:
-      erbb.build ('test', PATH_THIS, 'Debug')
-      erbb.build ('test', PATH_THIS, 'Release')
+      erbb.build_daisy_all (PATH_THIS, 'Debug')
+      erbb.build_daisy_all (PATH_THIS, 'Release')
 
       targets = [
          'audio-in-daisy',

--- a/blocks/test/configure.py
+++ b/blocks/test/configure.py
@@ -70,7 +70,7 @@ def configure_daisy (name, path):
 
    gyp_args = [
       '--depth=.',
-      '--generator-output=%s' % path_artifacts,
+      '--generator-output=%s/daisy' % path_artifacts,
       '--format', 'ninja-linux',
       '-D', 'OS=daisy',
       '-D', 'GYP_CROSSCOMPILE',

--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -127,10 +127,17 @@ Name: configure_vcvrack
 def configure_vcvrack (path):
    path_artifacts = os.path.join (path, 'artifacts')
 
-   gyp_args = [
-      '--depth=.',
-      '--generator-output=%s' % path_artifacts,
-   ]
+   if platform.system () == 'Linux':
+      gyp_args = [
+         '--depth=.',
+         '--generator-output=%s/simulator' % path_artifacts,
+         '--format', 'ninja'
+      ]
+   elif platform.system () == 'Darwin':
+      gyp_args = [
+         '--depth=.',
+         '--generator-output=%s' % path_artifacts,
+      ]
 
    cwd = os.getcwd ()
    os.chdir (path)
@@ -184,7 +191,7 @@ def configure_daisy (path):
 
    gyp_args = [
       '--depth=.',
-      '--generator-output=%s' % path_artifacts,
+      '--generator-output=%s/daisy' % path_artifacts,
       '--format', 'ninja-linux',
       '-D', 'OS=daisy',
       '-D', 'GYP_CROSSCOMPILE',
@@ -284,16 +291,16 @@ def cleanup (path):
 
 """
 ==============================================================================
-Name : build
+Name : build_daisy_all
 ==============================================================================
 """
 
-def build (name, path, configuration):
+def build_daisy_all (path, configuration):
    path_artifacts = os.path.join (path, 'artifacts')
 
    cmd = [
       'ninja',
-      '-C', os.path.join (path_artifacts, 'out', configuration),
+      '-C', os.path.join (path_artifacts, 'daisy', 'out', configuration),
    ]
 
    subprocess.check_call (cmd)
@@ -306,12 +313,12 @@ Name : build_daisy_target
 ==============================================================================
 """
 
-def build_target (target, path, configuration):
+def build_daisy_target (target, path, configuration):
    path_artifacts = os.path.join (path, 'artifacts')
 
    cmd = [
       'ninja',
-      '-C', os.path.join (path_artifacts, 'out', configuration),
+      '-C', os.path.join (path_artifacts, 'daisy', 'out', configuration),
       target
    ]
 
@@ -321,11 +328,11 @@ def build_target (target, path, configuration):
 
 """
 ==============================================================================
-Name : build_native_target
+Name : build_simulator_target
 ==============================================================================
 """
 
-def build_native_target (target, path, configuration):
+def build_simulator_target (target, path, configuration):
    path_artifacts = os.path.join (path, 'artifacts')
 
    if platform.system () == 'Darwin':
@@ -354,10 +361,8 @@ def build_native_target (target, path, configuration):
 
    elif platform.system () == 'Linux':
       cmd = [
-         'make',
-         '-k',
-         '-C', path_artifacts,
-         '-j', '%d' % multiprocessing.cpu_count (),
+         'ninja',
+         '-C', os.path.join (path_artifacts, 'simulator', 'out', configuration),
          target
       ]
 
@@ -376,8 +381,8 @@ def objcopy (name, path, configuration):
 
    print ('OBJCOPY %s' % name)
 
-   file_elf = os.path.join (path_artifacts, 'out', configuration, name)
-   file_bin = os.path.join (path_artifacts, 'out', configuration, '%s.bin' % name)
+   file_elf = os.path.join (path_artifacts, 'daisy', 'out', configuration, name)
+   file_bin = os.path.join (path_artifacts, 'daisy', 'out', configuration, '%s.bin' % name)
 
    shutil.copyfile (file_elf, file_bin)
 
@@ -406,10 +411,10 @@ def deploy (name, section, path, configuration, force_dfu_util=False):
          print ('Please use option \'dfu\' instead.')
          sys.exit ()
 
-      file_elf = os.path.join (path_artifacts, 'out', configuration, '%s' % name)
+      file_elf = os.path.join (path_artifacts, 'daisy', 'out', configuration, '%s' % name)
       deploy_openocd (name, file_elf)
    else:
-      file_bin = os.path.join (path_artifacts, 'out', configuration, '%s.bin' % name)
+      file_bin = os.path.join (path_artifacts, 'daisy', 'out', configuration, '%s.bin' % name)
       deploy_dfu_util (name, section, file_bin)
 
 

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -250,12 +250,13 @@ def build ():
 
       ast_erbb = read_erbb_ast (find_erbb ())
       module = ast_erbb.modules [0].name
-      erbb.build_target (module, cwd, configuration)
+      erbb.build_daisy_target (module, cwd, configuration)
       erbb.objcopy (module, cwd, configuration)
+
    elif target == 'simulator':
       ast_erbb = read_erbb_ast (find_erbb ())
       module = ast_erbb.modules [0].name
-      erbb.build_native_target (module, cwd, configuration)
+      erbb.build_simulator_target (module, cwd, configuration)
    else:
       print ("Error: Unknown target %s\n" % target)
       usage ()

--- a/eurorack-blocks.gypi
+++ b/eurorack-blocks.gypi
@@ -33,6 +33,12 @@
          ],
       }],
 
+      ['OS=="linux"', {
+         'includes': [
+            './include/erb/linux.gypi',
+         ],
+      }],
+
       ['OS=="daisy"', {
          'includes': [
             './include/erb/daisy.gypi',

--- a/include/erb/Led.hpp
+++ b/include/erb/Led.hpp
@@ -185,8 +185,37 @@ Name : impl_postprocess
 ==============================================================================
 */
 
-template <PinType Pin>
-void  Led <Pin>::impl_postprocess ()
+template <>
+inline void Led <PinType::Gpio>::impl_postprocess ()
+{
+   float val = float (_animation.get (_clock_ms)) * _brightness;
+   impl_data = val > 0.f;
+}
+
+
+
+/*
+==============================================================================
+Name : impl_postprocess
+==============================================================================
+*/
+
+template <>
+inline void Led <PinType::Dac>::impl_postprocess ()
+{
+   impl_data = static_cast <KeyframeTargetType> (_animation.get (_clock_ms) * _brightness);
+}
+
+
+
+/*
+==============================================================================
+Name : impl_postprocess
+==============================================================================
+*/
+
+template <>
+inline void Led <PinType::Pwm>::impl_postprocess ()
 {
    impl_data = static_cast <KeyframeTargetType> (_animation.get (_clock_ms) * _brightness);
 }

--- a/include/erb/def.h
+++ b/include/erb/def.h
@@ -71,7 +71,9 @@
       _Pragma ("GCC diagnostic ignored \"-Wunused-parameter\"") \
 
    #define erb_DISABLE_WARNINGS_VCVRACK \
-      _Pragma ("GCC diagnostic push")
+      _Pragma ("GCC diagnostic push") \
+      _Pragma ("GCC diagnostic ignored \"-Wpedantic\"") \
+      _Pragma ("GCC diagnostic ignored \"-Wunused-parameter\"") \
 
    #define erb_DISABLE_WARNINGS_GLOBAL_CTOR \
       _Pragma ("GCC diagnostic push")

--- a/include/erb/linux.gypi
+++ b/include/erb/linux.gypi
@@ -1,0 +1,59 @@
+##############################################################################
+#
+#     linux.gypi
+#     Copyright (c) 2014 Raphael DINGE
+#
+#Tab=3########################################################################
+
+
+
+{
+   'target_defaults': {
+      'configurations':
+      {
+         'Debug':
+         {
+            'defines': [
+               'DEBUG=1',
+            ],
+
+            'cflags':
+            [
+               '-O0',
+               '-g',
+            ],
+         },
+
+         'Release':
+         {
+            'defines': [
+               'NDEBUG=1',
+               'RELEASE=1',
+            ],
+
+            'cflags':
+            [
+               '-O3',
+            ],
+         },
+      },
+
+      'cflags': [
+         '-fPIC',
+         '-g',
+
+         '-Wall',
+         '-Wextra',
+         '-Wpedantic',
+         '-Werror',
+      ],
+
+      'cflags_c': [
+         '-std=gnu11',
+      ],
+
+      'cflags_cc': [
+         '-std=gnu++2a',
+      ],
+   },
+}

--- a/test/vcvrack/build.py
+++ b/test/vcvrack/build.py
@@ -34,7 +34,7 @@ if sys.version_info < (3, 7):
 
 if __name__ == '__main__':
    try:
-      erbb.build_native_target ('VcvRack', PATH_THIS, 'Release')
+      erbb.build_simulator_target ('VcvRack', PATH_THIS, 'Release')
 
    except subprocess.CalledProcessError as error:
       print ('Build command exited with %d' % error.returncode, file = sys.stderr)


### PR DESCRIPTION
This PR makes erbb simulator builds to use ninja on Linux.

This PR is preparation work for the refactor, as proper graph dependencies involving actions seems to be broken for the `make` format.
