### PR TITLE
Add alpha pot base and knob traits

### DIFF
--- a/build-system/erbui/generators/vcvrack/code.py
+++ b/build-system/erbui/generators/vcvrack/code.py
@@ -215,14 +215,14 @@ class Code:
 
    def control_style_to_widget (self, control):
       style_widget_map = {
-         'rogan.6ps': 'erb::Rogan6Ps',
-         'rogan.5ps': 'erb::Rogan5Ps',
-         'rogan.3ps': 'erb::Rogan3Ps',
-         'rogan.2ps': 'erb::Rogan2Ps',
-         'rogan.1ps': 'erb::Rogan1Ps',
+         'rogan.6ps': 'erb::AlphaPot <erb::Rogan6Ps>',
+         'rogan.5ps': 'erb::AlphaPot <erb::Rogan5Ps>',
+         'rogan.3ps': 'erb::AlphaPot <erb::Rogan3Ps>',
+         'rogan.2ps': 'erb::AlphaPot <erb::Rogan2Ps>',
+         'rogan.1ps': 'erb::AlphaPot <erb::Rogan1Ps>',
          'songhuei.9mm': 'erb::SongHuei9',
-         'sifam.drn111.white': 'erb::SifamDrn111',
-         'sifam.dbn151.white': 'erb::SifamDbn151',
+         'sifam.drn111.white': 'erb::AlphaPot <erb::SifamDrn111>',
+         'sifam.dbn151.white': 'erb::AlphaPot <erb::SifamDbn151>',
          'dailywell.2ms1': 'erb::Dailywell2Ms1',
          'dailywell.2ms3': 'erb::Dailywell2Ms3',
          'led.3mm.red': 'MediumLight <RedLight>',

--- a/include/erb/vcvrack/VcvWidgets.h
+++ b/include/erb/vcvrack/VcvWidgets.h
@@ -30,86 +30,44 @@ namespace erb
 
 
 
-struct Rogan6Ps : rack::Rogan
-{
-   Rogan6Ps () {
+template <typename KnobTrait>
+struct AlphaPot: rack::app::SvgKnob {
+   AlphaPot() {
+      minAngle = -0.83f * float (M_PI);
+      maxAngle = 0.83f * float (M_PI);
       shadow->blurRadius = 5;
       setSvg (APP->window->loadSvg (
-         rack::asset::plugin (plugin_instance, "res/rogan.6ps.svg")
+         rack::asset::plugin (plugin_instance, KnobTrait::resource_0)
       ));
    }
 };
 
-
-
-struct Rogan5Ps : rack::Rogan
-{
-   Rogan5Ps () {
-      shadow->blurRadius = 5;
-      setSvg (APP->window->loadSvg (
-         rack::asset::plugin (plugin_instance, "res/rogan.5ps.svg")
-      ));
-   }
+struct Rogan6Ps {
+   static constexpr const char * resource_0 = "res/rogan.6ps.svg";
 };
 
-
-
-struct Rogan3Ps : rack::Rogan
-{
-   Rogan3Ps () {
-      shadow->blurRadius = 5;
-      setSvg (APP->window->loadSvg (
-         rack::asset::plugin (plugin_instance, "res/rogan.3ps.svg")
-      ));
-   }
+struct Rogan5Ps {
+   static constexpr const char * resource_0 = "res/rogan.5ps.svg";
 };
 
-
-
-struct Rogan2Ps : rack::Rogan
-{
-   Rogan2Ps () {
-      shadow->blurRadius = 5;
-      setSvg (APP->window->loadSvg (
-         rack::asset::plugin (plugin_instance, "res/rogan.2ps.svg")
-      ));
-   }
+struct Rogan3Ps {
+   static constexpr const char * resource_0 = "res/rogan.3ps.svg";
 };
 
-
-
-struct Rogan1Ps : rack::Rogan
-{
-   Rogan1Ps () {
-      shadow->blurRadius = 5;
-      setSvg (APP->window->loadSvg (
-         rack::asset::plugin (plugin_instance, "res/rogan.1ps.svg")
-      ));
-   }
+struct Rogan2Ps {
+   static constexpr const char * resource_0 = "res/rogan.2ps.svg";
 };
 
-
-
-struct SifamDbn151 : rack::Rogan
-{
-   SifamDbn151 () {
-      shadow->blurRadius = 5;
-      setSvg (APP->window->loadSvg (
-         rack::asset::plugin (plugin_instance, "res/sifam.dbn151.white.svg")
-      ));
-   }
+struct Rogan1Ps {
+   static constexpr const char * resource_0 = "res/rogan.1ps.svg";
 };
 
+struct SifamDbn151 {
+   static constexpr const char * resource_0 = "res/sifam.dbn151.white.svg";
+};
 
-
-struct SifamDrn111 : rack::Rogan
-{
-   SifamDrn111 () {
-      shadow->blurRadius = 5;
-      setSvg (APP->window->loadSvg (
-         rack::asset::plugin (plugin_instance, "res/sifam.drn111.white.svg")
-      ));
-   }
+struct SifamDrn111 {
+   static constexpr const char * resource_0 = "res/sifam.drn111.white.svg";
 };
 
 


### PR DESCRIPTION
This PR adds the base Alpha pot template structure, and pass the knob type as a trait.
This allows multiple components to use the same knobs. 

This PR is preparation work for the upcoming encoder support.
