### PR TITLE
Remove unused msys2 from documentation

### DIFF
--- a/documentation/faust/setup.md
+++ b/documentation/faust/setup.md
@@ -26,7 +26,6 @@ You then only need minimum knowledge on how the terminal works to get going.
 - Windows at least version 10
 - The [Git Bash](https://git-scm.com/download) shell
 - The [Chocolatey](https://chocolatey.org) package manager
-- The [MSYS2](https://www.msys2.org) software distribution and building platform
 
 All commands on Windows are expecting the use of Git Bash.
 They are not compatible with Cmd or PowerShell.

--- a/documentation/getting-started/setup.md
+++ b/documentation/getting-started/setup.md
@@ -26,7 +26,6 @@ You then only need minimum knowledge on how the terminal works to get going.
 - Windows at least version 10
 - The [Git Bash](https://git-scm.com/download) shell
 - The [Chocolatey](https://chocolatey.org) package manager
-- The [MSYS2](https://www.msys2.org) software distribution and building platform
 
 All commands on Windows are expecting the use of Git Bash.
 They are not compatible with Cmd or PowerShell.

--- a/documentation/max/setup.md
+++ b/documentation/max/setup.md
@@ -23,7 +23,6 @@ You then only need minimum knowledge on how the terminal works to get going.
 - Windows at least version 10
 - The [Git Bash](https://git-scm.com/download) shell
 - The [Chocolatey](https://chocolatey.org) package manager
-- The [MSYS2](https://www.msys2.org) software distribution and building platform
 
 All commands on Windows are expecting the use of Git Bash.
 They are not compatible with Cmd or PowerShell.


### PR DESCRIPTION
This PR removes the mention of MSYS2 in the documentation, as we are not using it anymore.