### PR TITLE
Rack 2 support

### DIFF
--- a/build-system/erbb/generators/action/action_vcvrack_install_template.py
+++ b/build-system/erbb/generators/action/action_vcvrack_install_template.py
@@ -18,10 +18,10 @@ PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
 
 if platform.system () == 'Darwin':
-   PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.path.expanduser ("~"), 'Documents', 'Rack', 'plugins-v1'))
+   PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.path.expanduser ("~"), 'Documents', 'Rack2', 'plugins'))
 
 elif platform.system () == 'Linux':
-   PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.path.expanduser ("~"), '.Rack', 'plugins-v1'))
+   PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.path.expanduser ("~"), '.Rack2', 'plugins'))
 
 PATH_VCV_PLUGIN = os.path.abspath (os.path.join (PATH_VCV_PLUGINS, '%module.name%'))
 PATH_VCV_PLUGIN_RES = os.path.abspath (os.path.join (PATH_VCV_PLUGIN, 'res'))

--- a/build-system/erbb/generators/simulator/Makefile_template
+++ b/build-system/erbb/generators/simulator/Makefile_template
@@ -29,11 +29,15 @@ FLAGS += -I$(PATH_ROOT)/include
 FLAGS += -I$(RACK_DIR)/include
 FLAGS += -I$(RACK_DIR)/dep/include
 
+LDFLAGS += -shared
+LDFLAGS += -L$(RACK_DIR) -lRack
+
 ifdef ARCH_MAC
-	LDFLAGS += -shared -undefined dynamic_lookup
+	LDFLAGS += -undefined dynamic_lookup
 	TARGET := plugin.dylib
-	RACK_USER_DIR ?= $(HOME)/Documents/Rack
+	RACK_USER_DIR ?= $(HOME)/Documents/Rack2
 	FLAGS += -DARCH_MAC
+	FLAGS += -Wno-c99-extensions
 	CXXFLAGS += -stdlib=libc++
 	LDFLAGS += -stdlib=libc++
 	MAC_SDK_FLAGS = -mmacosx-version-min=10.14
@@ -42,20 +46,26 @@ ifdef ARCH_MAC
 endif
 
 ifdef ARCH_LIN
-	LDFLAGS += -shared
 	TARGET := plugin.so
-	RACK_USER_DIR ?= $(HOME)/.Rack
+	RACK_USER_DIR ?= $(HOME)/.Rack2
 	FLAGS += -DARCH_LIN
+	# This prevents static variables in the DSO (dynamic shared object) from
+	# being preserved after dlclose().
+	FLAGS += -fno-gnu-unique
+	# When Rack loads a plugin, it symlinks /tmp/Rack2 to its system dir,
+	# so the plugin can link to libRack.
+	LDFLAGS += -Wl,-rpath=/tmp/Rack2
+	LDFLAGS += -static-libstdc++ -static-libgcc
 	CXXFLAGS += -Wsuggest-override
 endif
 
 ifdef ARCH_WIN
-	LDFLAGS += -shared -L$(RACK_DIR) -lRack
 	LDFLAGS += -static-libstdc++
 	TARGET := plugin.dll
-	RACK_USER_DIR ?= "$(USERPROFILE)"/Documents/Rack
+	RACK_USER_DIR ?= "$(USERPROFILE)"/Documents/Rack2
 	FLAGS += -DARCH_WIN
 	FLAGS += -D_USE_MATH_DEFINES
+	FLAGS += -municode
 	CXXFLAGS += -Wsuggest-override
 endif
 
@@ -69,7 +79,6 @@ FLAGS += -O3 -DNDEBUG=1 -DRELEASE=1 -march=nocona -funsafe-math-optimizations
 endif
 
 %warnings%
-FLAGS += -Wno-c99-extensions
 
 FLAGS += -Derb_TARGET_VCV_RACK
 FLAGS += -Derb_BUFFER_SIZE=48
@@ -94,14 +103,17 @@ $(CONFIGURATION):
 package: all resources ../plugin.json ../panel_vcvrack.svg
 	@echo "PACKAGE $(CONFIGURATION) %module.name%"
 	@mkdir -p $(CONFIGURATION)/package/res
+ifdef ARCH_MAC
+	@install_name_tool -change libRack.dylib /tmp/Rack2/libRack.dylib $(CONFIGURATION)/$(TARGET)
+endif
 	@cp $(CONFIGURATION)/$(TARGET) $(CONFIGURATION)/package/$(TARGET)
 	@cp ../plugin.json $(CONFIGURATION)/package/plugin.json
 	@cp ../panel_vcvrack.svg $(CONFIGURATION)/package/res/panel_vcvrack.svg
 
 install: package
-	@echo "INSTALL $(RACK_USER_DIR)/plugins-v1/%module.name%/"
-	@mkdir -p $(RACK_USER_DIR)/plugins-v1/%module.name%
-	@cp -r $(CONFIGURATION)/package/* $(RACK_USER_DIR)/plugins-v1/%module.name%/
+	@echo "INSTALL $(RACK_USER_DIR)/plugins/%module.name%/"
+	@mkdir -p $(RACK_USER_DIR)/plugins/%module.name%
+	@cp -r $(CONFIGURATION)/package/* $(RACK_USER_DIR)/plugins/%module.name%/
 
 .PHONY: package install resources
 .DEFAULT_GOAL := all

--- a/build-system/erbui/generators/vcvrack/code.py
+++ b/build-system/erbui/generators/vcvrack/code.py
@@ -65,22 +65,26 @@ class Code:
             if category == 'Param':
                control.vcv_param_index = nbr_params
                controls_bind_config += '   module.ui.board.impl_bind (module.ui.%s, %s [%d]);\n' % (control.name, 'params', nbr_params)
-               controls_bind_config += '   configParam (%d, decltype (module.ui.%s)::ValueMin, decltype (module.ui.%s)::ValueMax, 0.f);\n\n' % (nbr_params, control.name, control.name)
+               controls_bind_config += '   configParam (%d, decltype (module.ui.%s)::ValueMin, decltype (module.ui.%s)::ValueMax, 0.f, "%s");\n\n' % (nbr_params, control.name, control.name, control.name)
                nbr_params += 1
 
             elif category == 'Input':
                control.vcv_input_index = nbr_inputs
                controls_bind_config += '   module.ui.board.impl_bind (module.ui.%s, %s [%d]);\n' % (control.name, 'inputs', nbr_inputs)
+               controls_bind_config += '   configInput (%d, "%s");\n\n' % (nbr_inputs, control.name)
+
                nbr_inputs += 1
 
             elif category == 'Output':
                control.vcv_output_index = nbr_outputs
                controls_bind_config += '   module.ui.board.impl_bind (module.ui.%s, %s [%d]);\n' % (control.name, 'outputs', nbr_outputs)
+               controls_bind_config += '   configOutput (%d, "%s");\n\n' % (nbr_outputs, control.name)
                nbr_outputs += 1
 
             elif category == 'Light':
                control.vcv_light_index = nbr_lights
                controls_bind_config += '   module.ui.board.impl_bind (module.ui.%s, %s [%d]);\n' % (control.name, 'lights', nbr_lights)
+               controls_bind_config += '   configLight (%d, "%s");\n\n' % (nbr_lights, control.name)
                nbr_lights += control.nbr_pins
 
       template = template.replace ('%module.nbr_params%', str (nbr_params))

--- a/build-system/erbui/generators/vcvrack/manifest.py
+++ b/build-system/erbui/generators/vcvrack/manifest.py
@@ -25,7 +25,7 @@ class Manifest:
          file.write ('{\n')
          file.write ('   "slug": "ErbPlugin%s",\n' % root.modules [0].name)
          file.write ('   "name": "Erb Plugin",\n')
-         file.write ('   "version": "1.0.0",\n')
+         file.write ('   "version": "2.0.0",\n')
          file.write ('   "license": "proprietary",\n')
          file.write ('   "brand": "Erb",\n')
          file.write ('   "author": "Erb",\n')

--- a/documentation/faust/setup.md
+++ b/documentation/faust/setup.md
@@ -123,7 +123,7 @@ COPY include/erb/vcvrack/resource/rogan.5ps.svg
 CXX dsp/ReverbSc.cpp
 LINK plugin.dylib
 PACKAGE Release Flanger
-INSTALL /Users/raf/Documents/Rack/plugins-v1/Flanger/
+INSTALL /Users/raf/Documents/Rack2/plugins/Flanger/
 ```
 
 

--- a/documentation/getting-started/setup.md
+++ b/documentation/getting-started/setup.md
@@ -111,10 +111,10 @@ COPY include/erb/vcvrack/resource/rogan.5ps.svg
 CXX dsp/ReverbSc.cpp
 LINK plugin.dylib
 PACKAGE Release Drop
-INSTALL /Users/raf/Documents/Rack/plugins-v1/Drop/
+INSTALL /Users/raf/Documents/Rack2/plugins/Drop/
 ```
 
-The build process will output the VCV Rack module in the `Rack/plugins-v1` folder.
+The build process will output the VCV Rack module in the `Rack2/plugins` folder.
 
 
 ## Testing in VCV Rack
@@ -178,7 +178,7 @@ This will open the project in Xcode:
 
 Press {guilabel}`⌘B` to build.
 
-The build process will output the VCV Rack module in the `Rack/plugins-v1` folder.
+The build process will output the VCV Rack module in the `Rack2/plugins` folder.
 
 
 ## Debugging in the simulator using Xcode

--- a/documentation/max/setup.md
+++ b/documentation/max/setup.md
@@ -139,7 +139,7 @@ Open the `Reverb.maxpat` file. If everything is correctly installed, it should l
 ```
 
 Now save your patch: this will automatically build the Reverb,
-and put the VCV Rack simulator module in the `Rack/plugins-v1` folder, ready to be used!
+and put the VCV Rack simulator module in the `Rack2/plugins` folder, ready to be used!
 
 
 ## Testing in VCV Rack

--- a/include/erb/def.h
+++ b/include/erb/def.h
@@ -57,6 +57,7 @@
       _Pragma ("clang diagnostic ignored \"-Wsuggest-override\"") \
       _Pragma ("clang diagnostic ignored \"-Wsuggest-destructor-override\"") \
       _Pragma ("clang diagnostic ignored \"-Wmacro-redefined\"") \
+      _Pragma ("clang diagnostic ignored \"-Wshadow-field\"") \
 
    #define erb_DISABLE_WARNINGS_FAUST_GEN \
       _Pragma ("clang diagnostic push") \
@@ -82,6 +83,7 @@
       _Pragma ("GCC diagnostic ignored \"-Wpedantic\"") \
       _Pragma ("GCC diagnostic ignored \"-Wunused-parameter\"") \
       _Pragma ("GCC diagnostic ignored \"-Wvla\"") \
+      _Pragma ("GCC diagnostic ignored \"-Wunused-variable\"") \
 
    #define erb_DISABLE_WARNINGS_FAUST_GEN \
       _Pragma ("GCC diagnostic push") \

--- a/include/erb/vcvrack/VcvWidgets.h
+++ b/include/erb/vcvrack/VcvWidgets.h
@@ -210,6 +210,8 @@ struct Dailywell2Ms : rack::app::Switch
    }
 
    void onChange (const rack::event::Change & e) override {
+      rack::ParamQuantity* paramQuantity = getParamQuantity();
+
       if (!frames.empty() && paramQuantity) {
          int index = int (std::round (paramQuantity->getValue () - paramQuantity->getMinValue ()));
          index = rack::math::clamp (index, 0, int (frames.size ()) - 1);


### PR DESCRIPTION
This PR adds VCV Rack 2 support to eurorack-blocks. The generated plug-ins are not supported by older versions of Rack, but this is considered ok as most of the user base has transitioned to Rack 2 already.

For this, we are switching to the VCV Rack SDK version 2.0.6, and are using [our mirror](https://github.com/ohmtech-rdi/vcv-rack-sdk) which presents all platforms in one convenient repository.

The [migration guide](https://vcvrack.com/manual/Migrate2) and @hemmer's [work](https://github.com/hemmer/eurorack-blocks/commit/4cbc1d79bcb6580a082d66ed89eee25fee901e61) were used as the starting point of this PR. (I did add hemmer's repo as a remote to cherry-pick commits in hope git would detect the original work, but apparently git didn't capture this properly, sorry @hemmer 😬)

We decided to go against specializing `configParam` for buttons and switches, as we don't have something really proper for `configSwitch`, and the benefit for those new methods probably defeats our original intent: after all, in the real world, a Eurorack module won't show more about a control than what is printed on the front aluminum panel. 

The makefile template was also edited to reflect the processes from Rack SDK `.mk` files. We decided to go against the upgrade to the model `nehalem`, as anyway the instructions it provides are not available on ARM obviously.

Finally, this PR won't work on M1 yet, but will in the next PR.

Thanks again @hemmer for your contribution!