### PR TITLE
Pinpoint python build system requirements

### DIFF
--- a/requirements/build-system.txt
+++ b/requirements/build-system.txt
@@ -2,17 +2,17 @@
 
 # SVG & PDF generation
 
-cairocffi
-cairosvg
+cairocffi>=1.4.0,<1.5.0
+CairoSVG>=2.6.0
 
 # DXF generation
 
-ezdxf
+ezdxf>=1.0.2
 
 # AudioSample generation
 
-soundfile
-numpy
+SoundFile>=0.12.1
+numpy>=1.21.0
 
 # Coverage
 


### PR DESCRIPTION
This PR fixes a problem (yet again) with our `cairocffi` dependency. For some reason we didn't investigate, version 1.5.0 doesn't install properly through pip anymore on macOS 10.15.

This PR fixes that by specifying the version, and making sure we don't try to build with 1.5.0.
While we are at it, we pinpoint the other versions, based on what was currently used on CI.

It seems also that the newest version of `SoundFile` solves the problem on Mac M1.