### PR TITLE
Fix kivu12 leds

### DIFF
--- a/boards/kivu12/firmware/BoardKivu12.hpp
+++ b/boards/kivu12/firmware/BoardKivu12.hpp
@@ -250,10 +250,12 @@ void  BoardKivu12::impl_postprocess (DacPin pin)
       // GND.
       // For this reason, the logic is inverted, and we need to adapt
       // the gamma too.
+      // from 4068 to 4094 it is on instead of off, so convert normalized
+      // range from 0 to 4067.
 
       auto val = _analog_outputs [pin.index];
       auto linear = 1.f - val * val * val;
-      auto linear_u12 = norm_to_u12 (linear);
+      auto linear_u12 = uint16_t (std::clamp (linear, 0.f, 1.f) * 4067.f);
 
       // LEDO-L8 LED1-L7 LED2-L6 ... LED7-L1
       // LED8-L9 LED9-L10 LED10-L11 ... LED15-L16

--- a/test/kivu12_l/Kivu12.cpp
+++ b/test/kivu12_l/Kivu12.cpp
@@ -1,0 +1,35 @@
+/*****************************************************************************
+
+      Kivu12.cpp
+      Copyright (c) 2020 Raphael DINGE
+
+*Tab=3***********************************************************************/
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#include "Kivu12.h"
+
+
+
+/*
+==============================================================================
+Name : process
+==============================================================================
+*/
+
+void  Kivu12::process ()
+{
+   // output 2 tones on output, just to make sure the board is running
+   osc1.set_freq (440.f);
+   osc2.set_freq (880.f);
+
+   for (size_t i = 0 ; i < erb_BUFFER_SIZE ; ++i)
+   {
+      ui.audio_out1 [i] = osc1.process ();
+      ui.audio_out2 [i] = osc2.process ();
+   }
+
+   ui.led = ui.pot;
+}

--- a/test/kivu12_l/Kivu12.erbb
+++ b/test/kivu12_l/Kivu12.erbb
@@ -1,0 +1,18 @@
+/*****************************************************************************
+
+      Kivu12.erbb
+      Copyright (c) 2020 Raphael DINGE
+
+*Tab=3***********************************************************************/
+
+use strict
+
+module Kivu12 {
+   // section qspi
+
+   sources {
+      file "Kivu12.cpp"
+      file "Kivu12.h"
+      file "Kivu12.erbui"
+   }
+}

--- a/test/kivu12_l/Kivu12.erbui
+++ b/test/kivu12_l/Kivu12.erbui
@@ -1,0 +1,42 @@
+/*****************************************************************************
+
+      Kivu12.erbui
+      Copyright (c) 2020 Raphael DINGE
+
+*Tab=3***********************************************************************/
+
+
+
+module Kivu12 {
+   board kivu12
+   material aluminum
+   header { label "Kivu12" }
+
+   control pot Pot {
+      position 6hp, 40mm
+      style rogan
+      label "LED"
+      pin P1
+   }
+
+   control led Led {
+      position 6hp, 80mm
+      style red
+      label "LED"
+      pin L1
+   }
+
+   control audio_out1 AudioOut {
+      position 7.33hp, 111mm
+      style knurled
+      label "OUT L"
+      pin AO1
+   }
+
+   control audio_out2 AudioOut {
+      position 10hp, 111mm
+      style knurled
+      label "OUT R"
+      pin AO2
+   }
+}

--- a/test/kivu12_l/Kivu12.h
+++ b/test/kivu12_l/Kivu12.h
@@ -1,0 +1,67 @@
+/*****************************************************************************
+
+      Kivu12.h
+      Copyright (c) 2020 Raphael DINGE
+
+*Tab=3***********************************************************************/
+
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+#include "artifacts/Kivu12Ui.h"
+
+#include "erb/erb.h"
+
+
+
+/*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+constexpr double pim2 = 2.f * M_PI;
+
+class OscSin
+{
+public:
+   void           set_freq_norm (float freq_norm)
+   {
+      float freq = 20.f * std::pow (500.f, std::abs (freq_norm));
+      set_freq (freq);
+   }
+
+   void           set_freq (float freq)
+   {
+      const double phase_step = pim2 * freq / erb_SAMPLE_RATE;
+      _step_cos = std::cos (phase_step);
+      _step_sin = std::sin (phase_step);
+   }
+
+   float          process ()
+   {
+      const double old_cos = _pos_cos;
+      const double old_sin = _pos_sin;
+      _pos_cos = old_cos * _step_cos - old_sin * _step_sin;
+      _pos_sin = old_cos * _step_sin + old_sin * _step_cos;
+
+      return float (_pos_sin);
+   }
+
+private:
+   double         _step_cos = 1.f;
+   double         _step_sin = 0.f;
+
+   double         _pos_cos = 1.f;
+   double         _pos_sin = 0.f;
+};
+
+
+
+struct Kivu12
+{
+   Kivu12Ui ui;
+   OscSin osc1;
+   OscSin osc2;
+   OscSin osc3;
+   OscSin osc4;
+
+   void  process ();
+};


### PR DESCRIPTION
This PR fixes what seems to be a "bug" on the PCA9685 12-bit led driver, where there is a "hole" beetwen the values from 4068 to 4094 (inclusive).

We fix that by scaling from 0 to 4067 (inclusive) instead of 0 to 4095. 4095 is anyway not full off in our case, so lacking the dynamic range from this "hole" doesn't seem to have a really important visual effect.

- fixes #472 