### PR TITLE
Remove libsndfile library from erbb setup

### DIFF
--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -173,14 +173,14 @@ def setup ():
 
    elif platform.system () == 'Linux':
       subprocess.check_call ('sudo apt-get update', shell=True)
-      subprocess.check_call ('sudo apt-get install -y gcc-arm-none-eabi libglu1-mesa-dev libcairo2-dev libffi-dev python3-dev kicad libsndfile1 dfu-util openocd', shell=True)
+      subprocess.check_call ('sudo apt-get install -y gcc-arm-none-eabi libglu1-mesa-dev libcairo2-dev libffi-dev python3-dev kicad dfu-util openocd', shell=True)
       subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)
       subprocess.check_call ('mkdir -p ~/.local/share/fonts/', shell=True)
       subprocess.check_call ('cp include/erb/vcvrack/design/d-din/*.otf ~/.local/share/fonts', shell=True, cwd=PATH_ROOT)
       subprocess.check_call ('cp include/erb/vcvrack/design/indie-flower/*.ttf ~/.local/share/fonts', shell=True, cwd=PATH_ROOT)
 
    elif platform.system () == 'Windows':
-      subprocess.check_call ('choco install gcc-arm-embedded libsndfile', shell=True)
+      subprocess.check_call ('choco install gcc-arm-embedded', shell=True)
       subprocess.check_call ('choco install kicad --version=6.0.6', shell=True)
       subprocess.check_call ('c:/msys64/usr/bin/bash -lc "pacman -S --needed base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo --noconfirm"', shell=True)
       subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)


### PR DESCRIPTION
This PR removes the `libsndfile` library from `erbb setup`, as the python package `SoundFile` already installs it in its wheel.