### PR TITLE
Fix kivu12 board cv out typo

### DIFF
--- a/boards/kivu12/README.md
+++ b/boards/kivu12/README.md
@@ -47,7 +47,7 @@ The Board provide the following features:
 - 8 CV In `CI1..CI8`:
    - Either with ±5V levels,
    - Or 2 (CI1 and CI2) with optional 0..10V levels, selectable with a jumper, to support CV Pitch and ADSR
-- 2 CV Out ±5V `CO1..CO2`,
+- 2 CV Out 0..5V `CO1..CO2`,
 - 2 Audio In ±5V `AI1..AI2`,
 - 2 Audio Out ±5V `AO1..AO2`.
 


### PR DESCRIPTION
This PR fixes a typo in the `kivu12` board README file, where the CV Out voltage level was described as ±5V when it is 0..5V in reality.