### PR TITLE
Fix led 16b value range to avoid hole between 4036 and 4094

### DIFF
--- a/boards/kivu12/firmware/BoardKivu12.hpp
+++ b/boards/kivu12/firmware/BoardKivu12.hpp
@@ -250,12 +250,12 @@ void  BoardKivu12::impl_postprocess (DacPin pin)
       // GND.
       // For this reason, the logic is inverted, and we need to adapt
       // the gamma too.
-      // from 4068 to 4094 it is on instead of off, so convert normalized
-      // range from 0 to 4067.
+      // from 4036 to 4094 it is on instead of off, so convert normalized
+      // range from 0 to 4035.
 
       auto val = _analog_outputs [pin.index];
       auto linear = 1.f - val * val * val;
-      auto linear_u12 = uint16_t (std::clamp (linear, 0.f, 1.f) * 4067.f);
+      auto linear_u12 = uint16_t (std::clamp (linear, 0.f, 1.f) * 4035.f);
 
       // LEDO-L8 LED1-L7 LED2-L6 ... LED7-L1
       // LED8-L9 LED9-L10 LED10-L11 ... LED15-L16


### PR DESCRIPTION
This PR fixes what seems to be a "bug" on the PCA9685 12-bit led driver, where there is a "hole" beetwen the values from 4036 to 4094 (inclusive).

We had a previous fix for that (#473 ) but the bug was still there for pins from LED8 to LED15.

We fix that by scaling from 0 to 4035 (inclusive) instead of 0 to 4095. 4095 is anyway not full off in our case, so lacking the dynamic range from this "hole" doesn't seem to have a really important visual effect.

- Fixes #482 