### PR TITLE
Update xcode syntax highlighters for faust

### DIFF
--- a/build-system/xcode/Erbb.xclangspec
+++ b/build-system/xcode/Erbb.xclangspec
@@ -15,6 +15,7 @@
                 "module", "import", "define", "sources", "file", "resources", "data",
                 "section", "flash", "qspi",
                 "stream", "mono", "interleaved", "planar",
+                "faust", "bind", "address",
                 "use", "strict",
             );
             Type = "xcode.syntax.keyword";

--- a/build-system/xcode/Erbui.xclangspec
+++ b/build-system/xcode/Erbui.xclangspec
@@ -16,6 +16,7 @@
                 "control", "label", "positioning", "sticker", "image", "pin", "pins", "cascade", "mode",
                 "position", "rotation", "offset", "style",
                 "route", "wire", "manual",
+                "faust", "init", "address", "property", "value",
                 "class", "include", "pcb", "bind", "type", "gpio", "pwm", "dac",
             );
             Type = "xcode.syntax.keyword";


### PR DESCRIPTION
This PR updates the Xcode syntax highlighter for the new keywords introduced for Faust.