### PR TITLE
Add missing step between install and setup

### DIFF
--- a/documentation/getting-started/setup.md
+++ b/documentation/getting-started/setup.md
@@ -33,7 +33,15 @@ Install by running the script below:
 ~/eurorack-blocks$ ./build-system/install.py
 ```
 
-This will add the `erbb` script to your `PATH`.
+This will add the `erbb` script to your `PATH`, but the `PATH` will be set only for new terminals.
+You can either close your current terminal and open a new one, or source the `erbb` environment
+explicitly into your current shell session:
+
+```shell-session
+~/eurorack-blocks$ source ./build-system/init.sh
+```
+
+Then:
 
 ```shell-session
 ~/eurorack-blocks$ erbb setup

--- a/documentation/max/setup.md
+++ b/documentation/max/setup.md
@@ -85,7 +85,15 @@ Install by running the script below:
 ~/eurorack-blocks$ ./build-system/install.py
 ```
 
-This will add the `erbb` script to your `PATH`.
+This will add the `erbb` script to your `PATH`, but the `PATH` will be set only for new terminals.
+You can either close your current terminal and open a new one, or source the `erbb` environment
+explicitly into your current shell session:
+
+```shell-session
+~/eurorack-blocks$ source ./build-system/init.sh
+```
+
+Then:
 
 ```shell-session
 ~/eurorack-blocks$ erbb setup


### PR DESCRIPTION
This PR fixes a step in the documentation, between the execution of the `install.py` script and `erbb setup`: the `PATH` will be changed the next time the shell resource file is loaded, but this was not documented. Now we give an indication on how to reload the shell resource file, either by closing it and opening a new one, or `source`ing the resource file directly into the current shell session.