### PR TITLE
Use control kind instead of style for default label positioning

### DIFF
--- a/build-system/erbui/generators/detail/panel.py
+++ b/build-system/erbui/generators/detail/panel.py
@@ -361,7 +361,7 @@ class Panel:
          align_y = 0.5
 
       elif label.positioning is None:
-         if control.style.is_thonk_pj398sm: # top
+         if control.kind in ['AudioIn', 'AudioOut', 'CvIn', 'CvOut', 'GateIn', 'GateOut']: # top
             position_y -= self.current_box.top + self.positioning_margin
             align_x = 0.5
             align_y = 0


### PR DESCRIPTION
This PR uses `Control` `kind` instead of `style` to figure out default label positioning, to move as much as possible style knowledge from the generators.

This PR is preparation work for the upcoming manufacturer and semantic style features.
