### PR TITLE
Toolchain windows kicad 6

### DIFF
--- a/boards/kivu12/build.py
+++ b/boards/kivu12/build.py
@@ -81,7 +81,7 @@ def get_kicad_python_path ():
       return os.path.join (PATH_TOOLCHAIN, 'KiCad.app', 'Contents', 'Frameworks', 'Python.framework', 'Versions', '3.8', 'bin', 'python3.8')
 
    elif platform.system () == 'Windows':
-      return 'c:/Program Files/KiCad/6.0/bin/python.exe'
+      return os.path.join (PATH_TOOLCHAIN, 'KiCad', '6.0', 'bin', 'python.exe')
 
    else:
       return 'python'

--- a/boards/kivu12/generate.py
+++ b/boards/kivu12/generate.py
@@ -24,7 +24,7 @@ PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
 if platform.system () == 'Darwin':
    sys.path.insert (0, os.path.join (PATH_TOOLCHAIN, 'KiCad.app', 'Contents', 'Frameworks', 'Python.framework', 'Versions', '3.8', 'lib', 'python3.8', 'site-packages'))
 elif platform.system () == 'Windows':
-   sys.path.insert(0, "c:/Program Files/KiCad/6.0/bin/Lib/site-packages/")
+   sys.path.insert (0, os.path.join (PATH_TOOLCHAIN, 'KiCad', '6.0', 'bin', 'Lib', 'site-packages'))
 
 import pcbnew
 

--- a/build-system/erbui/generators/front_panel/pcb.py
+++ b/build-system/erbui/generators/front_panel/pcb.py
@@ -366,7 +366,7 @@ class Pcb:
          return os.path.join (PATH_TOOLCHAIN, 'KiCad.app', 'Contents', 'Frameworks', 'Python.framework', 'Versions', '3.8', 'bin', 'python3.8')
 
       elif platform.system () == 'Windows':
-         return 'c:/Program Files/KiCad/6.0/bin/python.exe'
+         return os.path.join (PATH_TOOLCHAIN, 'KiCad', '6.0', 'bin', 'python.exe')
 
       else:
          return 'python'

--- a/build-system/erbui/generators/front_pcb/fill_zones.py
+++ b/build-system/erbui/generators/front_pcb/fill_zones.py
@@ -20,7 +20,7 @@ PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
 if platform.system () == 'Darwin':
    sys.path.insert (0, os.path.join (PATH_TOOLCHAIN, 'KiCad.app', 'Contents', 'Frameworks', 'Python.framework', 'Versions', '3.8', 'lib', 'python3.8', 'site-packages'))
 elif platform.system () == 'Windows':
-   sys.path.insert(0, "c:/Program Files/KiCad/6.0/bin/Lib/site-packages/")
+   sys.path.insert (0, os.path.join (PATH_TOOLCHAIN, 'KiCad', '6.0', 'bin', 'Lib', 'site-packages'))
 
 import pcbnew
 

--- a/build-system/erbui/generators/front_pcb/generate_gerber.py
+++ b/build-system/erbui/generators/front_pcb/generate_gerber.py
@@ -20,7 +20,7 @@ PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
 if platform.system () == 'Darwin':
    sys.path.insert (0, os.path.join (PATH_TOOLCHAIN, 'KiCad.app', 'Contents', 'Frameworks', 'Python.framework', 'Versions', '3.8', 'lib', 'python3.8', 'site-packages'))
 elif platform.system () == 'Windows':
-   sys.path.insert(0, "c:/Program Files/KiCad/6.0/bin/Lib/site-packages/")
+   sys.path.insert (0, os.path.join (PATH_TOOLCHAIN, 'KiCad', '6.0', 'bin', 'Lib', 'site-packages'))
 
 import pcbnew
 

--- a/build-system/erbui/generators/front_pcb/kicad_pcb.py
+++ b/build-system/erbui/generators/front_pcb/kicad_pcb.py
@@ -111,7 +111,7 @@ class KicadPcb:
          return os.path.join (PATH_TOOLCHAIN, 'KiCad.app', 'Contents', 'Frameworks', 'Python.framework', 'Versions', '3.8', 'bin', 'python3.8')
 
       elif platform.system () == 'Windows':
-         return 'c:/Program Files/KiCad/6.0/bin/python.exe'
+         return os.path.join (PATH_TOOLCHAIN, 'KiCad', '6.0', 'bin', 'python.exe')
 
       else:
          return 'python'

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -14,8 +14,6 @@ import random
 import shutil
 import subprocess
 import sys
-import urllib.request
-import zipfile
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
@@ -184,19 +182,7 @@ def setup ():
       subprocess.check_call ('cp include/erb/vcvrack/design/indie-flower/*.ttf ~/.local/share/fonts', shell=True, cwd=PATH_ROOT)
 
    elif platform.system () == 'Windows':
-
-      def show_progress (block_num, block_size, total_size):
-         print ('Downloading toolchain... %s%%' % round (block_num * block_size / total_size * 100, 2), end="\r")
-      urllib.request.urlretrieve (
-         'https://github.com/ohmtech-rdi/erb-toolchain-msys2-mingw64/releases/download/v0.1/msys2_mingw64.zip',
-         os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64.zip'),
-         show_progress
-      )
-
-      print ('Extracting toolchain...            ')
-      with zipfile.ZipFile (os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64.zip'), 'r') as zip_ref:
-         zip_ref.extractall (os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64'))
-
+      setup.install_msys2_mingw64 ()
       subprocess.check_call ('choco install gcc-arm-embedded', shell=True)
       subprocess.check_call ('choco install kicad --version=6.0.6', shell=True)
       subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -183,8 +183,8 @@ def setup ():
 
    elif platform.system () == 'Windows':
       setup.install_msys2_mingw64 ()
+      setup.install_kicad_windows ()
       subprocess.check_call ('choco install gcc-arm-embedded', shell=True)
-      subprocess.check_call ('choco install kicad --version=6.0.6', shell=True)
       subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)
       subprocess.check_call ('cp include/erb/vcvrack/design/d-din/*.otf c:/windows/fonts', shell=True, cwd=PATH_ROOT)
       subprocess.check_call ('cp include/erb/vcvrack/design/indie-flower/*.ttf c:/windows/fonts', shell=True, cwd=PATH_ROOT)

--- a/build-system/setup/__init__.py
+++ b/build-system/setup/__init__.py
@@ -65,6 +65,25 @@ def install_kicad_macos ():
 
 """
 ==============================================================================
+Name: install_kicad_windows
+==============================================================================
+"""
+
+def install_kicad_windows ():
+   name = 'kicad_minimal_windows_6.0.11-0.tar.gz'
+   download (
+      'https://github.com/ohmtech-rdi/erb-toolchain-windows-kicad-6/releases/download/v0.1/%s' % name,
+      name
+   )
+
+   print ('Extracting %s...            ' % name)
+   with tarfile.open (os.path.join (PATH_TOOLCHAIN, name), mode='r:gz') as tf:
+      tf.extractall (PATH_TOOLCHAIN)
+
+
+
+"""
+==============================================================================
 Name: install_msys2_mingw64
 ==============================================================================
 """

--- a/build-system/setup/__init__.py
+++ b/build-system/setup/__init__.py
@@ -12,6 +12,7 @@ import sys
 import tarfile
 import time
 import urllib.request
+import zipfile
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
@@ -59,3 +60,22 @@ def install_kicad_macos ():
    print ('Extracting %s...            ' % name)
    with tarfile.open (os.path.join (PATH_TOOLCHAIN, name), mode='r:gz') as tf:
       tf.extractall (PATH_TOOLCHAIN)
+
+
+
+"""
+==============================================================================
+Name: install_msys2_mingw64
+==============================================================================
+"""
+
+def install_msys2_mingw64 ():
+   name = 'msys2_mingw64.zip'
+   download (
+      'https://github.com/ohmtech-rdi/erb-toolchain-msys2-mingw64/releases/download/v0.1/%s' % name,
+      name
+   )
+
+   print ('Extracting %s...            ' % name)
+   with zipfile.ZipFile (os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64.zip'), 'r') as zip_ref:
+      zip_ref.extractall (os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64'))


### PR DESCRIPTION
This PR makes the install more isolated and fast by installing a minimal version of KiCad 6 directly into our build system.

This PR is part of a series of incremental changes to isolate our installation to make it more robust with different users configurations.
