### PR TITLE
Erbb build hardware

### DIFF
--- a/.github/workflows/macos_10_15.yml
+++ b/.github/workflows/macos_10_15.yml
@@ -51,19 +51,19 @@ jobs:
         run: erbb configure; erbb build
         working-directory: test/data
       - name: samples/bypass
-        run: erbb configure; erbb build; erbb build simulator
+        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
         working-directory: samples/bypass
       - name: samples/drop
-        run: erbb configure; erbb build; erbb build simulator
+        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
         working-directory: samples/drop
       - name: samples/reverb
-        run: erbb configure; erbb build; erbb build simulator
+        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
         working-directory: samples/reverb
       - name: samples/kick
-        run: erbb configure; erbb build; erbb build simulator
+        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
         working-directory: samples/kick
       - name: erbb init
-        run: mkdir init; cd init; erbb init Init; erbb configure; erbb build; erbb build simulator
+        run: mkdir init; cd init; erbb init Init; erbb configure; erbb build; erbb build hardware; erbb build simulator
         working-directory: samples
 
   unit_tests:

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -49,22 +49,22 @@ jobs:
       - run: python blocks/test/build.py
       - run: python build-system/install.py
       - name: test/data
-        run: erbb configure; erbb build
+        run: erbb configure; erbb build; erbb build hardware
         working-directory: test/data
       - name: samples/bypass
-        run: erbb configure; erbb build; erbb build simulator
+        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
         working-directory: samples/bypass
       - name: samples/drop
-        run: erbb configure; erbb build; erbb build simulator
+        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
         working-directory: samples/drop
       - name: samples/reverb
-        run: erbb configure; erbb build; erbb build simulator
+        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
         working-directory: samples/reverb
       - name: samples/kick
-        run: erbb configure; erbb build; erbb build simulator
+        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
         working-directory: samples/kick
       - name: erbb init
-        run: mkdir init; cd init; erbb init Init; erbb configure; erbb build; erbb build simulator
+        run: mkdir init; cd init; erbb init Init; erbb configure; erbb build; erbb build hardware; erbb build simulator
         working-directory: samples
 
   unit_tests:

--- a/build-system/erbui/__init__.py
+++ b/build-system/erbui/__init__.py
@@ -142,8 +142,11 @@ Name: generate_front_panel
 """
 
 def generate_front_panel (path, ast):
-   generate_front_panel_milling (path, ast)
-   generate_front_panel_printing (path, ast)
+   path_hardware = os.path.join (path, 'hardware')
+   if not os.path.exists (path_hardware):
+      os.makedirs (path_hardware)
+   generate_front_panel_milling (path_hardware, ast)
+   generate_front_panel_printing (path_hardware, ast)
 
 
 
@@ -178,7 +181,10 @@ Name: generate_front_pcb
 """
 
 def generate_front_pcb (path, ast):
-   generate_front_pcb_kicad_pcb (path, ast)
+   path_hardware = os.path.join (path, 'hardware')
+   if not os.path.exists (path_hardware):
+      os.makedirs (path_hardware)
+   generate_front_pcb_kicad_pcb (path_hardware, ast)
 
 
 

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -127,6 +127,7 @@ def usage ():
    print ('build [<target> [<configuration>]]')
    print ('   target:')
    print ('      daisy        Daisy firmware (default)')
+   print ('      hardware     Front panel hardware files')
    print ('      simulator    Simulator plug-in module')
    print ('   configuration:')
    print ('      debug        Debug configuration')
@@ -238,15 +239,16 @@ def build ():
       sys.exit (1)
 
    if target == 'daisy':
-      ast_erbui = read_erbui_ast (find_erbui ())
-      path_artifacts = os.path.join (cwd, 'artifacts')
-      erbui.generate_front_panel (path_artifacts, ast_erbui)
-      erbui.generate_front_pcb (path_artifacts, ast_erbui)
-
       ast_erbb = read_erbb_ast (find_erbb ())
       module = ast_erbb.modules [0].name
       erbb.build_daisy_target (module, cwd, configuration)
       erbb.objcopy (module, cwd, configuration)
+
+   elif target == 'hardware':
+      ast_erbui = read_erbui_ast (find_erbui ())
+      path_artifacts = os.path.join (cwd, 'artifacts')
+      erbui.generate_front_panel (path_artifacts, ast_erbui)
+      erbui.generate_front_pcb (path_artifacts, ast_erbui)
 
    elif target == 'simulator':
       ast_erbb = read_erbb_ast (find_erbb ())


### PR DESCRIPTION
This PR separates the `erbb build` for `daisy` and `hardware`.
It also creates a `hardware` folder to keep the `artifacts` folder clean and reduce noise.
