### PR TITLE
Fix vcvrack target pot value for bipolar mode

### DIFF
--- a/include/erb/Pot.hpp
+++ b/include/erb/Pot.hpp
@@ -45,6 +45,7 @@ Name : operator float
 template <FloatRange Range>
 Pot <Range>::operator float () const
 {
+#if defined (erb_TARGET_DAISY)
    if constexpr (Range == FloatRange::Normalized)
    {
       return impl_data;
@@ -53,6 +54,14 @@ Pot <Range>::operator float () const
    {
       return impl_data * 2.f - 1.f;
    }
+
+#elif defined (erb_TARGET_VCV_RACK)
+   return impl_data;
+
+#else
+   #error
+
+#endif
 }
 
 


### PR DESCRIPTION
This PR fixes a bug with the simulator where controls with `mode bipolar` were reporting incorrect values.

This is because bipolar parameters are declared as such in VCV Rack, so they can be by default in their neutral center. The internal value is therefore already bipolar, and no scaling needs to be done.