### PR TITLE
Pin brew faust version

### DIFF
--- a/.github/workflows/macos_10_15.yml
+++ b/.github/workflows/macos_10_15.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: brew install faust
+      - run: brew install faust@2.37.3
       - run: python3 build-system/install.py
       - run: erbb setup
       - name: test/micropatch
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: brew install faust
+      - run: brew install faust@2.37.3
       - run: python3 build-system/install.py
       - run: erbb setup
       - name: samples/faust

--- a/.github/workflows/macos_11.yml
+++ b/.github/workflows/macos_11.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: brew install faust
+      - run: brew install faust@2.37.3
       - run: python3 build-system/install.py
       - run: erbb setup
       - name: test/micropatch
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: brew install faust
+      - run: brew install faust@2.37.3
       - run: python3 build-system/install.py
       - run: erbb setup
       - name: samples/faust


### PR DESCRIPTION
This PR fixes a problem where the `brew` `faust` version was not pinned, so that the same build could emit an error if the code is incompatible. This happened with 2.40.0 which modifies the `dsp_memory_manager` interface. 
