### PR TITLE
Make pcbnew import explicit for darwin platform

### DIFF
--- a/build-system/erbui/generators/front_pcb/fill_zones.py
+++ b/build-system/erbui/generators/front_pcb/fill_zones.py
@@ -10,10 +10,13 @@
 
 from __future__ import print_function
 import os
+import platform
 import subprocess
 import sys
 
-sys.path.insert(0, "/Applications/Kicad/kicad.app/Contents/Frameworks/python/site-packages/")
+if platform.system () == 'Darwin':
+   sys.path.insert(0, "/Applications/Kicad/kicad.app/Contents/Frameworks/python/site-packages/")
+
 import pcbnew
 
 


### PR DESCRIPTION
This PR updates the import of `pcbnew` relative to the platform. This is a minor change, as only macOS needs a dynamic python path append, as the Linux environment is correctly configured for Kicad.

On the question: why not add the path to `PYTHONPATH`? Installation can go wrong in many ways, so we try to keep the most possible out of it, and ideally in python land.

This PR is preparation work for the upcoming Windows support.
