### PR TITLE
Action objcopy

### DIFF
--- a/blocks/test/build.py
+++ b/blocks/test/build.py
@@ -51,10 +51,6 @@ if __name__ == '__main__':
          'switch',
       ]
 
-      for target in targets:
-         erbb.objcopy (target, PATH_THIS, 'Debug')
-         erbb.objcopy (target, PATH_THIS, 'Release')
-
    except subprocess.CalledProcessError as error:
       print ('Build command exited with %d' % error.returncode, file = sys.stderr)
       sys.exit (1)

--- a/build-system/build-system.gyp
+++ b/build-system/build-system.gyp
@@ -36,6 +36,7 @@
             # generators/action
             'erbb/generators/action/action_daisy_template.py',
             'erbb/generators/action/action_data_template.py',
+            'erbb/generators/action/action_objcopy_template.py',
             'erbb/generators/action/action_ui_template.py',
             'erbb/generators/action/action_vcvrack_template.py',
             'erbb/generators/action/action.py',

--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -129,7 +129,7 @@ Name: configure
 
 def configure (path, ast):
    configure_vcvrack (path)
-   configure_daisy (path)
+   configure_daisy (path, ast)
    configure_vscode (path, ast)
 
 
@@ -179,7 +179,7 @@ Name: configure_daisy
 ==============================================================================
 """
 
-def configure_daisy (path):
+def configure_daisy (path, ast):
    path_artifacts = os.path.join (path, 'artifacts')
 
    gyp_args = [
@@ -200,6 +200,22 @@ def configure_daisy (path):
    os.chdir (path)
    gyp.main (gyp_args + ['project_daisy.gyp'])
    os.chdir (cwd)
+
+   module_name = ast.modules [0].name
+   cmd = [
+      'touch',
+      os.path.join (path_artifacts, 'daisy', 'out', 'Release', module_name)
+   ]
+
+   subprocess.check_call (cmd)
+
+   cmd = [
+      'touch',
+      os.path.join (path_artifacts, 'daisy', 'out', 'Debug', module_name)
+   ]
+
+   subprocess.check_call (cmd)
+
 
 
 

--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -340,32 +340,6 @@ def build_simulator_target (target, path, configuration):
 
 """
 ==============================================================================
-Name : objcopy
-==============================================================================
-"""
-
-def objcopy (name, path, configuration):
-   path_artifacts = os.path.join (path, 'artifacts')
-
-   print ('OBJCOPY %s' % name)
-
-   file_elf = os.path.join (path_artifacts, 'daisy', 'out', configuration, name)
-   file_bin = os.path.join (path_artifacts, 'daisy', 'out', configuration, '%s.bin' % name)
-
-   shutil.copyfile (file_elf, file_bin)
-
-   cmd = [
-      'arm-none-eabi-objcopy',
-      '-O', 'binary',
-      '-S', file_bin,
-   ]
-
-   subprocess.check_call (cmd)
-
-
-
-"""
-==============================================================================
 Name : deploy
 ==============================================================================
 """

--- a/build-system/erbb/generators/action/action.py
+++ b/build-system/erbb/generators/action/action.py
@@ -33,6 +33,7 @@ class Action:
       self.generate_module_action (path, module, 'ui')
       self.generate_module_action (path, module, 'vcvrack')
       self.generate_module_action (path, module, 'data')
+      self.generate_module_action (path, module, 'objcopy')
 
 
 

--- a/build-system/erbb/generators/action/action_objcopy_template.py
+++ b/build-system/erbb/generators/action/action_objcopy_template.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+#
+#     postbuild_objcopy.py
+#     Copyright (c) 2020 Raphael Dinge
+#
+#Tab=3########################################################################
+
+
+##### IMPORT #################################################################
+
+from __future__ import print_function
+import os
+import shutil
+import subprocess
+import sys
+
+PATH_ROOT = '%PATH_ROOT%'
+
+sys.path.insert (0, os.path.join (PATH_ROOT, 'build-system'))
+import erbb
+
+
+
+##############################################################################
+
+if sys.version_info < (3, 7):
+   print ('This script requires python 3.7 or greater.', file = sys.stderr)
+   sys.exit (1)
+
+
+
+##############################################################################
+
+def find_erbb ():
+   files = os.listdir (os.getcwd ())
+   for file in files:
+      if file.endswith ('.erbb'):
+         return file
+
+   return None
+
+if __name__ == '__main__':
+   try:
+      project_path = os.path.abspath (os.getcwd ())
+      product_dir = sys.argv [1]
+      module_name = sys.argv [2]
+
+      file_elf = os.path.join (project_path, product_dir, module_name)
+      file_bin = os.path.join (project_path, product_dir, '%s.bin' % module_name)
+
+      shutil.copyfile (file_elf, file_bin)
+      cmd = [
+         'arm-none-eabi-objcopy',
+         '-O', 'binary',
+         '-S', file_bin,
+      ]
+
+      subprocess.check_call (cmd)
+
+   except subprocess.CalledProcessError as error:
+      print ('Action exited with %d' % error.returncode, file = sys.stderr)
+      sys.exit (1)

--- a/build-system/erbb/generators/action/action_objcopy_template.py
+++ b/build-system/erbb/generators/action/action_objcopy_template.py
@@ -48,6 +48,9 @@ if __name__ == '__main__':
       file_elf = os.path.join (project_path, product_dir, module_name)
       file_bin = os.path.join (project_path, product_dir, '%s.bin' % module_name)
 
+      if os.stat (file_elf).st_size == 0:
+         sys.exit (0)
+
       shutil.copyfile (file_elf, file_bin)
       cmd = [
          'arm-none-eabi-objcopy',

--- a/build-system/erbb/generators/daisy/project.py
+++ b/build-system/erbb/generators/daisy/project.py
@@ -169,4 +169,15 @@ class Project:
          lines += '               \'action\': [ \'<!(which python3)\', \'artifacts/action_data.py\' ],\n'
          lines += '            },\n'
 
+      lines += '            {\n'
+      lines += '               \'action_name\': \'Objcopy\',\n'
+      lines += '               \'inputs\': [\n'
+      lines += '                  \'artifacts/daisy/out/Release/%s\',\n' % module.name
+      lines += '               ],\n'
+      lines += '               \'outputs\': [\n'
+      lines += '                  \'artifacts/daisy/out/Release/%s.bin)\',\n' % module.name
+      lines += '               ],\n'
+      lines += '               \'action\': [ \'<!(which python3)\', \'artifacts/action_objcopy.py\', \'<(PRODUCT_DIR)\', \'%s\' ],\n' % module.name
+      lines += '            },\n'
+
       return template.replace ('%           target_actions%', lines)

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -246,7 +246,6 @@ def build ():
       ast_erbb = read_erbb_ast (find_erbb ())
       module = ast_erbb.modules [0].name
       erbb.build_daisy_target (module, cwd, configuration)
-      erbb.objcopy (module, cwd, configuration)
 
    elif target == 'simulator':
       ast_erbb = read_erbb_ast (find_erbb ())


### PR DESCRIPTION
This PR makes the `objcopy` step an action rather than something done as a post-build step.

This is preparation work for the upcoming integrations, to make sure that all the build steps can be reported to the user.
