### PR TITLE
Remove ninja build system from erbb setup

### DIFF
--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -165,7 +165,7 @@ def setup ():
          if kicad_err != 0:
             # probably already installed
             print ('Skipping Kicad Install')
-      subprocess.check_call ('brew install armmbed/formulae/arm-none-eabi-gcc ninja cairo libffi dfu-util openocd', shell=True)
+      subprocess.check_call ('brew install armmbed/formulae/arm-none-eabi-gcc cairo libffi dfu-util openocd', shell=True)
       subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)
       subprocess.check_call ('mkdir -p ~/Library/Fonts', shell=True)
       subprocess.check_call ('cp include/erb/vcvrack/design/d-din/*.otf ~/Library/Fonts', shell=True, cwd=PATH_ROOT)
@@ -173,7 +173,7 @@ def setup ():
 
    elif platform.system () == 'Linux':
       subprocess.check_call ('sudo apt-get update', shell=True)
-      subprocess.check_call ('sudo apt-get install -y gcc-arm-none-eabi ninja-build libglu1-mesa-dev libcairo2-dev libffi-dev python3-dev kicad libsndfile1 dfu-util openocd', shell=True)
+      subprocess.check_call ('sudo apt-get install -y gcc-arm-none-eabi libglu1-mesa-dev libcairo2-dev libffi-dev python3-dev kicad libsndfile1 dfu-util openocd', shell=True)
       subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)
       subprocess.check_call ('mkdir -p ~/.local/share/fonts/', shell=True)
       subprocess.check_call ('cp include/erb/vcvrack/design/d-din/*.otf ~/.local/share/fonts', shell=True, cwd=PATH_ROOT)


### PR DESCRIPTION
This PR removes the Ninja build system from `erbb setup`, as it is not needed anymore.