### PR TITLE
Fix command chaining in github workflows

### DIFF
--- a/.github/workflows/macos_10_15.yml
+++ b/.github/workflows/macos_10_15.yml
@@ -21,22 +21,22 @@ jobs:
       - run: python3 blocks/test/configure.py
       - run: python3 blocks/test/build.py
       - name: test/data
-        run: erbb configure; erbb build
+        run: erbb configure && erbb build
         working-directory: test/data
       - name: samples/bypass
-        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
+        run: erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: samples/bypass
       - name: samples/drop
-        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
+        run: erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: samples/drop
       - name: samples/reverb
-        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
+        run: erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: samples/reverb
       - name: samples/kick
-        run: erbb configure; erbb build; erbb build hardware; erbb build gerber; erbb build simulator
+        run: erbb configure && erbb build && erbb build hardware && erbb build gerber && erbb build simulator
         working-directory: samples/kick
       - name: erbb init
-        run: mkdir init; cd init; erbb init Init; erbb configure; erbb build; erbb build hardware; erbb build simulator
+        run: mkdir init && cd init && erbb init Init && erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: samples
 
   software_max:
@@ -52,10 +52,10 @@ jobs:
       - run: python3 build-system/install.py
       - run: erbb setup
       - name: test/max
-        run: erbb configure; erbb build simulator; erbb build; erbb build hardware
+        run: erbb configure && erbb build simulator && erbb build && erbb build hardware
         working-directory: test/max
       - name: test/max2
-        run: erbb configure; erbb build simulator; erbb build; erbb build hardware
+        run: erbb configure && erbb build simulator && erbb build && erbb build hardware
         working-directory: test/max2
 
   software_faust:
@@ -72,16 +72,16 @@ jobs:
       - run: python3 build-system/install.py
       - run: erbb setup
       - name: samples/faust
-        run: erbb configure; erbb build; erbb build hardware; erbb build gerber; erbb build simulator
+        run: erbb configure && erbb build && erbb build hardware && erbb build gerber && erbb build simulator
         working-directory: samples/faust
       - name: test/faust
-        run: erbb configure; erbb build simulator; erbb build; erbb build hardware
+        run: erbb configure && erbb build simulator && erbb build && erbb build hardware
         working-directory: test/faust
       - name: test/faust2
-        run: erbb configure; erbb build simulator; erbb build; erbb build hardware
+        run: erbb configure && erbb build simulator && erbb build && erbb build hardware
         working-directory: test/faust2
       - name: test/faust3
-        run: erbb configure; erbb build simulator; erbb build; erbb build hardware
+        run: erbb configure && erbb build simulator && erbb build && erbb build hardware
         working-directory: test/faust3
 
   hardware:

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -21,22 +21,22 @@ jobs:
       - run: python blocks/test/build.py
       - run: python build-system/install.py
       - name: test/data
-        run: erbb configure; erbb build; erbb build hardware
+        run: erbb configure && erbb build && erbb build hardware
         working-directory: test/data
       - name: samples/bypass
-        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
+        run: erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: samples/bypass
       - name: samples/drop
-        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
+        run: erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: samples/drop
       - name: samples/reverb
-        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
+        run: erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: samples/reverb
       - name: samples/kick
-        run: erbb configure; erbb build; erbb build hardware; erbb build gerber; erbb build simulator
+        run: erbb configure && erbb build && erbb build hardware && erbb build gerber && erbb build simulator
         working-directory: samples/kick
       - name: erbb init
-        run: mkdir init; cd init; erbb init Init; erbb configure; erbb build; erbb build hardware; erbb build simulator
+        run: mkdir init && cd init && erbb init Init && erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: samples
 
   software_faust:
@@ -53,16 +53,16 @@ jobs:
       - run: python3 build-system/install.py
       - run: erbb setup
       - name: samples/faust
-        run: erbb configure; erbb build; erbb build hardware; erbb build gerber; erbb build simulator
+        run: erbb configure && erbb build && erbb build hardware && erbb build gerber && erbb build simulator
         working-directory: samples/faust
       - name: test/faust
-        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
+        run: erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: test/faust
       - name: test/faust2
-        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
+        run: erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: test/faust2
       - name: test/faust3
-        run: erbb configure; erbb build; erbb build hardware; erbb build simulator
+        run: erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: test/faust3
 
   hardware:


### PR DESCRIPTION
The workflows where executing `cmd1; cmd2` which doesn't allow to check the return status of `cmd1` (and procceed with `cmd2` anyway).
We changed that to `cmd1 && cmd2` to make sure any failure is detected.
