### PR TITLE
Rotate pad in footprints

### DIFF
--- a/build-system/erbui/generators/kicad/pcb.py
+++ b/build-system/erbui/generators/kicad/pcb.py
@@ -751,6 +751,11 @@ class Footprint:
 
    def rotate (self, rotation):
       self.at.rotate (rotation)
+      # pads need to be rotated as well for some reason
+      for pad in self.pads:
+         if not pad.at.rotation:
+            pad.at.rotation = 0
+         pad.at.rotation = (pad.at.rotation + rotation.degree + 360) % 360
 
    def translate (self, x, y):
       self.at.translate (x, y)


### PR DESCRIPTION
This PR fixes a bug where, for some reason, the pads in a rotated footprint were not rotated.

This was an issue for some pads, like the oval pads of the Eurorack jack connectors.

This PR is preparation work for the upcoming `kivu12` development board.