### PR TITLE
Erbb auto ansi color

### DIFF
--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -101,7 +101,7 @@ def read_erbui_ast (filepath):
    with file:
       try:
          ast = erbui.parse (filepath)
-      except erbb.error.Error as error:
+      except erbui.error.Error as error:
          if hasattr (sys.stderr, "isatty") and sys.stderr.isatty ():
             error.color ()
          print (str (error), file=sys.stderr)

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -74,8 +74,9 @@ def read_erbb_ast (filepath):
       try:
          ast = erbb.parse (filepath)
       except erbb.error.Error as error:
-         error.color ()
-         print ("%s" % str (error))
+         if hasattr (sys.stderr, "isatty") and sys.stderr.isatty ():
+            error.color ()
+         print (str (error), file=sys.stderr)
          sys.exit (1)
 
    return ast
@@ -101,8 +102,9 @@ def read_erbui_ast (filepath):
       try:
          ast = erbui.parse (filepath)
       except erbb.error.Error as error:
-         error.color ()
-         print ("%s" % str (error))
+         if hasattr (sys.stderr, "isatty") and sys.stderr.isatty ():
+            error.color ()
+         print (str (error), file=sys.stderr)
          sys.exit (1)
 
    return ast
@@ -348,13 +350,15 @@ def main ():
                sys.exit (1)
 
          except erbb.error.Error as error:
-            error.color ()
-            print (str (error))
+            if hasattr (sys.stderr, "isatty") and sys.stderr.isatty ():
+               error.color ()
+            print (str (error), file=sys.stderr)
             sys.exit (1)
 
          except erbui.error.Error as error:
-            error.color ()
-            print (str (error))
+            if hasattr (sys.stderr, "isatty") and sys.stderr.isatty ():
+               error.color ()
+            print (str (error), file=sys.stderr)
             sys.exit (1)
 
 


### PR DESCRIPTION
This PR makes the `erbb` script use color for reports, if and only if the underlying console supports ANSI escape codes (and in particular color sequences).

This PR is preparation work for integrations in the case where ANSI escape codes are not supported.