### PR TITLE
Modify gitmodules to allow anonymous git clone

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "submodules/kcgen"]
 	path = submodules/kcgen
-	url = git@github.com:ohmtech/kcgen.git
+	url = https://github.com/ohmtech/kcgen.git
 [submodule "submodules/kicad-libs"]
 	path = submodules/kicad-libs
-	url = git@github.com:ohmtech/kicad-libs.git
+	url = https://github.com/ohmtech/kicad-libs.git
 [submodule "submodules/libDaisy"]
 	path = submodules/libDaisy
-	url = git@github.com:electro-smith/libDaisy.git
+	url = https://github.com/electro-smith/libDaisy.git
 [submodule "submodules/vcv-rack-sdk"]
 	path = submodules/vcv-rack-sdk
-	url = git@github.com:ohmtech-rdi/vcv-rack-sdk.git
+	url = https://github.com/ohmtech-rdi/vcv-rack-sdk.git
 [submodule "submodules/gyp-next"]
 	path = submodules/gyp-next
 	url = https://github.com/nodejs/gyp-next.git


### PR DESCRIPTION
Reduce the barriers to new users unfamiliar with `git` and remove GitHub account requirement.

```
git clone --recurse-submodules https://github.com/ohmtech-rdi/eurorack-blocks.git
```

This can be used on a machine without any GitHub account credentials by users simply wanting to clone and play with the code, provided that submodules are specified as `https://` rather than `git@`

If a user has multiple machines, they may not have (or want all of them to have) GitHub account credentials configured just to clone software to look at and play with.

⚠️ Users who cloned previously the repository when submodules were using the SSH protocol instead of the HTTPS one, can just delete their local copy and clone again with the updated URL (make sure you don't have any local work before doing so!)

⚠️ Developers who cloned previously the repository when submodules were using the SSH protocol instead of the HTTPS one, need to execute the following commands in the repository:

```shell
# Synchronizes submodules' remote URL configuration setting to the value
# specified in .gitmodules.

git submodule sync

# Update the registered submodules to match what the superproject expects.
# You might get an error like "Unable to find current xx/yy revision in submodule path zz"

git submodule update --init --recursive --remote

# Pull submodules

git pull --recurse-submodules
```
