### PR TITLE
Specify explicit utf-8 encoding when required

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -44,7 +44,7 @@ Name: parse
 """
 
 def parse (filepath):
-   with open (filepath, "r") as data:
+   with open (filepath, 'r', encoding='utf-8') as data:
       input_text = data.read ()
 
    parser = Parser ()

--- a/build-system/erbb/generators/action/action.py
+++ b/build-system/erbb/generators/action/action.py
@@ -53,12 +53,12 @@ class Action:
       if not os.path.exists (path_actions):
          os.makedirs (path_actions)
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       path_rel_root = os.path.relpath (PATH_ROOT, path)
       template = template.replace ('%PATH_ROOT%', path_rel_root)
       template = template.replace ('%module.name%', module.name)
 
-      with open (path_py, 'w') as file:
+      with open (path_py, 'w', encoding='utf-8') as file:
          file.write (template)

--- a/build-system/erbb/generators/daisy/project.py
+++ b/build-system/erbb/generators/daisy/project.py
@@ -34,7 +34,7 @@ class Project:
       path_template = os.path.join (PATH_THIS, 'project_template.gyp')
       path_cpp = os.path.join (path, 'project_daisy.gyp')
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       path_rel_root = os.path.relpath (PATH_ROOT, path)
@@ -49,7 +49,7 @@ class Project:
       template = self.replace_sources (template, module, module.sources, path)
       template = self.replace_actions (template, module, path)
 
-      with open (path_cpp, 'w') as file:
+      with open (path_cpp, 'w', encoding='utf-8') as file:
          file.write (template)
 
 

--- a/build-system/erbb/generators/data/code.py
+++ b/build-system/erbb/generators/data/code.py
@@ -43,7 +43,7 @@ class Code:
       path_template = os.path.join (PATH_THIS, 'code_template.h')
       path_cpp = os.path.join (path, '%sData.h' % module.name)
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       template = template.replace ('%module.name%', module.name)
@@ -56,7 +56,7 @@ class Code:
 
       template = template.replace ('%entities%', entities_content)
 
-      with open (path_cpp, 'w') as file:
+      with open (path_cpp, 'w', encoding='utf-8') as file:
          file.write (template)
 
 
@@ -173,7 +173,7 @@ class Code:
       path_template = os.path.join (PATH_THIS, 'code_template.cpp')
       path_cpp = os.path.join (path, 'plugin_generated_data.cpp')
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       template = template.replace ('%module.name%', module.name)
@@ -186,7 +186,7 @@ class Code:
 
       template = template.replace ('%entities%', entities_content)
 
-      with open (path_cpp, 'w') as file:
+      with open (path_cpp, 'w', encoding='utf-8') as file:
          file.write (template)
 
 

--- a/build-system/erbb/generators/faust/code.py
+++ b/build-system/erbb/generators/faust/code.py
@@ -100,7 +100,7 @@ class Code:
          cwd = path
       )
 
-      with open (faust_dsp_json) as f:
+      with open (faust_dsp_json, 'r', encoding='utf-8') as f:
          faust_json = json.load (f)
 
       faust_dsp = self.generate_faust_dsp (faust_json)
@@ -157,7 +157,7 @@ class Code:
          for data in resources.datas:
             has_data = True
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       path_rel_root = os.path.relpath (PATH_ROOT, path)
@@ -176,7 +176,7 @@ class Code:
       template = template.replace ('%     module.spl_adapters%', self.generate_module_declaration_spl_adapter (faust_dsp, module))
       template = template.replace ('%     module.samples%', self.generate_module_declaration_samples (faust_dsp, module))
 
-      with open (path_output, 'w') as file:
+      with open (path_output, 'w', encoding='utf-8') as file:
          file.write (template)
 
 
@@ -238,10 +238,10 @@ class Code:
       path_template = os.path.join (PATH_THIS, 'code_template.hpp')
       path_output = os.path.join (path, '%s_erbb.hpp' % module.name)
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       template = template.replace ('%module.name%', module.name)
 
-      with open (path_output, 'w') as file:
+      with open (path_output, 'w', encoding='utf-8') as file:
          file.write (template)

--- a/build-system/erbb/generators/faust/project.py
+++ b/build-system/erbb/generators/faust/project.py
@@ -33,10 +33,10 @@ class Project:
       path_template = os.path.join (PATH_THIS, 'project_template.%s' % extension)
       path_output = os.path.join (path, '%s.%s' % (name, extension))
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       template = template.replace ('%Name%', name)
 
-      with open (path_output, 'w') as file:
+      with open (path_output, 'w', encoding='utf-8') as file:
          file.write (template)

--- a/build-system/erbb/generators/init/project.py
+++ b/build-system/erbb/generators/init/project.py
@@ -34,10 +34,10 @@ class Project:
       path_template = os.path.join (PATH_THIS, 'project_template.%s' % extension)
       path_output = os.path.join (path, '%s.%s' % (name, extension))
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       template = template.replace ('%Name%', name)
 
-      with open (path_output, 'w') as file:
+      with open (path_output, 'w', encoding='utf-8') as file:
          file.write (template)

--- a/build-system/erbb/generators/max/code.py
+++ b/build-system/erbb/generators/max/code.py
@@ -57,7 +57,7 @@ class Code:
          for data in resources.datas:
             has_data = True
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       template = template.replace ('%module.name%', module.name)
@@ -68,7 +68,7 @@ class Code:
          template = template.replace ('%include module.nameData.h%', '')
          template = template.replace ('%  module.nameData data;%', '')
 
-      with open (path_output, 'w') as file:
+      with open (path_output, 'w', encoding='utf-8') as file:
          file.write (template)
 
 
@@ -78,13 +78,13 @@ class Code:
       path_template = os.path.join (PATH_THIS, 'code_template.cpp')
       path_output = os.path.join (path, '%s_erbb.cpp' % module.name)
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       template = template.replace ('%module.name%', module.name)
       template = template.replace ('%  state.set_data%', self.generate_data_definition (path, module))
 
-      with open (path_output, 'w') as file:
+      with open (path_output, 'w', encoding='utf-8') as file:
          file.write (template)
 
 
@@ -114,11 +114,11 @@ class Code:
       path_input = os.path.join (path, 'module_max.cpp')
       module_max_def = os.path.join (path, 'module_max_def.py')
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       try:
-         file_input = open (path_input, 'r')
+         file_input = open (path_input, 'r', encoding='utf-8')
 
       except OSError:
          print ('warning: No gen code found. Please open %s.maxpat and save it to generate gen code.' % (module.name), file=sys.stderr)
@@ -153,12 +153,12 @@ class Code:
                print ('warning: Output %s not mapped.' % history_key, file=sys.stderr)
 
 
-      with open (module_max_def, 'w') as file:
+      with open (module_max_def, 'w', encoding='utf-8') as file:
          file.write (str (maxpat))
 
       template = template.replace ('%typedef struct State%', state_def)
 
-      with open (path_output, 'w') as file:
+      with open (path_output, 'w', encoding='utf-8') as file:
          file.write (template)
 
 
@@ -168,10 +168,10 @@ class Code:
       path_template = os.path.join (PATH_THIS, 'module_max_template.cpp')
       path_output = os.path.join (path, 'module_max_alt.cpp')
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
-      with open (path_output, 'w') as file:
+      with open (path_output, 'w', encoding='utf-8') as file:
          file.write (template)
 
 
@@ -184,7 +184,7 @@ class Code:
             if file_extension == '.maxpat':
                maxpat_path = file.path
 
-      with open (maxpat_path) as f:
+      with open (maxpat_path, 'r', encoding='utf-8') as f:
          max_json = json.load (f)
 
       return self.make_maxpat_patcher (max_json)

--- a/build-system/erbb/generators/max/project.py
+++ b/build-system/erbb/generators/max/project.py
@@ -33,10 +33,10 @@ class Project:
       path_template = os.path.join (PATH_THIS, 'project_template.%s' % extension)
       path_output = os.path.join (path, '%s.%s' % (name, extension))
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       template = template.replace ('%Name%', name)
 
-      with open (path_output, 'w') as file:
+      with open (path_output, 'w', encoding='utf-8') as file:
          file.write (template)

--- a/build-system/erbb/generators/vcvrack/project.py
+++ b/build-system/erbb/generators/vcvrack/project.py
@@ -34,7 +34,7 @@ class Project:
       path_template = os.path.join (PATH_THIS, 'project_template.gyp')
       path_cpp = os.path.join (path, 'project_vcvrack.gyp')
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       path_rel_root = os.path.relpath (PATH_ROOT, path)
@@ -47,7 +47,7 @@ class Project:
       template = self.replace_sources (template, module, module.sources, path)
       template = self.replace_actions (template, module, path)
 
-      with open (path_cpp, 'w') as file:
+      with open (path_cpp, 'w', encoding='utf-8') as file:
          file.write (template)
 
 

--- a/build-system/erbb/generators/vscode/launch.py
+++ b/build-system/erbb/generators/vscode/launch.py
@@ -32,7 +32,7 @@ class Launch:
       path_template = os.path.join (PATH_THIS, 'launch_template.json')
       path_dst = os.path.join (path, '.vscode', 'launch.json')
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       path_artifacts = os.path.join (path, 'artifacts')
@@ -42,5 +42,5 @@ class Launch:
       template = template.replace ('%executable_debug%', file_elf_debug)
       template = template.replace ('%svd_file%', file_svd)
 
-      with open (path_dst, 'w') as file:
+      with open (path_dst, 'w', encoding='utf-8') as file:
          file.write (template)

--- a/build-system/erbb/generators/vscode/tasks.py
+++ b/build-system/erbb/generators/vscode/tasks.py
@@ -32,8 +32,8 @@ class Tasks:
       path_template = os.path.join (PATH_THIS, 'tasks_template.json')
       path_dst = os.path.join (path, '.vscode', 'tasks.json')
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
-      with open (path_dst, 'w') as file:
+      with open (path_dst, 'w', encoding='utf-8') as file:
          file.write (template)

--- a/build-system/erbb/parser.py
+++ b/build-system/erbb/parser.py
@@ -43,7 +43,7 @@ class Parser:
    def _merge_import (self, node, import_):
       import_path = import_.path
       try:
-         file = open (import_path, 'r')
+         file = open (import_path, 'r', encoding='utf-8')
       except OSError:
          err = error.Error ()
          context = import_.literal

--- a/build-system/erbui/__init__.py
+++ b/build-system/erbui/__init__.py
@@ -34,7 +34,7 @@ Name: parse
 """
 
 def parse (filepath):
-   with open (filepath, "r") as data:
+   with open (filepath, 'r', encoding='utf-8') as data:
       input_text = data.read ()
 
    parser = Parser ()

--- a/build-system/erbui/analyser.py
+++ b/build-system/erbui/analyser.py
@@ -363,7 +363,7 @@ class Analyser:
       path_definition = os.path.join (PATH_BOARDS, module_board, 'definition.py')
 
       try:
-         file = open (path_definition, 'r')
+         file = open (path_definition, 'r', encoding='utf-8')
       except OSError:
          err = error.Error ()
          context = module.board.source_context

--- a/build-system/erbui/generators/daisy/code.py
+++ b/build-system/erbui/generators/daisy/code.py
@@ -31,7 +31,7 @@ class Code:
       path_template = os.path.join (PATH_THIS, 'code_template.cpp')
       path_cpp = os.path.join (path, 'main_daisy.cpp')
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       template = template.replace ('%module.name%', module.name)
@@ -40,7 +40,7 @@ class Code:
       template = self.replace_controls_preprocess (template, module.entities);
       template = self.replace_controls_postprocess (template, module.entities);
 
-      with open (path_cpp, 'w') as file:
+      with open (path_cpp, 'w', encoding='utf-8') as file:
          file.write (template)
 
 

--- a/build-system/erbui/generators/faust/code.py
+++ b/build-system/erbui/generators/faust/code.py
@@ -109,7 +109,7 @@ class Code:
    def generate_module (self, path, module):
       faust_dsp_json = os.path.join (path, '%s.dsp.json' % module.name)
 
-      with open (faust_dsp_json) as f:
+      with open (faust_dsp_json, 'r', encoding='utf-8') as f:
          faust_json = json.load (f)
 
       faust_dsp = self.generate_faust_dsp (faust_json)
@@ -190,7 +190,7 @@ class Code:
       path_template = os.path.join (PATH_THIS, 'code_template.hpp')
       path_output = os.path.join (path, '%s_erbui.hpp' % module.name)
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       path_rel_root = os.path.relpath (PATH_ROOT, path)
@@ -201,7 +201,7 @@ class Code:
       template = template.replace ('%  module.ui_input_entities%', self.generate_module_definition_ui_inputs (faust_dsp, module))
       template = template.replace ('%  module.ui_output_entities%', self.generate_module_definition_ui_outputs (faust_dsp, module))
 
-      with open (path_output, 'w') as file:
+      with open (path_output, 'w', encoding='utf-8') as file:
          file.write (template)
 
 

--- a/build-system/erbui/generators/front_pcb/kicad_pcb.py
+++ b/build-system/erbui/generators/front_pcb/kicad_pcb.py
@@ -346,7 +346,7 @@ class KicadPcb:
 
          bom += '%s;%d;%s;%s;%s\n' % (description, quantity, dist, dist_pn, dist_link)
 
-      with open (path_bom, 'w') as file:
+      with open (path_bom, 'w', encoding='utf-8') as file:
          file.write (bom)
 
 
@@ -456,7 +456,7 @@ class KicadPcb:
    #--------------------------------------------------------------------------
 
    def load (self, path):
-      with open (path, 'r') as file:
+      with open (path, 'r', encoding='utf-8') as file:
          content = file.read ()
       parser = s_expression.Parser ()
       return parser.parse (content, 'kicad_pcb')

--- a/build-system/erbui/generators/front_pcb/s_expression.py
+++ b/build-system/erbui/generators/front_pcb/s_expression.py
@@ -147,7 +147,7 @@ class Parser:
 class Writer:
    def write (self, ast, filename):
       content = self.write_any (ast)
-      with open (filename, 'w') as file:
+      with open (filename, 'w', encoding='utf-8') as file:
          file.write (content)
 
    def write_any (self, node, indent=0):

--- a/build-system/erbui/generators/max/code.py
+++ b/build-system/erbui/generators/max/code.py
@@ -36,7 +36,7 @@ class Code:
    def generate_module (self, path, module):
 
       try:
-         file_def = open (os.path.join (path, 'module_max_def.py'), 'r')
+         file_def = open (os.path.join (path, 'module_max_def.py'), 'r', encoding='utf-8')
 
       except OSError:
          # gen code is not generated yet
@@ -89,7 +89,7 @@ class Code:
       path_template = os.path.join (PATH_THIS, 'code_template.cpp')
       path_output = os.path.join (path, '%s_erbui.cpp' % module.name)
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       path_rel_root = os.path.relpath (PATH_ROOT, path)
@@ -100,7 +100,7 @@ class Code:
       template = template.replace ('%  state.set_param%', self.generate_module_definition_set_param (module, module_max_def))
       template = template.replace ('%  ui.param = state.m_param%', self.generate_module_definition_get_param (module, module_max_def))
 
-      with open (path_output, 'w') as file:
+      with open (path_output, 'w', encoding='utf-8') as file:
          file.write (template)
 
 

--- a/build-system/erbui/generators/ui/code.py
+++ b/build-system/erbui/generators/ui/code.py
@@ -33,7 +33,7 @@ class Code:
       path_template = os.path.join (PATH_THIS, 'code_template.h')
       path_cpp = os.path.join (path, '%sUi.h' % module.name)
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       self._board_definition = self.load_board_definition (module)
@@ -45,7 +45,7 @@ class Code:
       entities_content = self.generate_entities (module.entities)
       template = template.replace ('%entities%', entities_content)
 
-      with open (path_cpp, 'w') as file:
+      with open (path_cpp, 'w', encoding='utf-8') as file:
          file.write (template)
 
 
@@ -149,7 +149,7 @@ class Code:
       path_definition = os.path.join (PATH_BOARDS, module_board, 'definition.py')
 
       try:
-         file = open (path_definition, 'r')
+         file = open (path_definition, 'r', encoding='utf-8')
       except OSError:
          err = error.Error ()
          context = module.board.source_context

--- a/build-system/erbui/generators/vcvrack/code.py
+++ b/build-system/erbui/generators/vcvrack/code.py
@@ -31,7 +31,7 @@ class Code:
       path_template = os.path.join (PATH_THIS, 'code_template.cpp')
       path_cpp = os.path.join (path, 'plugin_vcvrack.cpp')
 
-      with open (path_template, 'r') as file:
+      with open (path_template, 'r', encoding='utf-8') as file:
          template = file.read ()
 
       template = template.replace ('%module.name%', module.name)
@@ -42,7 +42,7 @@ class Code:
       template = self.replace_controls_postprocess (template, module.entities);
       template = self.replace_controls_widget (template, module.entities);
 
-      with open (path_cpp, 'w') as file:
+      with open (path_cpp, 'w', encoding='utf-8') as file:
          file.write (template)
 
 

--- a/build-system/erbui/generators/vcvrack/manifest.py
+++ b/build-system/erbui/generators/vcvrack/manifest.py
@@ -21,7 +21,7 @@ class Manifest:
    def generate (self, path, root):
       path_json = os.path.join (path, 'plugin.json')
 
-      with open (path_json, 'w') as file:
+      with open (path_json, 'w', encoding='utf-8') as file:
          file.write ('{\n')
          file.write ('   "slug": "ErbPlugin%s",\n' % root.modules [0].name)
          file.write ('   "name": "Erb Plugin",\n')

--- a/build-system/erbui/generators/vcvrack/panel.py
+++ b/build-system/erbui/generators/vcvrack/panel.py
@@ -51,8 +51,8 @@ class Panel:
    # Post-process the file to solve that problem.
 
    def post_process (self, path_svg_pp, path_svg):
-      with open (path_svg_pp, 'r') as file_pp:
-         with open (path_svg, 'w') as file:
+      with open (path_svg_pp, 'r', encoding='utf-8') as file_pp:
+         with open (path_svg, 'w', encoding='utf-8') as file:
             for line in file_pp:
                line = self.post_process_line (line)
                file.write (line)

--- a/build-system/erbui/parser.py
+++ b/build-system/erbui/parser.py
@@ -42,7 +42,7 @@ class Parser:
       path_layout = os.path.join (PATH_BOARDS, module.super_identifier.name, 'layout.erbui')
 
       try:
-         file = open (path_layout, 'r')
+         file = open (path_layout, 'r', encoding='utf-8')
       except OSError:
          err = error.Error ()
          context = module.super_identifier

--- a/build-system/erbuic.py
+++ b/build-system/erbuic.py
@@ -94,7 +94,7 @@ def read_ast (args):
       sys.exit (1)
 
    try:
-      file = open (args.input, 'r')
+      file = open (args.input, 'r', encoding='utf-8')
    except IOError as e:
       if args.no_diagnostics_color:
          logging.error ("fatal error: Unable to open for read '%s' file: %s", args.input, e.strerror)

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -65,7 +65,7 @@ def read_erbb_ast (filepath):
       sys.exit (1)
 
    try:
-      file = open (filepath, 'r')
+      file = open (filepath, 'r', encoding='utf-8')
    except IOError as e:
       print ("\033[91mfatal error:\033[0m Unable to open for read '%s' file: %s" % (args.input, e.strerror))
       sys.exit (1)
@@ -93,7 +93,7 @@ def read_erbui_ast (filepath):
       sys.exit (1)
 
    try:
-      file = open (filepath, 'r')
+      file = open (filepath, 'r', encoding='utf-8')
    except IOError as e:
       print ("\033[91mfatal error:\033[0m Unable to open for read '%s' file: %s" % (args.input, e.strerror))
       sys.exit (1)


### PR DESCRIPTION
This PR specifies explicitly, for all files opened by `erbb`, that the text files encoding is UTF-8, when appropriate:
- All our templates and generated files are UTF-8
- Users `.erbb` and `.erbui` files are UTF-8
- JSON and SVG files are UTF-8
- Kicad files are UTF-8

Faust is using lex/bison, and lex works only on bytes, irrespective of any encoding. Therefore a typical multibytes character like `é` (`0xC3 0xA9` very common in the French language, from which Faust originates) wouldn't be correctly interpreted. This is important for the Faust address binding, and since it uses string literal notation, it should be expected to have multibytes character.
For this reason, Faust `dsp` files will be *assumed* to be UTF-8.

This PR is preparation work for the upcoming Windows support, where, even on Python 3, the Windows code page 1252 is expected.
This is a potential issue, are we are using, for example, the `°` character in the grammar, for which the encoding is different in code page 1252.
