### PR TITLE
Fix erbb error parsing

### DIFF
--- a/build-system/erbb/error.py
+++ b/build-system/erbb/error.py
@@ -258,8 +258,6 @@ class ParseError (Error):
                expected ['keywords'].append ("'{}'".format (rule_name))
             elif rule_name in grammar.CONTROL_KINDS:
                expected ['control_kinds'].append ("'{}'".format (rule_name))
-            elif rule_name in grammar.CONTROL_STYLES:
-               expected ['control_styles'].append ("'{}'".format (rule_name))
             elif rule_name in grammar.SYMBOLS:
                expected ['symbols'].append ("'{}'".format (rule_name))
             else:


### PR DESCRIPTION
This PR fixes `erbb` error parsing, which doesn't have the concept of control styles. This is most likely due a wrong copy/paste.
