### PR TITLE
Board definition pcb

### DIFF
--- a/boards/kivu12/definition.py
+++ b/boards/kivu12/definition.py
@@ -10,7 +10,7 @@
 {
    'class': 'erb::BoardKivu12',
    'include': 'BoardKivu12.h',
-   'hardware': 'hardware/kivu12.kicad_pcb',
+   'pcb': 'hardware/kivu12.kicad_pcb',
    'width': 12, # hp
    'pins': {
 

--- a/build-system/erbui/generators/front_pcb/kicad_pcb.py
+++ b/build-system/erbui/generators/front_pcb/kicad_pcb.py
@@ -46,7 +46,7 @@ class KicadPcb:
 
       if module.board:
          board_definition, board_path = self.load_board_definition (module)
-         pcb_path = os.path.join (board_path, board_definition ['hardware'])
+         pcb_path = os.path.join (board_path, board_definition ['pcb'])
       else:
          pcb_path = os.path.join (PATH_THIS, 'board.null', 'board.null.kicad_pcb')
 


### PR DESCRIPTION
This PR refines the board definition when addressing the pcb by using `pcb` instead of the more generic and less precise `hardware`

This PR is preparation work for the custom board feature.
