### PR TITLE
Fix typo

### DIFF
--- a/build-system/erbui/generators/kicad/pcb.py
+++ b/build-system/erbui/generators/kicad/pcb.py
@@ -983,7 +983,7 @@ class Footprint:
          if not node: return None
 
          fp_poly = Footprint.FpPoly ()
-         fp_polypts = Pts.parse (node.first_kind ('pts'))
+         fp_poly.pts = Pts.parse (node.first_kind ('pts'))
          fp_poly.layer = node.property ('layer')
          fp_poly.width = node.property ('width')
          fp_poly.fill = node.property ('fill')


### PR DESCRIPTION
This PR fixes a small typo that would make all footprint polygons to not render properly. This is because there was a missing `.` in the `FpPoly` parser, so that the poly would be empty.