### PR TITLE
Board definition include

### DIFF
--- a/boards/daisy_field/BoardDaisyField.h
+++ b/boards/daisy_field/BoardDaisyField.h
@@ -1,0 +1,26 @@
+/*****************************************************************************
+
+      BoardDaisyField.h
+      Copyright (c) 2020 Raphael DINGE
+
+*Tab=3***********************************************************************/
+
+
+
+#pragma once
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#if defined (erb_TARGET_DAISY)
+   #include "firmware/BoardDaisyField.h"
+
+#elif defined (erb_TARGET_VCV_RACK)
+   #include "simulator/BoardDaisyField.h"
+
+#endif
+
+
+
+/*\\\ EOF \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/boards/daisy_field/definition.py
+++ b/boards/daisy_field/definition.py
@@ -9,8 +9,7 @@
 
 {
    'class': 'erb::BoardDaisyField',
-   'simulator': 'simulator/BoardDaisyField.h',
-   'firmware': 'firmware/BoardDaisyField.h',
+   'include': 'BoardDaisyField.h',
    'pins': {
       'CI1': {
          'accept': ['CvIn'],

--- a/boards/daisy_micropatch/BoardDaisyMicropatch.h
+++ b/boards/daisy_micropatch/BoardDaisyMicropatch.h
@@ -1,0 +1,26 @@
+/*****************************************************************************
+
+      BoardDaisyMicropatch.h
+      Copyright (c) 2020 Raphael DINGE
+
+*Tab=3***********************************************************************/
+
+
+
+#pragma once
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#if defined (erb_TARGET_DAISY)
+   #include "firmware/BoardDaisyMicropatch.h"
+
+#elif defined (erb_TARGET_VCV_RACK)
+   #include "simulator/BoardDaisyMicropatch.h"
+
+#endif
+
+
+
+/*\\\ EOF \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/boards/daisy_micropatch/definition.py
+++ b/boards/daisy_micropatch/definition.py
@@ -9,8 +9,7 @@
 
 {
    'class': 'erb::BoardDaisyMicropatch',
-   'simulator': 'simulator/BoardDaisyMicropatch.h',
-   'firmware': 'firmware/BoardDaisyMicropatch.h',
+   'include': 'BoardDaisyMicropatch.h',
    'pins': {
       'CI1': {
          'accept': ['CvIn'],

--- a/boards/daisy_seed/BoardDaisySeed.h
+++ b/boards/daisy_seed/BoardDaisySeed.h
@@ -1,0 +1,26 @@
+/*****************************************************************************
+
+      BoardDaisySeed.h
+      Copyright (c) 2020 Raphael DINGE
+
+*Tab=3***********************************************************************/
+
+
+
+#pragma once
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#if defined (erb_TARGET_DAISY)
+   #include "firmware/BoardDaisySeed.h"
+
+#elif defined (erb_TARGET_VCV_RACK)
+   #include "simulator/BoardDaisySeed.h"
+
+#endif
+
+
+
+/*\\\ EOF \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/boards/daisy_seed/definition.py
+++ b/boards/daisy_seed/definition.py
@@ -9,8 +9,7 @@
 
 {
    'class': 'erb::BoardDaisySeed',
-   'simulator': 'simulator/BoardDaisySeed.h',
-   'firmware': 'firmware/BoardDaisySeed.h',
+   'include': 'BoardDaisySeed.h',
    'pins': {
       'Pin0': {
          'type': 'gpio',

--- a/boards/kivu12/BoardKivu12.h
+++ b/boards/kivu12/BoardKivu12.h
@@ -1,0 +1,26 @@
+/*****************************************************************************
+
+      BoardKivu12.h
+      Copyright (c) 2020 Raphael DINGE
+
+*Tab=3***********************************************************************/
+
+
+
+#pragma once
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#if defined (erb_TARGET_DAISY)
+   #include "firmware/BoardKivu12.h"
+
+#elif defined (erb_TARGET_VCV_RACK)
+   #include "simulator/BoardKivu12.h"
+
+#endif
+
+
+
+/*\\\ EOF \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/boards/kivu12/definition.py
+++ b/boards/kivu12/definition.py
@@ -9,8 +9,7 @@
 
 {
    'class': 'erb::BoardKivu12',
-   'simulator': 'simulator/BoardKivu12.h',
-   'firmware': 'firmware/BoardKivu12.h',
+   'include': 'BoardKivu12.h',
    'hardware': 'hardware/kivu12.kicad_pcb',
    'width': 12, # hp
    'pins': {

--- a/boards/mega/BoardMega.h
+++ b/boards/mega/BoardMega.h
@@ -13,6 +13,10 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
+#if defined (erb_TARGET_DAISY)
+   #error Board mega doesn't support Daisy firmware builds
+#endif
+
 #include "erb/vcvrack/BoardGeneric.h"
 
 

--- a/boards/mega/definition.py
+++ b/boards/mega/definition.py
@@ -8,8 +8,7 @@
 
 {
    'class': 'erb::BoardMega',
-   'simulator': 'simulator/BoardMega.h',
-   'firmware': '',
+   'include': 'BoardMega.h',
    'width': 42, # hp
    'pins': {
       'DII1': {

--- a/build-system/erbui/generators/ui/code.py
+++ b/build-system/erbui/generators/ui/code.py
@@ -39,18 +39,13 @@ class Code:
 
       self._board_definition, self._board_path = self.load_board_definition (module)
       board_class = self._board_definition ['class']
-      board_firmware = self._board_definition ['firmware']
-      board_simulator = self._board_definition ['simulator']
+      board_include = self._board_definition ['include']
 
-      firmware_path = os.path.join (self._board_path, board_firmware)
-      simulator_path = os.path.join (self._board_path, board_simulator)
-
-      firmware_path = os.path.relpath (firmware_path, os.path.dirname (path))
-      simulator_path = os.path.relpath (simulator_path, os.path.dirname (path))
+      include_path = os.path.join (self._board_path, board_include)
+      include_path = os.path.relpath (include_path, os.path.dirname (path))
 
       template = template.replace ('%module.name%', module.name)
-      template = template.replace ('%module.board.firmware.path%', firmware_path)
-      template = template.replace ('%module.board.simulator.path%', simulator_path)
+      template = template.replace ('%module.board.include.path%', include_path)
       template = template.replace ('%type(module.board)%', board_class)
 
       entities_content = self.generate_entities (module.entities)

--- a/build-system/erbui/generators/ui/code_template.h
+++ b/build-system/erbui/generators/ui/code_template.h
@@ -18,14 +18,7 @@
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 #include "erb/erb.h"
-
-#if defined (erb_TARGET_DAISY)
-   #include "%module.board.firmware.path%"
-
-#elif defined (erb_TARGET_VCV_RACK)
-   #include "%module.board.simulator.path%"
-
-#endif
+#include "%module.board.include.path%"
 
 
 


### PR DESCRIPTION
This PR simplifies the board definition by having one include for the board, where the propert target board is loaded using the `erb_TARGET` macro.

This PR is preparation work for the custom board feature.
