### PR TITLE
Fix erbb simulator make strict conf flags

### DIFF
--- a/build-system/erbb/generators/simulator/Makefile_template
+++ b/build-system/erbb/generators/simulator/Makefile_template
@@ -64,6 +64,7 @@ endif
 # Optimization
 FLAGS_Release += -O3 -DNDEBUG=1 -DRELEASE=1 -march=nocona -funsafe-math-optimizations
 FLAGS_Debug += -O0 -g -DDEBUG=1 -march=nocona -funsafe-math-optimizations
+%warnings%
 
 FLAGS += -Derb_TARGET_VCV_RACK
 FLAGS += -Derb_BUFFER_SIZE=48

--- a/build-system/erbb/generators/simulator/Makefile_template
+++ b/build-system/erbb/generators/simulator/Makefile_template
@@ -18,9 +18,6 @@ CONFIGURATION ?= Debug
 
 
 
-# Warnings
-FLAGS += -Wall -Wextra -Wno-unused-parameter
-
 # C standard
 CFLAGS += -std=gnu11
 
@@ -62,9 +59,16 @@ ifdef ARCH_WIN
 endif
 
 # Optimization
-FLAGS_Release += -O3 -DNDEBUG=1 -DRELEASE=1 -march=nocona -funsafe-math-optimizations
-FLAGS_Debug += -O0 -g -DDEBUG=1 -march=nocona -funsafe-math-optimizations
+ifeq ($(CONFIGURATION),Debug)
+FLAGS += -O0 -g -DDEBUG=1 -march=nocona -funsafe-math-optimizations
+endif
+
+ifeq ($(CONFIGURATION),Release)
+FLAGS += -O3 -DNDEBUG=1 -DRELEASE=1 -march=nocona -funsafe-math-optimizations
+endif
+
 %warnings%
+FLAGS += -Wno-c99-extensions
 
 FLAGS += -Derb_TARGET_VCV_RACK
 FLAGS += -Derb_BUFFER_SIZE=48

--- a/build-system/erbb/generators/simulator/make.py
+++ b/build-system/erbb/generators/simulator/make.py
@@ -28,12 +28,12 @@ class Make:
 
    def generate (self, path, root):
       for module in root.modules:
-         self.generate_module (path, module)
+         self.generate_module (path, module, root.strict)
 
 
    #--------------------------------------------------------------------------
 
-   def generate_module (self, path, module):
+   def generate_module (self, path, module, strict):
       path_template = os.path.join (PATH_THIS, 'Makefile_template')
       path_simulator = os.path.join (path, 'artifacts', 'simulator')
       path_makefile = os.path.join (path_simulator, 'Makefile')
@@ -58,6 +58,7 @@ class Make:
       template = template.replace ('%define_PATH_ROOT%', 'PATH_ROOT ?= %s' % path_root)
       template = template.replace ('%define_RACK_DIR%', 'RACK_DIR ?= %s' % path_rack_dir)
       template = template.replace ('%define_ARCH%', arch)
+      template = self.replace_warnings (template, strict)
       template = self.replace_defines (template, module, module.defines)
       template = self.replace_bases (template, module, module.bases, path_simulator);
       template = self.replace_sources (template, module, module.sources, path_simulator)
@@ -66,6 +67,17 @@ class Make:
 
       with open (path_makefile, 'w', encoding='utf-8') as file:
          file.write (template)
+
+
+   #--------------------------------------------------------------------------
+
+   def replace_warnings (self, template, strict):
+      lines = ''
+
+      if strict:
+         lines += 'FLAGS += -Wall -Wextra -Wpedantic -Werror\n'
+
+      return template.replace ('%warnings%', lines)
 
 
    #--------------------------------------------------------------------------

--- a/include/erb/def.h
+++ b/include/erb/def.h
@@ -46,6 +46,7 @@
       _Pragma ("clang diagnostic ignored \"-Wconversion\"") \
       _Pragma ("clang diagnostic ignored \"-Wglobal-constructors\"") \
       _Pragma ("clang diagnostic ignored \"-Wunused-parameter\"") \
+      _Pragma ("clang diagnostic ignored \"-Wunused-variable\"") \
       _Pragma ("clang diagnostic ignored \"-Winconsistent-missing-destructor-override\"") \
       _Pragma ("clang diagnostic ignored \"-Wcast-align\"") \
       _Pragma ("clang diagnostic ignored \"-Wcast-qual\"") \
@@ -55,6 +56,7 @@
       _Pragma ("clang diagnostic ignored \"-Wunknown-warning-option\"") \
       _Pragma ("clang diagnostic ignored \"-Wsuggest-override\"") \
       _Pragma ("clang diagnostic ignored \"-Wsuggest-destructor-override\"") \
+      _Pragma ("clang diagnostic ignored \"-Wmacro-redefined\"") \
 
    #define erb_DISABLE_WARNINGS_FAUST_GEN \
       _Pragma ("clang diagnostic push") \


### PR DESCRIPTION
This PR:
- Adds support for the `use strict` feature in simulator `make` target
- Adds support for proper debug/release flags
- Silents some more warnings from VCV Rack SDK headers
