### PR TITLE
Allocate ram auto

### DIFF
--- a/include/erb/detail/MonotonicMemoryPool.h
+++ b/include/erb/detail/MonotonicMemoryPool.h
@@ -35,6 +35,7 @@ public:
    virtual        ~MonotonicMemoryPool () = default;
 
    size_t         allocate (size_t alignment, size_t size);
+   size_t         allocate_npos_on_error (size_t alignment, size_t size);
 
 
 

--- a/include/erb/detail/MonotonicMemoryPool.hpp
+++ b/include/erb/detail/MonotonicMemoryPool.hpp
@@ -35,11 +35,9 @@ Name : allocate
 template <size_t MaxSize>
 size_t   MonotonicMemoryPool <MaxSize>::allocate (size_t alignment, size_t size)
 {
-   const size_t mask = alignment - 1;
-   const size_t max_needed_size = size + mask;
-   const size_t pos = _pos.fetch_add (max_needed_size, std::memory_order_relaxed);
+   size_t pos = allocate_npos_on_error (alignment, size);
 
-   if (pos + max_needed_size > MaxSize)
+   if (pos == size_t (-1))
    {
 #if defined (erb_TARGET_DAISY)
       asm ("bkpt 255");
@@ -49,6 +47,30 @@ size_t   MonotonicMemoryPool <MaxSize>::allocate (size_t alignment, size_t size)
       // - Multiple modules are being debugged (check erb/config.h for workaround)
       throw std::bad_alloc ();
 #endif
+   }
+
+   return pos;
+}
+
+
+
+/*
+==============================================================================
+Name : allocate_npos_on_error
+==============================================================================
+*/
+
+template <size_t MaxSize>
+size_t   MonotonicMemoryPool <MaxSize>::allocate_npos_on_error (size_t alignment, size_t size)
+{
+   const size_t mask = alignment - 1;
+   const size_t max_needed_size = size + mask;
+   const size_t pos = _pos.fetch_add (max_needed_size, std::memory_order_relaxed);
+
+   if (pos + max_needed_size > MaxSize)
+   {
+      _pos = pos; // not concurrent-safe
+      return size_t (-1);
    }
 
    const size_t aligned_pos = (pos + mask) & ~mask;

--- a/include/erb/detail/Sdram.h
+++ b/include/erb/detail/Sdram.h
@@ -39,6 +39,8 @@ public:
    template <typename T, class... Args>
    static T *     allocate (Args &&... args);
 
+   static void *  allocate_bytes_nullptr_on_error (size_t size);
+
 
 
 /*\\\ PROTECTED \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
@@ -55,6 +57,7 @@ protected:
 private:
 
    void *         allocate_raw (size_t alignment, size_t size);
+   void *         allocate_raw_nullptr_on_error (size_t alignment, size_t size);
 
    MonotonicMemoryPool <erb_SDRAM_MEM_POOL_SIZE>
                   _memory_pool;

--- a/include/erb/detail/Sram.h
+++ b/include/erb/detail/Sram.h
@@ -40,6 +40,8 @@ public:
    template <typename T, class... Args>
    static T *     allocate (Args &&... args);
 
+   static void *  allocate_bytes_nullptr_on_error (size_t size);
+
 
 
 /*\\\ PROTECTED \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
@@ -56,6 +58,7 @@ protected:
 private:
 
    void *         allocate_raw (size_t alignment, size_t size);
+   void *         allocate_raw_nullptr_on_error (size_t alignment, size_t size);
 
 #if defined (erb_TARGET_DAISY)
    uint8_t *      _sram_memory_pool_storage = nullptr;

--- a/include/erb/detail/fnc.h
+++ b/include/erb/detail/fnc.h
@@ -25,6 +25,8 @@ namespace erb
 
 
 
+inline void *     allocate_bytes_auto (size_t size);
+
 template <size_t NbrChannels>
 void              scale (std::array <Buffer, NbrChannels> & out, float * const * in, float gain);
 template <size_t NbrChannels>

--- a/include/erb/detail/fnc.hpp
+++ b/include/erb/detail/fnc.hpp
@@ -13,12 +13,48 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
+#include "erb/config.h"
+#include "erb/detail/Sram.h"
+#include "erb/detail/Sdram.h"
+
 #include <algorithm>
 
 
 
 namespace erb
 {
+
+
+
+/*
+==============================================================================
+Name : allocate_bytes_auto
+==============================================================================
+*/
+
+void *   allocate_bytes_auto (size_t size)
+{
+   void * ptr = Sram::allocate_bytes_nullptr_on_error (size);
+
+   if (ptr == nullptr)
+   {
+      ptr = Sdram::allocate_bytes_nullptr_on_error (size);
+   }
+
+   if (ptr == nullptr)
+   {
+#if defined (erb_TARGET_DAISY)
+      asm ("bkpt 255");
+#elif (erb_RAM_MEM_POOL_SIZE_SIMULATOR_CHECK)
+      // Either:
+      // - The module is using too much memory,
+      // - Multiple modules are being debugged (check erb/config.h for workaround)
+      throw std::bad_alloc ();
+#endif
+   }
+
+   return ptr;
+}
 
 
 

--- a/include/erb/erb.h
+++ b/include/erb/erb.h
@@ -45,6 +45,8 @@
    #error Unknown erb target
 #endif
 
+#include "erb/detail/fnc.h"
+
 
 
 namespace erb

--- a/src/detail/Sram.cpp
+++ b/src/detail/Sram.cpp
@@ -51,6 +51,20 @@ Sram::Sram ()
 
 
 
+
+/*
+==============================================================================
+Name : allocate_bytes_nullptr_on_error
+==============================================================================
+*/
+
+void *   Sram::allocate_bytes_nullptr_on_error (size_t size)
+{
+   return use_instance ().allocate_raw_nullptr_on_error (1, size);
+}
+
+
+
 /*
 ==============================================================================
 Name : use_instance
@@ -86,6 +100,32 @@ Name : allocate_raw
 void *   Sram::allocate_raw (size_t alignment, size_t size)
 {
    const size_t pos = _memory_pool.allocate (alignment, size);
+
+#if defined (erb_TARGET_DAISY)
+   return &_sram_memory_pool_storage [pos];
+
+#else
+   ((void)(pos)); // ignore pos
+
+   // Not all c++17 cstdlib do have a 'std::aligned_alloc' implementation.
+   // Use 'std::malloc' as optimising alignment is not needed for the simulator.
+   return std::malloc (size);
+#endif
+}
+
+
+
+/*
+==============================================================================
+Name : allocate_raw_nullptr_on_error
+==============================================================================
+*/
+
+void *   Sram::allocate_raw_nullptr_on_error (size_t alignment, size_t size)
+{
+   const size_t pos = _memory_pool.allocate_npos_on_error (alignment, size);
+
+   if (pos == size_t (-1)) return nullptr;
 
 #if defined (erb_TARGET_DAISY)
    return &_sram_memory_pool_storage [pos];


### PR DESCRIPTION
This PR provides a new function which uses a greedy heuristic for allocation, preferring AXI SRAM over SDRAM.

This PR is preparation work for the upcoming Max and FAUST integrations.
