### PR TITLE
Fix shift register timings

### DIFF
--- a/boards/kivu12/firmware/BoardKivu12.hpp
+++ b/boards/kivu12/firmware/BoardKivu12.hpp
@@ -124,7 +124,7 @@ void  BoardKivu12::impl_preprocess ()
 
    _gpio_b_sr4021_clock.write (false);
    _gpio_b_sr4021_latch.write (true);
-   daisy::System::DelayTicks (1);
+   daisy::System::DelayTicks (100);
 
    _gpio_b_sr4021_latch.write (false);
 
@@ -138,7 +138,7 @@ void  BoardKivu12::impl_preprocess ()
       _digital_inputs [gpio1_order [i]] = !_gpio_inputs [1].read ();
 
       _gpio_b_sr4021_clock.write (true);
-      daisy::System::DelayTicks (1);
+      daisy::System::DelayTicks (100);
    }
 
 #elif defined (erb_USE_DAISY_IMPL)


### PR DESCRIPTION
This PR fixes a bug where reading `BX` was wrong. Basically having an input high would influence slightly the next reading.

This bug is quite rare and occurred on some boards we tested with the upcoming Kivu12 development board.

We solved it by increasing the number of ticks between the shift register state change. After quite some back and forth, it seems to properly solve the problem.

Incidentally, that also seems to reflect the timing `libDaisy` was using before making a refactor, which potentially introduced wrong timings. [here](https://github.com/electro-smith/libDaisy/blob/4ac1f665be53eef8f136763a9e223efefa2cbf71/src/dev_sr_4021.c#L42) is the older version.