### PR TITLE
Erbui front pcb merge

### DIFF
--- a/build-system/erbui/ast.py
+++ b/build-system/erbui/ast.py
@@ -918,8 +918,8 @@ class Route (Node):
    def mode (self): return self.keyword_mode.value
 
    @property
-   def is_auto (self):
-      return self.mode == 'auto'
+   def is_manual (self):
+      return self.mode == 'manual'
 
    @property
    def is_wire (self):


### PR DESCRIPTION
This PR allows iterative routing when changing the `erbui` file (eg. for pin swapping or manufacturer change) without having to re-route the entire PCB. It does so by replacing components only when the `kicad_pcb` file already exists. 
