### PR TITLE
Fix windows kicad support

### DIFF
--- a/build-system/erbui/generators/front_pcb/kicad_pcb.py
+++ b/build-system/erbui/generators/front_pcb/kicad_pcb.py
@@ -154,9 +154,15 @@ class KicadPcb:
       path_pcb = os.path.join (path, '%s.kicad_pcb' % module.name)
 
       if platform.system () == 'Darwin':
-         kicad_python_path = '/Applications/KiCad/kicad.app/Contents/Frameworks/Python.framework/Versions/2.7/bin/python2.7'
+         kicad_python_path = '/Applications/KiCad/kicad.app/Contents/Frameworks/Python.framework/Versions/3.8/bin/python3.8'
+         if not os.path.exists (kicad_python_path):
+            # pre KiCad 6
+            kicad_python_path = '/Applications/KiCad/kicad.app/Contents/Frameworks/Python.framework/Versions/2.7/bin/python2.7'
       elif platform.system () == 'Windows':
-         kicad_python_path = 'c:/Program Files/KiCad/bin/python.exe'
+         kicad_python_path = 'c:/Program Files/KiCad/6.0/bin/python.exe'
+         if not os.path.exists (kicad_python_path):
+            # pre KiCad 6
+            kicad_python_path = 'c:/Program Files/KiCad/bin/python.exe'
       else:
          kicad_python_path = 'python'
 
@@ -176,9 +182,15 @@ class KicadPcb:
       path_pcb = os.path.join (path, '%s.kicad_pcb' % module.name)
 
       if platform.system () == 'Darwin':
-         kicad_python_path = '/Applications/KiCad/kicad.app/Contents/Frameworks/Python.framework/Versions/2.7/bin/python2.7'
+         kicad_python_path = '/Applications/KiCad/kicad.app/Contents/Frameworks/Python.framework/Versions/3.8/bin/python3.8'
+         if not os.path.exists (kicad_python_path):
+            # pre KiCad 6
+            kicad_python_path = '/Applications/KiCad/kicad.app/Contents/Frameworks/Python.framework/Versions/2.7/bin/python2.7'
       elif platform.system () == 'Windows':
-         kicad_python_path = 'c:/Program Files/KiCad/bin/python.exe'
+         kicad_python_path = 'c:/Program Files/KiCad/6.0/bin/python.exe'
+         if not os.path.exists (kicad_python_path):
+            # pre KiCad 6
+            kicad_python_path = 'c:/Program Files/KiCad/bin/python.exe'
       else:
          kicad_python_path = 'python'
 

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -181,7 +181,7 @@ def setup ():
 
    elif platform.system () == 'Windows':
       subprocess.check_call ('choco install gcc-arm-embedded libsndfile', shell=True)
-      subprocess.check_call ('choco install kicad --version=5.1.12.1', shell=True)
+      subprocess.check_call ('choco install kicad --version=6.0.6', shell=True)
       subprocess.check_call ('c:/msys64/usr/bin/bash -lc "pacman -S --needed base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo --noconfirm"', shell=True)
       subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)
       subprocess.check_call ('cp include/erb/vcvrack/design/d-din/*.otf c:/windows/fonts', shell=True, cwd=PATH_ROOT)


### PR DESCRIPTION
This PR fixes Windows installation of KiCad, as chocolatey package for our current version 5.1.12.1 is broken (link to original KiCad installer returns a 404) and not likely to be fixed.

We fix this issue by upgrading to KiCad 6 on Windows and supporting breaking changes in the new Python API while retaining backward compatibility with KiCad 5 by checking which variant of the API is available at runtime.

Support for KiCad 6 on other platforms is still not "official" as:
- Installation on macOS requires our minimal version to speed up installation on CI, and needs to be done,
- KiCad 6 stock support only appears with Ubuntu 22.04, so we first need to add Ubuntu 22.04 support as a whole.

> **Note**
> - This PR needs to be merged to allow #445 to be merged

