### PR TITLE
Erbui exclude pins

### DIFF
--- a/build-system/erbui/analyser.py
+++ b/build-system/erbui/analyser.py
@@ -25,6 +25,7 @@ class Analyser:
    def __init__ (self):
       self._board_definition = {}
       self._used_pins = {} # map from physical pin number to declaration
+      self._excluded_pins = []
       self._cascade_index = 0
 
    #--------------------------------------------------------------------------
@@ -41,6 +42,8 @@ class Analyser:
       assert module.is_module
 
       self._board_definition = self.load_board_definition (module)
+
+      self.exclude_pins (module)
 
       self.set_auto_board_width (module)
 
@@ -59,6 +62,18 @@ class Analyser:
          self.resolve_alias (module, alias)
 
       self.make_cascade_eval_list (module)
+
+
+   #--------------------------------------------------------------------------
+
+   def exclude_pins (self, module):
+      epins = [e for e in module.entities if e.is_exclude_pins]
+      for epin in epins:
+         for name in epin.names:
+            for pool in self._board_definition ['pools']:
+               if name in self._board_definition ['pools'][pool]:
+                  self._board_definition ['pools'][pool].remove (name)
+                  self._excluded_pins.append (name)
 
 
    #--------------------------------------------------------------------------
@@ -335,6 +350,8 @@ class Analyser:
       pools = self._board_definition ['pools']
       for key, value in pools.items ():
          module.unused_pins.extend (value)
+
+      module.unused_pins.extend (self._excluded_pins)
 
 
    #--------------------------------------------------------------------------

--- a/build-system/erbui/ast.py
+++ b/build-system/erbui/ast.py
@@ -82,6 +82,9 @@ class Node:
    def is_sticker (self): return isinstance (self, Sticker)
 
    @property
+   def is_exclude_pins (self): return isinstance (self, ExcludePins)
+
+   @property
    def is_pin (self): return isinstance (self, Pin)
 
    @property
@@ -483,6 +486,22 @@ class Alias (Node):
          return adapter.SourceContext.from_token (self.identifier_reference)
 
       return super (Alias, self).source_context_part (part) # pragma: no cover
+
+
+# -- ExcludePins -------------------------------------------------------------
+
+class ExcludePins (Node):
+   def __init__ (self, identifiers):
+      assert isinstance (identifiers, list)
+      super (ExcludePins, self).__init__ ()
+      self.identifiers = identifiers
+      self.pins = [ Pin (ident) for ident in identifiers]
+
+   @staticmethod
+   def typename (): return 'exclude'
+
+   @property
+   def names (self): return [ ident.name for ident in self.identifiers ]
 
 
 # -- Control -----------------------------------------------------------------

--- a/build-system/erbui/grammar.py
+++ b/build-system/erbui/grammar.py
@@ -111,6 +111,10 @@ def control_kind ():                   return list (CONTROL_KINDS)
 def control_name ():                   return name
 def control_declaration ():            return 'control', control_name, control_kind, control_body
 
+# Exclude Pins
+
+def exclude_declaration ():            return 'exclude', [pins_declaration, pin_declaration]
+
 # Footer
 def footer_entities ():                return ZeroOrMore ([label_declaration, image_declaration])
 def footer_body ():                    return '{', footer_entities, '}'
@@ -134,7 +138,7 @@ def material_name ():                  return ['aluminum', 'brushed_aluminum', '
 def material_declaration ():           return 'material', material_name, Optional (material_color)
 
 # Module
-def module_entities ():                return ZeroOrMore ([board_declaration, width_declaration, material_declaration, header_declaration, footer_declaration, line_declaration, label_declaration, sticker_declaration, image_declaration, control_declaration, alias_declaration])
+def module_entities ():                return ZeroOrMore ([board_declaration, width_declaration, material_declaration, header_declaration, footer_declaration, line_declaration, label_declaration, sticker_declaration, image_declaration, control_declaration, alias_declaration, exclude_declaration])
 def module_body ():                    return '{', module_entities, '}'
 def module_name ():                    return name
 def module_inheritance_clause ():      return 'extends', board_name

--- a/build-system/erbui/visitor.py
+++ b/build-system/erbui/visitor.py
@@ -242,6 +242,19 @@ class Visitor (PTNodeVisitor):
       return list (children)
 
 
+   #-- Exclude Pins ----------------------------------------------------------
+
+   def visit_exclude_declaration (self, node, children):
+      if children.pins_declaration:
+         exclude = ast.ExcludePins (children.pins_declaration [0].identifiers)
+      elif children.pin_declaration:
+         exclude = ast.ExcludePins ([children.pin_declaration [0].identifier])
+      else:
+         assert False
+
+      return exclude
+
+
    #-- Control ---------------------------------------------------------------
 
    def visit_control_declaration (self, node, children):

--- a/build-system/xcode/Erbui.xclangspec
+++ b/build-system/xcode/Erbui.xclangspec
@@ -12,7 +12,7 @@
             StartChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_";
             Chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
             Words = (
-                "module", "extends", "board", "width", "material", "header", "footer", "line", "alias",
+                "module", "extends", "board", "width", "material", "header", "footer", "line", "alias", "exclude",
                 "control", "label", "positioning", "sticker", "image", "pin", "pins", "cascade", "mode",
                 "position", "rotation", "offset", "style",
 

--- a/documentation/erbui/grammar.md
+++ b/documentation/erbui/grammar.md
@@ -47,7 +47,8 @@ it is a set of multiple `control`, `image`, `label`, `width`, `material`, etc. _
 > _module-entity_ → [sticker-declaration](#sticker) \
 > _module-entity_ → [image-declaration](#image) \
 > _module-entity_ → [control-declaration](#control) \
-> _module-entity_ → [alias-declaration](#alias)
+> _module-entity_ → [alias-declaration](#alias) \
+> _module-entity_ → [exclude-declaration](#exclude)
 
 ### Extensions
 
@@ -230,6 +231,34 @@ void  process ()
    float freq_val2 = ui.vco_freq;   // better
 }
 ```
+
+
+## `exclude`
+
+An `exclude` allows to prevent the use of one or more pins to be used for the entire module.
+It is typically used when a pin is colliding with a control on the board, but it makes more
+sense to exclude the pin rather than move the control.
+
+### Grammar
+
+> _exclude-declaration_ → **`exclude`** exclude-entity \
+> _exclude-entity_ → [pins-declaration](#pins) \
+> _exclude-entity_ → [pin-declaration](#pin)
+
+For example:
+
+```erbui
+module Foo {
+   board kivu12
+   exclude pins P1, P2
+
+   control pot1 Pot { ... }
+   control pot2 Pot { ... }
+}
+```
+
+The pins of `pot1` and `pot2` will be respectively `P3` and `P4`, instead of `P1` and `P2` which
+are excluded.
 
 
 ## `mode`


### PR DESCRIPTION
This PR adds the `exclude` keyword to allow to exclude pins, when the pin headers are colliding with crucial placement of controls, and there are enough pins in the pool just to avoid a conflicting pin.
