### PR TITLE
Add micropatch test to github workflows

### DIFF
--- a/.github/workflows/macos_10_15.yml
+++ b/.github/workflows/macos_10_15.yml
@@ -18,6 +18,9 @@ jobs:
       - run: brew install faust
       - run: python3 build-system/install.py
       - run: erbb setup
+      - name: test/micropatch
+        run: erbb configure && erbb build && erbb build simulator && erbb build simulator_xcode
+        working-directory: test/micropatch
       - name: test/data
         run: erbb configure && erbb build
         working-directory: test/data

--- a/.github/workflows/macos_11.yml
+++ b/.github/workflows/macos_11.yml
@@ -18,6 +18,9 @@ jobs:
       - run: brew install faust
       - run: python3 build-system/install.py
       - run: erbb setup
+      - name: test/micropatch
+        run: erbb configure && erbb build && erbb build simulator && erbb build simulator_xcode
+        working-directory: test/micropatch
       - name: test/data
         run: erbb configure && erbb build
         working-directory: test/data

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -18,6 +18,9 @@ jobs:
       - run: python3 build-system/install.py
       - run: erbb setup
       - run: python build-system/install.py
+      - name: test/micropatch
+        run: erbb configure && erbb build && erbb build simulator
+        working-directory: test/micropatch
       - name: test/data
         run: erbb configure && erbb build && erbb build hardware
         working-directory: test/data

--- a/.github/workflows/windows_2019.yml
+++ b/.github/workflows/windows_2019.yml
@@ -17,6 +17,9 @@ jobs:
           submodules: recursive
       - run: python3 build-system/install.py
       - run: erbb setup
+      - name: test/micropatch
+        run: erbb configure && erbb build && erbb build simulator
+        working-directory: test/micropatch
       - name: test/data
         run: erbb configure && erbb build && erbb build simulator && erbb build hardware
         working-directory: test/data

--- a/test/micropatch/Micropatch.h
+++ b/test/micropatch/Micropatch.h
@@ -17,7 +17,7 @@
 
 /*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-constexpr double pim2 = 2.f * M_PI;
+constexpr double pim2 = 2.0 * M_PI;
 
 class OscSin
 {
@@ -25,7 +25,7 @@ public:
    void           set_freq_norm (float freq_norm)
    {
       float freq = 20.f * std::pow (500.f, std::abs (freq_norm));
-      const double phase_step = pim2 * freq / erb_SAMPLE_RATE;
+      const double phase_step = pim2 * double (freq) / double (erb_SAMPLE_RATE);
       _step_cos = std::cos (phase_step);
       _step_sin = std::sin (phase_step);
    }
@@ -41,11 +41,11 @@ public:
    }
 
 private:
-   double         _step_cos = 1.f;
-   double         _step_sin = 0.f;
+   double         _step_cos = 1.0;
+   double         _step_sin = 0.0;
 
-   double         _pos_cos = 1.f;
-   double         _pos_sin = 0.f;
+   double         _pos_cos = 1.0;
+   double         _pos_sin = 0.0;
 };
 
 


### PR DESCRIPTION
This PR adds the `micropatch` test in the CI tests as:
- It will be used by users, as part of the patch.Init () Electrosmith module,
- It tests a module extending a board
