### PR TITLE
Use scope add instead of entities append, to provide proper parenting

### DIFF
--- a/build-system/erbui/analyser.py
+++ b/build-system/erbui/analyser.py
@@ -119,7 +119,7 @@ class Analyser:
 
       entities = [e for e in module.entities if e.is_width]
       if len (entities) == 0:
-         module.entities.append (module.board.width)
+         module.add (module.board.width)
 
 
    #--------------------------------------------------------------------------
@@ -252,7 +252,7 @@ class Analyser:
       cascade_from = ast.CascadeFrom ()
       cascade_from.reference = control_from
       cascade_from.index = self._cascade_index
-      control.entities.append (cascade_from)
+      control.add (cascade_from)
       self._cascade_index += 1
 
 
@@ -428,7 +428,7 @@ class Analyser:
             pool_pin.mark_unavailable ()
             pin_identifier = pool_pin.identifier
             pin = ast.Pin (pin_identifier)
-            control.entities.append (pin)
+            control.add (pin)
 
       elif control.is_pin_multiple:
          pin_arrays = [e for e in control.entities if e.is_pin_array]
@@ -447,7 +447,7 @@ class Analyser:
                identifiers.append (pin_identifier)
 
             pin_array = ast.Pins (identifiers)
-            control.entities.append (pin_array)
+            control.add (pin_array)
 
 
    #--------------------------------------------------------------------------

--- a/build-system/erbui/tests/test_analyser.py
+++ b/build-system/erbui/tests/test_analyser.py
@@ -35,7 +35,7 @@ class TestAnalyser (unittest.TestCase):
          mock.identifier ('cv_in1'),
          mock.keyword ('CvIn')
       )
-      module.entities.append (control)
+      module.add (control)
 
       analyser = Analyser ()
       analyser.make_cascade_eval_list (module)
@@ -52,14 +52,14 @@ class TestAnalyser (unittest.TestCase):
          mock.keyword ('CvIn')
       )
       cascade_to = ast.CascadeTo (mock.identifier ('cv_in2'))
-      control.entities.append (cascade_to)
-      module.entities.append (control)
+      control.add (cascade_to)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('cv_in2'),
          mock.keyword ('CvIn')
       )
-      module.entities.append (control)
+      module.add (control)
 
       analyser = Analyser ()
       for control in module.controls:
@@ -80,15 +80,15 @@ class TestAnalyser (unittest.TestCase):
          mock.identifier ('cv_in2'),
          mock.keyword ('CvIn')
       )
-      module.entities.append (control)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('cv_in1'),
          mock.keyword ('CvIn')
       )
       cascade_to = ast.CascadeTo (mock.identifier ('cv_in2'))
-      control.entities.append (cascade_to)
-      module.entities.append (control)
+      control.add (cascade_to)
+      module.add (control)
 
       analyser = Analyser ()
       for control in module.controls:
@@ -110,30 +110,30 @@ class TestAnalyser (unittest.TestCase):
          mock.keyword ('CvIn')
       )
       cascade_to = ast.CascadeTo (mock.identifier ('cv_in2'))
-      control.entities.append (cascade_to)
-      module.entities.append (control)
+      control.add (cascade_to)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('cv_in2'),
          mock.keyword ('CvIn')
       )
       cascade_to = ast.CascadeTo (mock.identifier ('cv_in3'))
-      control.entities.append (cascade_to)
-      module.entities.append (control)
+      control.add (cascade_to)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('cv_in3'),
          mock.keyword ('CvIn')
       )
       cascade_to = ast.CascadeTo (mock.identifier ('cv_in4'))
-      control.entities.append (cascade_to)
-      module.entities.append (control)
+      control.add (cascade_to)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('cv_in4'),
          mock.keyword ('CvIn')
       )
-      module.entities.append (control)
+      module.add (control)
 
       analyser = Analyser ()
       for control in module.controls:
@@ -156,31 +156,31 @@ class TestAnalyser (unittest.TestCase):
          mock.identifier ('cv_in4'),
          mock.keyword ('CvIn')
       )
-      module.entities.append (control)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('cv_in3'),
          mock.keyword ('CvIn')
       )
       cascade_to = ast.CascadeTo (mock.identifier ('cv_in4'))
-      control.entities.append (cascade_to)
-      module.entities.append (control)
+      control.add (cascade_to)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('cv_in2'),
          mock.keyword ('CvIn')
       )
       cascade_to = ast.CascadeTo (mock.identifier ('cv_in3'))
-      control.entities.append (cascade_to)
-      module.entities.append (control)
+      control.add (cascade_to)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('cv_in1'),
          mock.keyword ('CvIn')
       )
       cascade_to = ast.CascadeTo (mock.identifier ('cv_in2'))
-      control.entities.append (cascade_to)
-      module.entities.append (control)
+      control.add (cascade_to)
+      module.add (control)
 
       analyser = Analyser ()
       for control in module.controls:
@@ -204,30 +204,30 @@ class TestAnalyser (unittest.TestCase):
          mock.keyword ('CvIn')
       )
       cascade_to = ast.CascadeTo (mock.identifier ('cv_in4'))
-      control.entities.append (cascade_to)
-      module.entities.append (control)
+      control.add (cascade_to)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('cv_in2'),
          mock.keyword ('CvIn')
       )
       cascade_to = ast.CascadeTo (mock.identifier ('cv_in3'))
-      control.entities.append (cascade_to)
-      module.entities.append (control)
+      control.add (cascade_to)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('cv_in4'),
          mock.keyword ('CvIn')
       )
-      module.entities.append (control)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('cv_in1'),
          mock.keyword ('CvIn')
       )
       cascade_to = ast.CascadeTo (mock.identifier ('cv_in2'))
-      control.entities.append (cascade_to)
-      module.entities.append (control)
+      control.add (cascade_to)
+      module.add (control)
 
       analyser = Analyser ()
       for control in module.controls:

--- a/build-system/erbui/tests/test_generator_front_pcb.py
+++ b/build-system/erbui/tests/test_generator_front_pcb.py
@@ -71,8 +71,8 @@ class TestGeneratorFrontPcb (unittest.TestCase):
 
    def test_003 (self):
       module = ast.Module (mock.identifier ('test_generator_front_pcb_003'), None)
-      module.entities.append (ast.Width (ast.DistanceLiteral (mock.literal ('10hp'), 'hp')))
-      module.entities.append (ast.Board (mock.identifier ("kivu12")))
+      module.add (ast.Width (ast.DistanceLiteral (mock.literal ('10hp'), 'hp')))
+      module.add (ast.Board (mock.identifier ("kivu12")))
 
       control = ast.Control (
          mock.identifier ('test'),
@@ -82,12 +82,12 @@ class TestGeneratorFrontPcb (unittest.TestCase):
          ast.DistanceLiteral (mock.literal ('5hp'), 'hp'),
          ast.DistanceLiteral (mock.literal ('32mm'), 'mm'),
       )
-      control.entities.append (position)
+      control.add (position)
       style = ast.Style (mock.keyword ('songhuei.9mm'))
-      control.entities.append (style)
+      control.add (style)
       pin = ast.Pin (mock.identifier ('P1'))
-      control.entities.append (pin)
-      module.entities.append (control)
+      control.add (pin)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('test'),
@@ -97,12 +97,12 @@ class TestGeneratorFrontPcb (unittest.TestCase):
          ast.DistanceLiteral (mock.literal ('5hp'), 'hp'),
          ast.DistanceLiteral (mock.literal ('64mm'), 'mm'),
       )
-      control.entities.append (position)
+      control.add (position)
       style = ast.Style (mock.keyword ('rogan.6ps'))
-      control.entities.append (style)
+      control.add (style)
       pin = ast.Pin (mock.identifier ('P2'))
-      control.entities.append (pin)
-      module.entities.append (control)
+      control.add (pin)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('test'),
@@ -112,12 +112,12 @@ class TestGeneratorFrontPcb (unittest.TestCase):
          ast.DistanceLiteral (mock.literal ('5hp'), 'hp'),
          ast.DistanceLiteral (mock.literal ('96mm'), 'mm'),
       )
-      control.entities.append (position)
+      control.add (position)
       style = ast.Style (mock.keyword ('thonk.pj398sm.hex'))
-      control.entities.append (style)
+      control.add (style)
       pin = ast.Pin (mock.identifier ('CI1'))
-      control.entities.append (pin)
-      module.entities.append (control)
+      control.add (pin)
+      module.add (control)
 
       module.board.load_builtin ()
 

--- a/build-system/erbui/tests/test_generators.py
+++ b/build-system/erbui/tests/test_generators.py
@@ -36,49 +36,49 @@ class TestGenerators (unittest.TestCase):
       global_namespace = ast.GlobalNamespace ()
 
       module = ast.Module (mock.identifier ('Test'), None)
-      module.entities.append (ast.Width (ast.DistanceLiteral (mock.literal ('10hp'), 'hp')))
-      module.entities.append (ast.Material (mock.keyword ('aluminum'), None))
+      module.add (ast.Width (ast.DistanceLiteral (mock.literal ('10hp'), 'hp')))
+      module.add (ast.Material (mock.keyword ('aluminum'), None))
 
       header = ast.Header ()
       label = ast.Label (ast.StringLiteral (mock.literal ('Test Header')))
-      header.entities.append (label)
-      module.entities.append (header)
+      header.add (label)
+      module.add (header)
 
       footer = ast.Footer ()
       label = ast.Label (ast.StringLiteral (mock.literal ('Test Footer')))
-      footer.entities.append (label)
-      module.entities.append (footer)
+      footer.add (label)
+      module.add (footer)
 
       label = ast.Label (ast.StringLiteral (mock.literal ('Test Module Center')))
       positioning = ast.Positioning (mock.keyword ('center'))
-      label.entities.append (positioning)
-      module.entities.append (label)
+      label.add (positioning)
+      module.add (label)
 
       line = ast.Line ()
       position = ast.Position (
          ast.DistanceLiteral (mock.literal ('0mm'), 'mm'),
          ast.DistanceLiteral (mock.literal ('1mm'), 'mm'),
       )
-      line.entities.append (position)
+      line.add (position)
       position = ast.Position (
          ast.DistanceLiteral (mock.literal ('2mm'), 'mm'),
          ast.DistanceLiteral (mock.literal ('3mm'), 'mm'),
       )
-      line.entities.append (position)
-      module.entities.append (line)
+      line.add (position)
+      module.add (line)
 
       line = ast.Line ()
       position = ast.Position (
          ast.DistanceLiteral (mock.literal ('4.5mm'), 'mm'),
          ast.DistanceLiteral (mock.literal ('5.6mm'), 'mm'),
       )
-      line.entities.append (position)
+      line.add (position)
       position = ast.Position (
          ast.DistanceLiteral (mock.literal ('1hp'), 'hp'),
          ast.DistanceLiteral (mock.literal ('-8.0mm'), 'mm'),
       )
-      line.entities.append (position)
-      module.entities.append (line)
+      line.add (position)
+      module.add (line)
 
       control = ast.Control (
          mock.identifier ('test'),
@@ -89,37 +89,37 @@ class TestGenerators (unittest.TestCase):
          ast.DistanceLiteral (mock.literal ('10.2mm'), 'mm'),
          ast.DistanceLiteral (mock.literal ('10.3mm'), 'mm'),
       )
-      control.entities.append (position)
+      control.add (position)
 
       style = ast.Style (mock.keyword ('rogan.6ps'))
-      control.entities.append (style)
+      control.add (style)
 
       label = ast.Label (ast.StringLiteral (mock.literal ('Test Center')))
       positioning = ast.Positioning (mock.keyword ('center'))
-      label.entities.append (positioning)
-      control.entities.append (label)
+      label.add (positioning)
+      control.add (label)
 
       label = ast.Label (ast.StringLiteral (mock.literal ('Test Left')))
       positioning = ast.Positioning (mock.keyword ('left'))
-      label.entities.append (positioning)
-      control.entities.append (label)
+      label.add (positioning)
+      control.add (label)
 
       label = ast.Label (ast.StringLiteral (mock.literal ('Test Top')))
       positioning = ast.Positioning (mock.keyword ('top'))
-      label.entities.append (positioning)
-      control.entities.append (label)
+      label.add (positioning)
+      control.add (label)
 
       label = ast.Label (ast.StringLiteral (mock.literal ('Test Right')))
       positioning = ast.Positioning (mock.keyword ('right'))
-      label.entities.append (positioning)
-      control.entities.append (label)
+      label.add (positioning)
+      control.add (label)
 
       label = ast.Label (ast.StringLiteral (mock.literal ('Test Bottom')))
       positioning = ast.Positioning (mock.keyword ('bottom'))
-      label.entities.append (positioning)
-      control.entities.append (label)
+      label.add (positioning)
+      control.add (label)
 
-      module.entities.append (control)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('switch1'),
@@ -130,15 +130,15 @@ class TestGenerators (unittest.TestCase):
          ast.DistanceLiteral (mock.literal ('1.0mm'), 'mm'),
          ast.DistanceLiteral (mock.literal ('2.0mm'), 'mm'),
       )
-      control.entities.append (position)
+      control.add (position)
 
       style = ast.Style (mock.keyword ('dailywell.2ms1'))
-      control.entities.append (style)
+      control.add (style)
 
       rotation = ast.Rotation (ast.RotationLiteral (mock.literal ('90°ccw'), '°ccw'))
-      control.entities.append (rotation)
+      control.add (rotation)
 
-      module.entities.append (control)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('switch2'),
@@ -149,15 +149,15 @@ class TestGenerators (unittest.TestCase):
          ast.DistanceLiteral (mock.literal ('3.0mm'), 'mm'),
          ast.DistanceLiteral (mock.literal ('4.0mm'), 'mm'),
       )
-      control.entities.append (position)
+      control.add (position)
 
       style = ast.Style (mock.keyword ('dailywell.2ms3'))
-      control.entities.append (style)
+      control.add (style)
 
       rotation = ast.Rotation (ast.RotationLiteral (mock.literal ('90°cw'), '°cw'))
-      control.entities.append (rotation)
+      control.add (rotation)
 
-      module.entities.append (control)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('switch3'),
@@ -168,15 +168,15 @@ class TestGenerators (unittest.TestCase):
          ast.DistanceLiteral (mock.literal ('5.0mm'), 'mm'),
          ast.DistanceLiteral (mock.literal ('1hp'), 'hp'),
       )
-      control.entities.append (position)
+      control.add (position)
 
       style = ast.Style (mock.keyword ('dailywell.2ms3'))
-      control.entities.append (style)
+      control.add (style)
 
       rotation = ast.Rotation (ast.RotationLiteral (mock.literal ('180°'), '°'))
-      control.entities.append (rotation)
+      control.add (rotation)
 
-      module.entities.append (control)
+      module.add (control)
 
       control = ast.Control (
          mock.identifier ('gate_out'),
@@ -187,73 +187,75 @@ class TestGenerators (unittest.TestCase):
          ast.DistanceLiteral (mock.literal ('10.00mm'), 'mm'),
          ast.DistanceLiteral (mock.literal ('50.01mm'), 'mm'),
       )
-      control.entities.append (position)
+      control.add (position)
 
       style = ast.Style (mock.keyword ('thonk.pj398sm.knurled'))
-      control.entities.append (style)
+      control.add (style)
 
       label = ast.Label (ast.StringLiteral (mock.literal ('OUT')))
       positioning = ast.Positioning (mock.keyword ('top'))
-      label.entities.append (positioning)
-      control.entities.append (label)
+      label.add (positioning)
+      control.add (label)
 
-      module.entities.append (control)
+      module.add (control)
 
-      global_namespace.entities.append (module)
+      global_namespace.add (module)
       return global_namespace
 
 
    def make_ast_002 (self):
       global_namespace = self.make_ast_001 ()
-      entities = global_namespace.modules [0].entities
-      entities = [entity for entity in entities if not entity.is_material]
-      entities.append (ast.Material (mock.keyword ('aluminum'), mock.keyword ('black')))
+      module = global_namespace.modules [0]
+      module.entities = [entity for entity in module.entities if not entity.is_material]
+      module.add (ast.Material (mock.keyword ('aluminum'), mock.keyword ('black')))
       return global_namespace
 
 
    def make_ast_003 (self):
       global_namespace = self.make_ast_001 ()
-      entities = global_namespace.modules [0].entities
-      entities = [entity for entity in entities if not entity.is_material]
-      entities.append (ast.Material (mock.keyword ('brushed_aluminum'), None))
+      module = global_namespace.modules [0]
+      module.entities = [entity for entity in module.entities if not entity.is_material]
+      module.add (ast.Material (mock.keyword ('brushed_aluminum'), None))
       return global_namespace
 
 
    def make_ast_004 (self):
       global_namespace = self.make_ast_001 ()
-      entities = global_namespace.modules [0].entities
-      entities = [entity for entity in entities if not entity.is_material]
-      entities.append (ast.Material (mock.keyword ('brushed_aluminum'), mock.keyword ('black')))
+      module = global_namespace.modules [0]
+      module.entities = [entity for entity in module.entities if not entity.is_material]
+      module.add (ast.Material (mock.keyword ('brushed_aluminum'), mock.keyword ('black')))
       return global_namespace
 
 
    def make_ast_005 (self):
       global_namespace = self.make_ast_001 ()
-      entities = global_namespace.modules [0].entities
-      entities = [entity for entity in entities if not entity.is_material]
-      entities.append (ast.Material (mock.keyword ('aluminum_coated'), mock.keyword ('white')))
+      module = global_namespace.modules [0]
+      module.entities = [entity for entity in module.entities if not entity.is_material]
+      module.add (ast.Material (mock.keyword ('aluminum_coated'), mock.keyword ('white')))
       return global_namespace
 
 
    def make_ast_006 (self):
       global_namespace = self.make_ast_001 ()
-      entities = global_namespace.modules [0].entities
-      entities = [entity for entity in entities if not entity.is_material]
-      entities.append (ast.Material (mock.keyword ('aluminum_coated'), mock.keyword ('black')))
+      module = global_namespace.modules [0]
+      module.entities = [entity for entity in module.entities if not entity.is_material]
+      module.add (ast.Material (mock.keyword ('aluminum_coated'), mock.keyword ('black')))
       return global_namespace
 
 
    def make_ast_007 (self):
       global_namespace = self.make_ast_001 ()
       entities = global_namespace.modules [0].entities
-      entities = [entity for entity in entities if not entity.is_footer]
+      module = global_namespace.modules [0]
+      module.entities = [entity for entity in module.entities if not entity.is_footer]
       return global_namespace
 
 
    def make_ast_008 (self):
       global_namespace = self.make_ast_002 ()
       entities = global_namespace.modules [0].entities
-      entities = [entity for entity in entities if not entity.is_footer]
+      module = global_namespace.modules [0]
+      module.entities = [entity for entity in module.entities if not entity.is_footer]
       return global_namespace
 
 


### PR DESCRIPTION
This PR fixes the test fixes, by using the proper scope `add` rather than manipulating directly scope `entities`.

This PR is preparation work for the upcoming PCB component enhanced solving, which relies on proper element parenting.
