### PR TITLE
Stop xcodebuild on first error to minimize noise during error reporting

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -322,6 +322,7 @@ def build_simulator_target (target, path, configuration):
          '-configuration', configuration,
          '-target', target,
          '-parallelizeTargets',
+         '-PBXBuildsContinueAfterErrors=NO',
          'SYMROOT=%s' % os.path.join (path_artifacts, 'build')
       ]
 


### PR DESCRIPTION
This PR stops on the first error for the simulator build on Xcode, to prevent noise, in particular for script execution phases, for which the build system does not know that the build should be stopped here.

This PR is preparation work for integrations, where consoles are generally not an ideal way to look for errors.
