### PR TITLE
Specify cairo surface point unit explicitly

### DIFF
--- a/build-system/erbui/generators/vcvrack/panel.py
+++ b/build-system/erbui/generators/vcvrack/panel.py
@@ -42,6 +42,7 @@ class Panel:
       path_svg = os.path.join (path, 'panel_vcvrack.svg')
 
       surface = cairocffi.SVGSurface (path_svg_pp, module.width.pt, MODULE_HEIGHT * MM_TO_PT)
+      surface.set_document_unit (cairocffi.SVG_UNIT_PT)
       context = cairocffi.Context (surface)
 
       panel = detailPanel ()


### PR DESCRIPTION
This PR enforces the use of point units, as they are not the default anymore, at least for Windows 11 installation, for some reason.

- Partially corrects #481 