### PR TITLE
Add missing action in gyp file

### DIFF
--- a/build-system/build-system.gyp
+++ b/build-system/build-system.gyp
@@ -39,6 +39,7 @@
             'erbb/generators/action/action_faust_template.py',
             'erbb/generators/action/action_max_template.py',
             'erbb/generators/action/action_ui_template.py',
+            'erbb/generators/action/action_vcvrack_install_template.py',
             'erbb/generators/action/action_vcvrack_template.py',
             'erbb/generators/action/action.py',
 


### PR DESCRIPTION
This PR fixes a missing file for the `build-system.gyp` file. This not a user-visible change.