### PR TITLE
Fix attr import error by updating myst-parser to 0.17.2

### DIFF
--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -18,4 +18,4 @@ sphinx-notfound-page==0.8
 sphinx-autobuild==2021.3.14
 
 # Markdown
-myst_parser==0.16.1
+myst_parser==0.17.2


### PR DESCRIPTION
This PR fixes the documentation build:

```
Running Sphinx v4.3.2
loading translations [en]... done

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/eurorack-blocks/envs/latest/lib/python3.8/site-packages/sphinx/cmd/build.py", line 276, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/docs/checkouts/readthedocs.org/user_builds/eurorack-blocks/envs/latest/lib/python3.8/site-packages/sphinx/application.py", line 237, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/eurorack-blocks/envs/latest/lib/python3.8/site-packages/sphinx/application.py", line 394, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/eurorack-blocks/envs/latest/lib/python3.8/site-packages/sphinx/registry.py", line 442, in load_extension
    metadata = setup(app)
  File "/home/docs/checkouts/readthedocs.org/user_builds/eurorack-blocks/envs/latest/lib/python3.8/site-packages/myst_parser/__init__.py", line 12, in setup
    from myst_parser.sphinx_parser import MystParser
  File "/home/docs/checkouts/readthedocs.org/user_builds/eurorack-blocks/envs/latest/lib/python3.8/site-packages/myst_parser/sphinx_parser.py", line 15, in <module>
    from myst_parser.main import default_parser
  File "/home/docs/checkouts/readthedocs.org/user_builds/eurorack-blocks/envs/latest/lib/python3.8/site-packages/myst_parser/main.py", line 3, in <module>
    import attr
ModuleNotFoundError: No module named 'attr'

Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/eurorack-blocks/envs/latest/lib/python3.8/site-packages/myst_parser/main.py", line 3, in <module>
    import attr
ModuleNotFoundError: No module named 'attr'
The full traceback has been saved in /tmp/sphinx-err-4yk07jw5.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```

By upgrading `myst-parser` to version 0.17.2, which doesn't rely on `attr` anymore.

This is very unclear why the build suddenly broke (given our `pip` `requirements.txt` file).