### PR TITLE
M1 support

### DIFF
--- a/build-system/erbb/generators/simulator/Makefile_template
+++ b/build-system/erbb/generators/simulator/Makefile_template
@@ -13,6 +13,7 @@
 %define_PATH_ROOT%
 %define_RACK_DIR%
 %define_ARCH%
+%define_CXX%
 
 CONFIGURATION ?= Debug
 

--- a/build-system/erbb/generators/simulator/make.py
+++ b/build-system/erbb/generators/simulator/make.py
@@ -49,15 +49,19 @@ class Make:
 
       if platform.system () == 'Darwin':
          arch = 'ARCH_MAC := 1\nARCH := mac'
+         cxx = 'CXX = arch -x86_64 clang'
       elif platform.system () == 'Linux':
          arch = 'ARCH_LIN := 1\nARCH := lin'
+         cxx = '' # default
       elif platform.system () == 'Windows':
          arch = 'ARCH_WIN := 1\nARCH := win\nARCH_WIN_64 := 1\nBITS := 64'
+         cxx = '' # default
 
       template = template.replace ('%module.name%', module.name)
       template = template.replace ('%define_PATH_ROOT%', 'PATH_ROOT ?= %s' % path_root.replace ('\\', '/'))
       template = template.replace ('%define_RACK_DIR%', 'RACK_DIR ?= %s' % path_rack_dir.replace ('\\', '/'))
       template = template.replace ('%define_ARCH%', arch)
+      template = template.replace ('%define_CXX%', cxx)
       template = self.replace_warnings (template, strict)
       template = self.replace_defines (template, module, module.defines)
       template = self.replace_bases (template, module, module.bases, path_simulator);


### PR DESCRIPTION
This PR forces `clang` to run on the `x86_64` architecture, when generating VCV Rack 2 modules on macOS. This allows to bring M1 support to eurorack-blocks, using Rosetta 2. 

> **Note** For now this can't be tested on CI until GitHub Actions supports [this virtual environment](https://github.com/actions/virtual-environments/issues/2187).

> **Warning** Debugging VCV Rack (x86_64) from Xcode running on M1 doesn't work.
