### PR TITLE
Erbui pcb route

### DIFF
--- a/.github/workflows/macos_10_15.yml
+++ b/.github/workflows/macos_10_15.yml
@@ -60,7 +60,7 @@ jobs:
         run: erbb configure; erbb build; erbb build hardware; erbb build simulator
         working-directory: samples/reverb
       - name: samples/kick
-        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
+        run: erbb configure; erbb build; erbb build hardware; erbb build gerber; erbb build simulator
         working-directory: samples/kick
       - name: test/max
         run: erbb configure; erbb build simulator; erbb build; erbb build hardware

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -61,7 +61,7 @@ jobs:
         run: erbb configure; erbb build; erbb build hardware; erbb build simulator
         working-directory: samples/reverb
       - name: samples/kick
-        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
+        run: erbb configure; erbb build; erbb build hardware; erbb build gerber; erbb build simulator
         working-directory: samples/kick
       - name: erbb init
         run: mkdir init; cd init; erbb init Init; erbb configure; erbb build; erbb build hardware; erbb build simulator

--- a/build-system/erbui/__init__.py
+++ b/build-system/erbui/__init__.py
@@ -213,6 +213,16 @@ def generate_front_pcb_kicad_pcb (path, ast):
 
 
 
+"""
+==============================================================================
+Name: generate_front_pcb_gerber
+==============================================================================
+"""
 
+def generate_front_pcb_gerber (path, ast):
+   path_hardware = os.path.join (path, 'hardware')
+   if not os.path.exists (path_hardware):
+      os.makedirs (path_hardware)
 
-
+   generator = kicad_pcbKicadPcb ()
+   generator.generate_gerber (path_hardware, ast)

--- a/build-system/erbui/ast.py
+++ b/build-system/erbui/ast.py
@@ -58,6 +58,9 @@ class Node:
    def is_material (self): return isinstance (self, Material)
 
    @property
+   def is_route (self): return isinstance (self, Route)
+
+   @property
    def is_header (self): return isinstance (self, Header)
 
    @property
@@ -288,6 +291,15 @@ class Module (Scope):
       return entities [0]
 
    @property
+   def route (self):
+      entities = [e for e in self.entities if e.is_route]
+      assert (len (entities) <= 1)
+      if entities:
+         return entities [0]
+      else:
+         return None
+
+   @property
    def header (self):
       entities = [e for e in self.entities if e.is_header]
       assert (len (entities) == 1)
@@ -406,6 +418,29 @@ class Material (Node):
    @property
    def is_aluminum_coated_black (self):
       return self.type == 'aluminum_coated' and self.color == 'black'
+
+
+# -- Route -------------------------------------------------------------------
+
+class Route (Node):
+   def __init__ (self, keyword_mode):
+      assert isinstance (keyword_mode, adapter.Keyword)
+      super (Route, self).__init__ ()
+      self.keyword_mode = keyword_mode
+
+   @staticmethod
+   def typename (): return 'route'
+
+   @property
+   def mode (self): return self.keyword_mode.value
+
+   @property
+   def is_auto (self):
+      return self.mode == 'auto'
+
+   @property
+   def is_wire (self):
+      return self.mode == 'wire'
 
 
 # -- Header ------------------------------------------------------------------

--- a/build-system/erbui/grammar.py
+++ b/build-system/erbui/grammar.py
@@ -16,6 +16,7 @@ KEYWORDS = (
    'position', 'rotation', 'offset', 'style',
    'positioning', 'center', 'left', 'top', 'right', 'bottom',
    'aluminum', 'brushed_aluminum', 'aluminum_coated', 'natural', 'white', 'black',
+   'route', 'wire', 'manual',
 )
 UNITS = ('mm', 'cm', 'hp', '°', '°ccw', '°cw')
 CONTROL_KINDS = ('AudioIn', 'AudioOut', 'Button', 'CvIn', 'CvOut', 'GateIn', 'GateOut', 'Led', 'LedBi', 'LedRgb', 'Pot', 'Switch', 'Trim')
@@ -112,7 +113,6 @@ def control_name ():                   return name
 def control_declaration ():            return 'control', control_name, control_kind, control_body
 
 # Exclude Pins
-
 def exclude_declaration ():            return 'exclude', [pins_declaration, pin_declaration]
 
 # Footer
@@ -124,6 +124,10 @@ def footer_declaration ():             return 'footer', footer_body
 def header_entities ():                return ZeroOrMore ([label_declaration, image_declaration])
 def header_body ():                    return '{', header_entities, '}'
 def header_declaration ():             return 'header', header_body
+
+# Module Route
+def route_mode ():                     return ['wire', 'manual']
+def route_declaration ():              return 'route', route_mode
 
 # Module Width
 def width_declaration ():              return 'width', distance_declaration
@@ -138,7 +142,7 @@ def material_name ():                  return ['aluminum', 'brushed_aluminum', '
 def material_declaration ():           return 'material', material_name, Optional (material_color)
 
 # Module
-def module_entities ():                return ZeroOrMore ([board_declaration, width_declaration, material_declaration, header_declaration, footer_declaration, line_declaration, label_declaration, sticker_declaration, image_declaration, control_declaration, alias_declaration, exclude_declaration])
+def module_entities ():                return ZeroOrMore ([board_declaration, width_declaration, material_declaration, header_declaration, footer_declaration, line_declaration, label_declaration, sticker_declaration, image_declaration, control_declaration, alias_declaration, exclude_declaration, route_declaration])
 def module_body ():                    return '{', module_entities, '}'
 def module_name ():                    return name
 def module_inheritance_clause ():      return 'extends', board_name

--- a/build-system/erbui/visitor.py
+++ b/build-system/erbui/visitor.py
@@ -144,6 +144,19 @@ class Visitor (PTNodeVisitor):
       return self.to_keyword (node)
 
 
+   #-- Route -----------------------------------------------------------------
+
+   def visit_route_declaration (self, node, children):
+      route_mode = children.route_mode [0]
+
+      route = ast.Route (route_mode)
+
+      return route
+
+   def visit_route_mode (self, node, children):
+      return self.to_keyword (node)
+
+
    #-- Header ----------------------------------------------------------------
 
    def visit_header_declaration (self, node, children):

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -130,6 +130,7 @@ def usage ():
    print ('build [<target> [<configuration>]]')
    print ('   target:')
    print ('      daisy        Daisy firmware (default)')
+   print ('      gerber       Front panel PCB files from Kicad file only')
    print ('      hardware     Front panel hardware files')
    print ('      simulator    Simulator plug-in module')
    print ('   configuration:')
@@ -251,6 +252,11 @@ def build ():
       erbb.build_daisy_target (module, cwd, configuration)
       erbb.objcopy (module, cwd, configuration)
 
+   elif target == 'gerber':
+      ast_erbui = read_erbui_ast (find_erbui ())
+      path_artifacts = os.path.join (cwd, 'artifacts')
+      erbui.generate_front_pcb_gerber (path_artifacts, ast_erbui)
+
    elif target == 'hardware':
       ast_erbui = read_erbui_ast (find_erbui ())
       path_artifacts = os.path.join (cwd, 'artifacts')
@@ -261,6 +267,7 @@ def build ():
       ast_erbb = read_erbb_ast (find_erbb ())
       module = ast_erbb.modules [0].name
       erbb.build_simulator_target (module, cwd, configuration)
+
    else:
       print ("Error: Unknown target %s\n" % target)
       usage ()

--- a/build-system/xcode/Erbui.xclangspec
+++ b/build-system/xcode/Erbui.xclangspec
@@ -15,6 +15,7 @@
                 "module", "extends", "board", "width", "material", "header", "footer", "line", "alias", "exclude",
                 "control", "label", "positioning", "sticker", "image", "pin", "pins", "cascade", "mode",
                 "position", "rotation", "offset", "style",
+                "route", "wire", "manual",
 
 
             );

--- a/documentation/erbui/grammar.md
+++ b/documentation/erbui/grammar.md
@@ -40,6 +40,7 @@ it is a set of multiple `control`, `image`, `label`, `width`, `material`, etc. _
 > _module-entity_ → [board-declaration](#board) \
 > _module-entity_ → [width-declaration](#width) \
 > _module-entity_ → [material-declaration](#material) \
+> _module-entity_ → [route-declaration](#route) \
 > _module-entity_ → [header-declaration](#header) \
 > _module-entity_ → [footer-declaration](#footer) \
 > _module-entity_ → [line-declaration](#line) \
@@ -92,6 +93,19 @@ A `material` defines the actual material used to produce the module front panel.
 > _material-name_ → **`brushed_aluminum`** \
 > _material-color_ → **`natural`** \
 > _material-color_ → **`black`**
+
+
+## `route`
+
+A `route` defines the way the front PCB is routed, `wire` if not specified (which requires hand soldering).
+`manual` allows to manually route the front PCB or use an autorouteur. In that case, all the
+hand soldering pads are removed to leave more space for routing.
+
+### Grammar
+
+> _route-declaration_ → **`route`** route-mode \
+> _route-mode_ → **`wire`** \
+> _route-mode_ → **`manual`**
 
 
 ## `board`


### PR DESCRIPTION
This PR adds a mode that allows to manually route (and therefore use an external autorouteur) a generated front panel PCB in order to save some soldering time.

For now we can't automate fully the autorouteur, because Kicad can't export or import the Spectra session files without a GUI. A working solution would be to generate the session and back directly from the Kicad files, but this is a lot of work. We decided for now to postpone it.
