### PR TITLE
Toolchain msys2 mingw64

### DIFF
--- a/build-system/.gitignore
+++ b/build-system/.gitignore
@@ -1,0 +1,1 @@
+toolchain/

--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -18,6 +18,12 @@ import sys
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
+PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (PATH_THIS))
+
+if platform.system () == 'Windows':
+   MAKE_CMD = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin', 'mingw32-make.exe')
+else:
+   MAKE_CMD = 'make'
 
 sys.path.insert (0, os.path.join (PATH_ROOT, 'submodules', 'gyp-next', 'pylib'))
 import gyp
@@ -348,7 +354,7 @@ def build_daisy_all (path, configuration):
    os.environ ['CONFIGURATION'] = configuration
 
    cmd = [
-      'make',
+      MAKE_CMD,
       '--jobs',
       '--directory=%s' % os.path.join (path_artifacts, 'daisy')
    ]
@@ -379,7 +385,7 @@ def build_libdaisy ():
    print ('BUILD libDaisy')
 
    cmd = [
-      'make',
+      MAKE_CMD,
       '--jobs',
       '--silent',
       '--directory=%s' % os.path.join (PATH_ROOT, 'submodules', 'libDaisy'),
@@ -490,7 +496,7 @@ def build_simulator_make_target (target, path, configuration):
    os.environ ["CONFIGURATION"] = configuration
 
    cmd = [
-      'make',
+      MAKE_CMD,
       '--jobs',
       '--directory=%s' % os.path.join (path_artifacts, 'simulator'),
       'install'

--- a/build-system/erbb/generators/simulator/make.py
+++ b/build-system/erbb/generators/simulator/make.py
@@ -15,6 +15,7 @@ PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS)))))
 PATH_ERBB_GENS = os.path.join (PATH_ROOT, 'build-system', 'erbb', 'generators')
 PATH_ERBUI_GENS = os.path.join (PATH_ROOT, 'build-system', 'erbui', 'generators')
+PATH_BUILD_SYSTEM = os.path.join (PATH_ROOT, 'build-system')
 PATH_RACK = os.path.join (PATH_ROOT, 'submodules', 'vcv-rack-sdk')
 
 
@@ -54,8 +55,10 @@ class Make:
          arch = 'ARCH_LIN := 1\nARCH := lin'
          cxx = '' # default
       elif platform.system () == 'Windows':
+         PATH_GPP = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin', 'g++.exe')
+         path_cxx = os.path.relpath (PATH_GPP, path_simulator)
          arch = 'ARCH_WIN := 1\nARCH := win\nARCH_WIN_64 := 1\nBITS := 64'
-         cxx = '' # default
+         cxx = 'CXX = %s' % path_cxx.replace ('\\', '/')
 
       template = template.replace ('%module.name%', module.name)
       template = template.replace ('%define_PATH_ROOT%', 'PATH_ROOT ?= %s' % path_root.replace ('\\', '/'))

--- a/build-system/erbui/generators/detail/panel.py
+++ b/build-system/erbui/generators/detail/panel.py
@@ -18,15 +18,17 @@ from ... import ast
 from ... import adapter
 from ..kicad import pcb
 
-if platform.system () == 'Windows' and sys.version_info >= (3, 8):
-   # Starting from 3.8, Python no longer searches for DLLs in PATH
-   os.add_dll_directory (r"C:\msys64\mingw64\bin")
+PATH_THIS = os.path.abspath (os.path.dirname (__file__))
+PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS))))
+
+if platform.system () == 'Windows':
+   bin_dir = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin')
+   os.environ ['PATH'] = '%s;%s' % (bin_dir, os.environ ['PATH'])
+   if sys.version_info >= (3, 8):
+      os.add_dll_directory (bin_dir)
+
 import cairocffi
 import cairosvg
-
-
-
-PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 
 
 

--- a/build-system/erbui/generators/front_panel/pcb.py
+++ b/build-system/erbui/generators/front_panel/pcb.py
@@ -20,16 +20,21 @@ from ..detail.panel import Panel as detailPanel
 from ..kicad import pcb as kicadPcb
 from ..kicad import s_expression
 
-if platform.system () == 'Windows' and sys.version_info >= (3, 8):
-   # Starting from 3.8, Python no longer searches for DLLs in PATH
-   os.add_dll_directory (r"C:\msys64\mingw64\bin")
+PATH_THIS = os.path.abspath (os.path.dirname (__file__))
+PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS))))
+
+if platform.system () == 'Windows':
+   bin_dir = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin')
+   os.environ ['PATH'] = '%s;%s' % (bin_dir, os.environ ['PATH'])
+   if sys.version_info >= (3, 8):
+      os.add_dll_directory (bin_dir)
+
 import cairocffi
 
 from svg2mod.importer import Svg2ModImport
 from svg2mod.exporter import (DEFAULT_DPI, Svg2ModExportPretty)
 from svg2mod.coloredlogger import logger
 
-PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_GENERATORS = os.path.abspath (os.path.dirname (PATH_THIS))
 
 MM_TO_PT = 72.0 / 25.4

--- a/build-system/erbui/generators/front_panel/pdf.py
+++ b/build-system/erbui/generators/front_panel/pdf.py
@@ -14,9 +14,15 @@ import sys
 
 from ..detail.panel import Panel as detailPanel
 
-if platform.system () == 'Windows' and sys.version_info >= (3, 8):
-   # Starting from 3.8, Python no longer searches for DLLs in PATH
-   os.add_dll_directory (r"C:\msys64\mingw64\bin")
+PATH_THIS = os.path.abspath (os.path.dirname (__file__))
+PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS))))
+
+if platform.system () == 'Windows':
+   bin_dir = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin')
+   os.environ ['PATH'] = '%s;%s' % (bin_dir, os.environ ['PATH'])
+   if sys.version_info >= (3, 8):
+      os.add_dll_directory (bin_dir)
+
 import cairocffi
 
 

--- a/build-system/erbui/generators/vcvrack/panel.py
+++ b/build-system/erbui/generators/vcvrack/panel.py
@@ -14,9 +14,15 @@ import sys
 
 from ..detail.panel import Panel as detailPanel
 
-if platform.system () == 'Windows' and sys.version_info >= (3, 8):
-   # Starting from 3.8, Python no longer searches for DLLs in PATH
-   os.add_dll_directory (r"C:\msys64\mingw64\bin")
+PATH_THIS = os.path.abspath (os.path.dirname (__file__))
+PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS))))
+
+if platform.system () == 'Windows':
+   bin_dir = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin')
+   os.environ ['PATH'] = '%s;%s' % (bin_dir, os.environ ['PATH'])
+   if sys.version_info >= (3, 8):
+      os.add_dll_directory (bin_dir)
+
 import cairocffi
 
 

--- a/build-system/init.sh
+++ b/build-system/init.sh
@@ -2,7 +2,6 @@
 
 BUILD_SYSTEM_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-${(%):-%x}}" )" &> /dev/null && pwd )
 export PATH=$PATH:$BUILD_SYSTEM_DIR/scripts
-export PATH=$PATH:/c/msys64/mingw64/bin
 
 _erbb_complete()
 {

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -11,8 +11,11 @@ from __future__ import print_function
 import os
 import platform
 import random
+import shutil
 import subprocess
 import sys
+import urllib.request
+import zipfile
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
@@ -180,6 +183,23 @@ def setup ():
       subprocess.check_call ('cp include/erb/vcvrack/design/indie-flower/*.ttf ~/.local/share/fonts', shell=True, cwd=PATH_ROOT)
 
    elif platform.system () == 'Windows':
+      PATH_TOOLCHAIN = os.path.abspath (os.path.join (PATH_ROOT, 'build-system', 'toolchain'))
+      if os.path.exists (PATH_TOOLCHAIN):
+         shutil.rmtree (PATH_TOOLCHAIN)
+      os.makedirs (PATH_TOOLCHAIN)
+
+      def show_progress (block_num, block_size, total_size):
+         print ('Downloading toolchain... %s%%' % round (block_num * block_size / total_size * 100, 2), end="\r")
+      urllib.request.urlretrieve (
+         'https://github.com/ohmtech-rdi/erb-toolchain-msys2-mingw64/releases/download/v0.1/msys2_mingw64.zip',
+         os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64.zip'),
+         show_progress
+      )
+
+      print ('Extracting toolchain...            ')
+      with zipfile.ZipFile (os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64.zip'), 'r') as zip_ref:
+         zip_ref.extractall (os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64'))
+
       subprocess.check_call ('choco install gcc-arm-embedded', shell=True)
       subprocess.check_call ('choco install kicad --version=6.0.6', shell=True)
       subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -182,7 +182,6 @@ def setup ():
    elif platform.system () == 'Windows':
       subprocess.check_call ('choco install gcc-arm-embedded', shell=True)
       subprocess.check_call ('choco install kicad --version=6.0.6', shell=True)
-      subprocess.check_call ('c:/msys64/usr/bin/bash -lc "pacman -S --needed base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo --noconfirm"', shell=True)
       subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)
       subprocess.check_call ('cp include/erb/vcvrack/design/d-din/*.otf c:/windows/fonts', shell=True, cwd=PATH_ROOT)
       subprocess.check_call ('cp include/erb/vcvrack/design/indie-flower/*.ttf c:/windows/fonts', shell=True, cwd=PATH_ROOT)


### PR DESCRIPTION
This PR changes the way `erbb setup` install the MSYS2 Ming64 tools we use to build the simulator and use cairo to produce graphics (making the panel in different formats).

It does so by directly copying the relevant file rather than relying on the MSYS2 package manager. In practice, our users can have different configurations and it becomes difficult to make sure eurorack-blocks is directly installed. To circumvent this:
- We install the packages we need in the eurorack-blocks build-system to provide isolation
- We changed the build-system to ensure we select our versions of the tools

To ensure we select properly our tools, we manipulate the `PATH`, but do this from within python. This ensures:
- We don't polute the global environment of the user
- We make sure that the order of directories in the `PATH` do not have any impact on eurorack-blocks tool selection.

Removing the dependency on msys2 also removes one manual installation, and make the eurorack-blocks installation more lean.

Finally, the method we use is similar to the one chosen for Daisy.
