### PR TITLE
Quiet xcodebuild to report only errors and warnings to minimize noise

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -318,6 +318,7 @@ def build_simulator_target (target, path, configuration):
 
       cmd = [
          xcodebuild_path,
+         '-quiet',
          '-project', os.path.join (path_artifacts, 'project_vcvrack.xcodeproj'),
          '-configuration', configuration,
          '-target', target,


### PR DESCRIPTION
This PR quiets the output of the Xcode command line build, to only report errors and warnings, to minimize noise when building the simulator on macOS.

This PR is preparation work for integrations, where consoles are generally not an ideal way to look for errors.
