### PR TITLE
Fix missing internal buffers allocation

### DIFF
--- a/build-system/erbb/generators/faust/code_template.hpp
+++ b/build-system/erbb/generators/faust/code_template.hpp
@@ -79,6 +79,7 @@ void  %module.name%::init ()
    mydsp::fManager = &mem;
 
    mydsp::classInit (erb_SAMPLE_RATE);
+   dsp.memoryCreate();
    dsp.instanceInit (erb_SAMPLE_RATE);
    dsp.buildUserInterface (&adapter);
 }


### PR DESCRIPTION
Fix missing internal buffers allocation by calling `memoryCreate` before the DSP instance is inited, following the [documentation](https://faustdoc.grame.fr/manual/architectures/#defining-and-using-a-custom-memory-manager) on the new `-mem` option.

- Fixes #460 