### PR TITLE
Param range norm bipolar discrete

### DIFF
--- a/build-system/erbui/generators/vcvrack/code.py
+++ b/build-system/erbui/generators/vcvrack/code.py
@@ -62,16 +62,9 @@ class Code:
             category = self.control_kind_to_vcv_category (control)
 
             if category == 'Param':
-               if control.mode is not None and control.mode.is_bipolar:
-                  min_val = -1
-               else:
-                  min_val = 0
-
-               max_val = 2 if control.style.is_dailywell_2ms3 else 1
-
                control.vcv_param_index = nbr_params
                controls_bind_config += '   module.ui.board.impl_bind (module.ui.%s, %s [%d]);\n' % (control.name, 'params', nbr_params)
-               controls_bind_config += '   configParam (%d, %f, %f, 0.f);\n\n' % (nbr_params, min_val, max_val)
+               controls_bind_config += '   configParam (%d, decltype (module.ui.%s)::ValueMin, decltype (module.ui.%s)::ValueMax, 0.f);\n\n' % (nbr_params, control.name, control.name)
                nbr_params += 1
 
             elif category == 'Input':

--- a/include/erb/AudioIn.h
+++ b/include/erb/AudioIn.h
@@ -30,6 +30,9 @@ class AudioIn
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
+   static constexpr float ValueMin = -1.f;
+   static constexpr float ValueMax = 1.f;
+
    inline         AudioIn (const Buffer & data);
    virtual        ~AudioIn () = default;
 

--- a/include/erb/AudioOut.h
+++ b/include/erb/AudioOut.h
@@ -30,6 +30,9 @@ class AudioOut
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
+   static constexpr float ValueMin = -1.f;
+   static constexpr float ValueMax = 1.f;
+
    inline         AudioOut (Buffer & data);
    virtual        ~AudioOut () = default;
 

--- a/include/erb/Button.h
+++ b/include/erb/Button.h
@@ -28,6 +28,9 @@ class Button
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
+   static constexpr float ValueMin = 0.f;
+   static constexpr float ValueMax = 1.f;
+
    inline         Button (const uint8_t & data);
    virtual        ~Button () = default;
 

--- a/include/erb/CvIn.h
+++ b/include/erb/CvIn.h
@@ -31,6 +31,8 @@ class CvIn
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
+   static constexpr float ValueMin = FloatRangeTrait <Range>::Min;
+   static constexpr float ValueMax = FloatRangeTrait <Range>::Max;
 
    inline         CvIn (const float & data);
    virtual        ~CvIn () = default;

--- a/include/erb/CvOut.h
+++ b/include/erb/CvOut.h
@@ -29,6 +29,9 @@ class CvOut
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
+   static constexpr float ValueMin = FloatRangeTrait <Range>::Min;
+   static constexpr float ValueMax = FloatRangeTrait <Range>::Max;
+
                   CvOut (float & data);
    virtual        ~CvOut () = default;
 

--- a/include/erb/FloatRange.h
+++ b/include/erb/FloatRange.h
@@ -29,6 +29,46 @@ enum class FloatRange
 };
 
 
+template <FloatRange>
+struct FloatRangeTrait
+{
+};
+
+
+template <>
+struct FloatRangeTrait <FloatRange::Normalized>
+{
+   static constexpr float Min = 0.f;
+   static constexpr float Max = 1.f;
+};
+
+
+template <>
+struct FloatRangeTrait <FloatRange::Bipolar>
+{
+   static constexpr float Min = -1.f;
+   static constexpr float Max = 1.f;
+};
+
+
+template <>
+struct FloatRangeTrait <FloatRange::Pitch>
+{
+   static constexpr float Min = 0.f;
+   static constexpr float Max = 10.f;
+};
+
+
+template <>
+struct FloatRangeTrait <FloatRange::Adsr>
+{
+   static constexpr float Min = 0.f;
+   static constexpr float Max = 1.f;
+};
+
+
+
+
 
 }  // namespace erb
 

--- a/include/erb/GateIn.h
+++ b/include/erb/GateIn.h
@@ -28,6 +28,8 @@ class GateIn
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
+   static constexpr float ValueMin = 0.f;
+   static constexpr float ValueMax = 1.f;
 
    inline         GateIn (const uint8_t & data);
    virtual        ~GateIn () = default;

--- a/include/erb/GateOut.h
+++ b/include/erb/GateOut.h
@@ -34,6 +34,9 @@ class GateOut
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
+   static constexpr float ValueMin = 0.f;
+   static constexpr float ValueMax = 1.f;
+
                   GateOut (uint8_t & data, const uint64_t & clock_ms);
    virtual        ~GateOut () = default;
 

--- a/include/erb/Led.h
+++ b/include/erb/Led.h
@@ -46,6 +46,9 @@ class Led
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
+   static constexpr float ValueMin = 0.f;
+   static constexpr float ValueMax = 1.f;
+
    using BindingType = typename LedBinding <Pin>::type;
    using KeyframeTargetType = typename LedKeyframeTarget <Pin>::type;
 

--- a/include/erb/LedBi.h
+++ b/include/erb/LedBi.h
@@ -41,6 +41,9 @@ class LedBi
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
+   static constexpr float ValueMin = 0.f;
+   static constexpr float ValueMax = 1.f;
+
                   LedBi (typename Led <Pin>::BindingType data_r, typename Led <Pin>::BindingType data_g, const uint64_t & clock_ms);
    virtual        ~LedBi () = default;
 

--- a/include/erb/LedRgb.h
+++ b/include/erb/LedRgb.h
@@ -41,6 +41,9 @@ class LedRgb
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
+   static constexpr float ValueMin = 0.f;
+   static constexpr float ValueMax = 1.f;
+
                   LedRgb (typename Led <Pin>::BindingType data_r, typename Led <Pin>::BindingType data_g, typename Led <Pin>::BindingType data_b, const uint64_t & clock_ms);
    virtual        ~LedRgb () = default;
 

--- a/include/erb/Pot.h
+++ b/include/erb/Pot.h
@@ -29,6 +29,8 @@ class Pot
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
+   static constexpr float ValueMin = FloatRangeTrait <Range>::Min;
+   static constexpr float ValueMax = FloatRangeTrait <Range>::Max;
 
    inline         Pot (const float & data);
    virtual        ~Pot () = default;

--- a/include/erb/Switch.h
+++ b/include/erb/Switch.h
@@ -36,6 +36,8 @@ class Switch
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 public:
+   static constexpr float ValueMin = 0.f;
+   static constexpr float ValueMax = float (NbrPosition) - 1.f;
 
    static_assert (NbrPosition == 2 || NbrPosition == 3);
 


### PR DESCRIPTION
This PR standardizes the way parameter ranges are represented:
- Either unipolar/normalised (0, 1),
- or bipolar (-1, 1),
- or discrete (0, N).

This standard representation allows us to remove style knowledge from the simulator code generation.

This PR is preparation work for the upcoming manufacturer and semantic style features.
