### PR TITLE
Regroup hardware build in a single erbui function

### DIFF
--- a/build-system/erbui/__init__.py
+++ b/build-system/erbui/__init__.py
@@ -164,16 +164,19 @@ def generate_daisy_code (path, module):
 
 """
 ==============================================================================
-Name: generate_front_panel
+Name: generate_hardware
 ==============================================================================
 """
 
-def generate_front_panel (path, ast):
+def generate_hardware (path, ast):
    path_hardware = os.path.join (path, 'hardware')
    if not os.path.exists (path_hardware):
       os.makedirs (path_hardware)
+
    generate_front_panel_dxf (path_hardware, ast)
    generate_front_panel_printing (path_hardware, ast)
+   generate_front_pcb_kicad_pcb (path_hardware, ast)
+   generate_front_pcb_bom (path_hardware, ast)
 
 
 
@@ -198,21 +201,6 @@ Name: generate_front_panel_printing
 def generate_front_panel_printing (path, ast):
    generator = front_panelPrinting ()
    generator.generate (path, ast)
-
-
-
-"""
-==============================================================================
-Name: generate_front_pcb
-==============================================================================
-"""
-
-def generate_front_pcb (path, ast):
-   path_hardware = os.path.join (path, 'hardware')
-   if not os.path.exists (path_hardware):
-      os.makedirs (path_hardware)
-   generate_front_pcb_kicad_pcb (path_hardware, ast)
-   generate_front_pcb_bom (path_hardware, ast)
 
 
 

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -267,8 +267,7 @@ def build ():
    elif target == 'hardware':
       ast_erbui = read_erbui_ast (find_erbui ())
       path_artifacts = os.path.join (cwd, 'artifacts')
-      erbui.generate_front_panel (path_artifacts, ast_erbui)
-      erbui.generate_front_pcb (path_artifacts, ast_erbui)
+      erbui.generate_hardware (path_artifacts, ast_erbui)
 
    elif target == 'simulator':
       ast_erbb = read_erbb_ast (find_erbb ())


### PR DESCRIPTION
This PR refactors the `erbb build hardware` call to a single `erbui` call. This will allow to decide explicitely which generators to call in a short-term future, to adapt to different manufacturer processes.

This PR is preparation work for the upcoming manufacturer and semantic style features.
