### PR TITLE
Fix faust memory create

### DIFF
--- a/.github/workflows/windows_2019.yml
+++ b/.github/workflows/windows_2019.yml
@@ -83,8 +83,8 @@ jobs:
       - name: Check max
         run: grep "Loaded ErbPluginMax" $USERPROFILE/Documents/Rack2/log.txt
 
-  software_faust:
-    name: Software Faust
+  software_faust_2_37_3:
+    name: Software Faust 2.37.3
     runs-on: windows-2019
     defaults:
       run:
@@ -95,6 +95,42 @@ jobs:
           submodules: recursive
       - run: curl https://github.com/grame-cncm/faust/releases/download/2.37.3/Faust-2.37.3-win64.exe --location --output Faust-2.37.3-win64.exe
       - run: ./Faust-2.37.3-win64.exe //S
+      - run: echo 'export PATH=$PATH:/c/Program\ Files/Faust/bin' >> ~/.bash_profile
+      - run: cat ~/.bash_profile
+      - run: choco install vcvrack
+      - run: python3 build-system/install.py
+      - run: erbb setup
+      - name: samples/faust
+        run: erbb configure && erbb build && erbb build hardware && erbb build gerber && erbb build simulator
+        working-directory: samples/faust
+      - name: test/faust
+        run: erbb configure && erbb build simulator && erbb build && erbb build hardware
+        working-directory: test/faust
+      - name: test/faust2
+        run: erbb configure && erbb build simulator && erbb build && erbb build hardware
+        working-directory: test/faust2
+      - name: test/faust3
+        run: erbb configure && erbb build simulator && erbb build && erbb build hardware
+        working-directory: test/faust3
+      - name: VCV Rack headless run
+        run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n' && cat $USERPROFILE/Documents/Rack2/log.txt
+      - name: Check faust
+        run: grep "Loaded ErbPluginFaust" $USERPROFILE/Documents/Rack2/log.txt
+      - name: Check flanger
+        run: grep "Loaded ErbPluginFlanger" $USERPROFILE/Documents/Rack2/log.txt
+
+  software_faust:
+    name: Software Faust
+    runs-on: windows-2019
+    defaults:
+      run:
+        shell: bash -l {0} # Source profile for each step
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - run: curl https://github.com/grame-cncm/faust/releases/download/2.41.1/Faust-2.41.1-win64.exe --location --output Faust-2.41.1-win64.exe
+      - run: ./Faust-2.41.1-win64.exe //S
       - run: echo 'export PATH=$PATH:/c/Program\ Files/Faust/bin' >> ~/.bash_profile
       - run: cat ~/.bash_profile
       - run: choco install vcvrack

--- a/build-system/erbb/generators/faust/code_template.hpp
+++ b/build-system/erbb/generators/faust/code_template.hpp
@@ -70,6 +70,26 @@ void  dsp_memory_manager::destroy (void * ptr)
 
 /*
 ==============================================================================
+Name : call_faust_mydsp_memoryCreate_if_exists
+Description :
+   Patch Faust introduction of 'memoryCreate' which introduces a breaking
+   change: the function must be called if it exists.
+==============================================================================
+*/
+
+template <typename T>
+auto  call_faust_mydsp_memoryCreate_if_exists (T & dsp, int) -> decltype (dsp.memoryCreate ())
+{
+   dsp.memoryCreate ();
+}
+
+template <typename T>
+auto  call_faust_mydsp_memoryCreate_if_exists (T & dsp, long) -> void {}
+
+
+
+/*
+==============================================================================
 Name : init
 ==============================================================================
 */
@@ -79,6 +99,7 @@ void  %module.name%::init ()
    mydsp::fManager = &mem;
 
    mydsp::classInit (erb_SAMPLE_RATE);
+   call_faust_mydsp_memoryCreate_if_exists (dsp, 0);
    dsp.instanceInit (erb_SAMPLE_RATE);
    dsp.buildUserInterface (&adapter);
 }


### PR DESCRIPTION
Fix missing internal buffers allocation by calling `memoryCreate` before the DSP instance is inited, following the [documentation](https://faustdoc.grame.fr/manual/architectures/#defining-and-using-a-custom-memory-manager) on the new `-mem` option.

The `memoryCreate` function is a new function, but which must be called, in order for the DSP to correctly instantiate.

To keep compatibility with pre-2.41, we are checking whether the function exists or not at build time and call it if available.

- Fixes #460 