### PR TITLE
Add stub for faust 2.40.0 new dsp memory manager usage functions

### DIFF
--- a/build-system/erbb/generators/faust/code_template.h
+++ b/build-system/erbb/generators/faust/code_template.h
@@ -97,6 +97,10 @@ struct dsp_memory_manager
 {
    ~dsp_memory_manager () = default;
 
+   inline void     begin (size_t) {}
+   inline void     info (size_t, size_t, size_t) {}
+   inline void     end () {}
+
    inline void *   allocate (size_t size);
    inline void     destroy (void * ptr);
 };


### PR DESCRIPTION
This PR adds Faust 2.40.0 support with stubs, for the new `dsp_memory_manager` functions.

This fixes the current problem on CI where Faust targets can't build on macOS, but we can't pin the installed Faust brew version either.