### PR TITLE
Erbui enhance pcb component solving

### DIFF
--- a/build-system/erbui/ast.py
+++ b/build-system/erbui/ast.py
@@ -1371,6 +1371,10 @@ class Style (Scope):
 
    @property
    def is_alpha_9mm (self):
+      return self.is_knob and self.parent.kind == 'Pot'
+
+   @property
+   def is_knob (self):
       return self.is_rogan or self.is_sifam
 
    @property

--- a/build-system/erbui/generators/front_pcb/kicad_pcb.py
+++ b/build-system/erbui/generators/front_pcb/kicad_pcb.py
@@ -205,14 +205,14 @@ class KicadPcb:
             parts [part_name] = 1
 
       for control in module.controls:
-         style_name = control.style.name
-         inc_part (style_name)
-         if style_name.startswith ('rogan.'):
+         inc_part (control.style.name)
+
+         if control.style.is_alpha_9mm:
             inc_part ('alpha.9mm')
-         elif style_name.startswith ('thonk.pj398sm.'):
+         elif control.style.is_thonk_pj398sm:
             inc_part ('thonk.pj398sm')
-         elif style_name == 'tl1105':
-            inc_part ('1rblk')
+         elif control.style.is_tl1105:
+            inc_part ('1rblk') # button cap
 
       bom = 'Description;Quantity;Distributor;Distributor Part Nbr;Distributor Link\n'
 


### PR DESCRIPTION
This PR enhances the choice of the PCB component based on the control style, by using the control kind instead of the style name alone.

This PR is preparation work for the upcoming encoder support.
