### PR TITLE
Fix libxml2-utils_2.9.10+dfsg-5ubuntu0.20.04.1_amd64.deb 404 Not Found

### DIFF
--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+      - run: sudo apt-get update
       - run: sudo apt-get install faust
       - run: python3 build-system/install.py
       - run: erbb setup


### PR DESCRIPTION
This PR fixes `faust` `apt` `install`