### PR TITLE
Fix cairo font alignments on windows

### DIFF
--- a/build-system/erbui/generators/detail/panel.py
+++ b/build-system/erbui/generators/detail/panel.py
@@ -213,6 +213,13 @@ class Panel:
       xbearing, ybearing, width_pt, height_pt, dx, dy = context.text_extents (label.text)
       ascent, descent, height, max_x_advance, max_y_advance = context.font_extents ()
 
+      if platform.system () == 'Windows':
+         # for some reason, cairo extents are exactly 2 points more on windows
+         width_pt -= 2
+         # for some reason, ascent and descent are rounded up on windows
+         # correct by approximating the real ascent for vertical alignment
+         ascent *= self.current_font_height / (ascent + descent)
+
       if control is not None and control.is_kind_out and not module.material.is_dark:
          self.generate_back_out_path (context, module, control)
 


### PR DESCRIPTION
This PR fixes 2 problems in cairo on Windows where, for whatever reason, the text and font extents do not return the same value as on macOS:
- The text extent width is around 2pt bigger
- The font extents ascent and descent are more or less rounded to the next integer, so that the ascent + descent is not the font height.

We correct this by removing 2pt to the text width, and make an approximation of the correct ascent for vertical alignment.

The vertical alignment is not perfect, because ascent and descent are rounded independently, but most probably good enough: in our tests, this is at worst 0.1mm-precise, which is typically less than the front panel machine tolerance (either drilled aluminum or PCB).

One should note that `cairocffi.FontOptions.set_hint_metrics` with `cairocffi.HINT_METRICS_OFF` doesn't seem to have any impact on that.

Another problem is that the font weight for bold interpretation is different, even though we supply the bold font. It seems impossible to correct this for some reason unfortunately.

A better way to fix all this would be probably to scrap all font handling from cairo, and use freetype directly. We tried also to use pango, but for some reason kerning is not properly acknowledged for the fonts we use, which is even worse.
