### PR TITLE
Use comma instead of semicolon for digikey bom upload parser

### DIFF
--- a/boards/kivu12/build.py
+++ b/boards/kivu12/build.py
@@ -159,7 +159,7 @@ def build_bom_digikey ():
       sheet_sch = sch.Root.read (sheet_path)
       symbols.extend (sheet_sch.symbols)
 
-   line_format = '{DistPartNumber};{quantity}\n'
+   line_format = '{DistPartNumber},{quantity}\n'
    header_map = {
       'DistPartNumber': 'Digi-Key Part Number',
       'quantity': 'Quantity',


### PR DESCRIPTION
This PR fixes a bug in the `kivu12` DigiKey BOM generator script were the generated CSV was not compatible with DigiKey BOM uploader: DigiKey doesn't recognise `;` to be a valid separator, so we use `,` instead.