### PR TITLE
Fix cairo dll load

### DIFF
--- a/build-system/erbui/generators/detail/panel.py
+++ b/build-system/erbui/generators/detail/panel.py
@@ -7,14 +7,23 @@
 
 
 
-import cairocffi
-import cairosvg
+
 import math
 import os
+import platform
 import random
+import sys
 
 from ... import ast
 from ... import adapter
+
+if platform.system () == 'Windows' and sys.version_info >= (3, 8):
+   # Starting from 3.8, Python no longer searches for DLLs in PATH
+   os.add_dll_directory (r"C:\msys64\mingw64\bin")
+import cairocffi
+import cairosvg
+
+
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 

--- a/build-system/erbui/generators/front_panel/pdf.py
+++ b/build-system/erbui/generators/front_panel/pdf.py
@@ -7,11 +7,17 @@
 
 
 
-import cairocffi
 import math
 import os
+import platform
+import sys
 
 from ..detail.panel import Panel as detailPanel
+
+if platform.system () == 'Windows' and sys.version_info >= (3, 8):
+   # Starting from 3.8, Python no longer searches for DLLs in PATH
+   os.add_dll_directory (r"C:\msys64\mingw64\bin")
+import cairocffi
 
 
 

--- a/build-system/erbui/generators/vcvrack/panel.py
+++ b/build-system/erbui/generators/vcvrack/panel.py
@@ -7,11 +7,17 @@
 
 
 
-import cairocffi
 import math
 import os
+import platform
+import sys
 
 from ..detail.panel import Panel as detailPanel
+
+if platform.system () == 'Windows' and sys.version_info >= (3, 8):
+   # Starting from 3.8, Python no longer searches for DLLs in PATH
+   os.add_dll_directory (r"C:\msys64\mingw64\bin")
+import cairocffi
 
 
 


### PR DESCRIPTION
This PR fixes libcairo DLL loading problem on Windows by adding its parent folder to the Python DLL search path, starting from Python 3.8.

This fix is adapted from the [pycairo unit tests setup](https://github.com/pygobject/pycairo/blob/8c5d0c700cb4b49bff1092dca498ef3e75439a26/tests/__init__.py#L6).

> **Note**
> Since the `windows-2019` GitHub virtual environment [Python runtime is 3.7.9](https://github.com/actions/virtual-environments/blob/releases/win19/20220619/images/win/Windows2019-Readme.md#language-and-runtime), we can't test this fix properly on CI. But it has been tested by [@Mdashdotdashn ](https://github.com/Mdashdotdashn).