### PR TITLE
Toolchain windows gcc arm none eabi

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -19,9 +19,10 @@ import sys
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
 PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (PATH_THIS))
+PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
 
 if platform.system () == 'Windows':
-   MAKE_CMD = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin', 'mingw32-make.exe')
+   MAKE_CMD = os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64', 'bin', 'mingw32-make.exe')
 else:
    MAKE_CMD = 'make'
 
@@ -391,7 +392,15 @@ def build_libdaisy ():
       '--directory=%s' % os.path.join (PATH_ROOT, 'submodules', 'libDaisy'),
    ]
 
-   subprocess.check_call (cmd)
+   if platform.system () == 'Windows':
+      PATH_ARM_BIN = os.path.join (PATH_TOOLCHAIN, 'gcc-arm-none-eabi-10.3-2021.10', 'bin')
+      env = dict (
+         os.environ,
+         **{'GCC_PATH': PATH_ARM_BIN}
+      )
+      subprocess.check_call (cmd, env=env)
+   else:
+      subprocess.check_call (cmd)
 
 
 

--- a/build-system/erbb/generators/daisy/Makefile_template
+++ b/build-system/erbb/generators/daisy/Makefile_template
@@ -19,15 +19,14 @@ CONFIGURATION ?= Debug
 
 
 # Toolchain
-CC = arm-none-eabi-gcc
-CXX = arm-none-eabi-g++
-GDB = arm-none-eabi-gdb
-AS = arm-none-eabi-gcc -x assembler-with-cpp
-CP = arm-none-eabi-objcopy
-SZ = arm-none-eabi-size
-HEX = arm-none-eabi-objcopy -O ihex
-BIN = arm-none-eabi-objcopy -O binary -S
-
+%define_CC%
+%define_CXX%
+%define_GDB%
+%define_AS%
+%define_CP%
+%define_SZ%
+%define_HEX%
+%define_BIN%
 
 
 # C standard

--- a/build-system/erbb/generators/daisy/make.py
+++ b/build-system/erbb/generators/daisy/make.py
@@ -13,8 +13,10 @@ import sys
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS)))))
-PATH_ERBB_GENS = os.path.join (PATH_ROOT, 'build-system', 'erbb', 'generators')
-PATH_ERBUI_GENS = os.path.join (PATH_ROOT, 'build-system', 'erbui', 'generators')
+PATH_BUILD_SYSTEM = os.path.join (PATH_ROOT, 'build-system')
+PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
+PATH_ERBB_GENS = os.path.join (PATH_BUILD_SYSTEM, 'erbb', 'generators')
+PATH_ERBUI_GENS = os.path.join (PATH_BUILD_SYSTEM, 'erbui', 'generators')
 PATH_LIBDAISY = os.path.join (PATH_ROOT, 'submodules', 'libDaisy')
 
 
@@ -59,6 +61,27 @@ class Make:
       template = template.replace ('%module.name%', module.name)
       template = template.replace ('%define_PATH_ROOT%', 'PATH_ROOT ?= %s' % path_root.replace ('\\', '/'))
       template = template.replace ('%define_PATH_LIBDAISY%', 'LIBDAISY_DIR ?= %s' % path_libdaisy.replace ('\\', '/'))
+
+      if platform.system () == 'Windows':
+         PATH_ARM_BIN = os.path.join (PATH_TOOLCHAIN, 'gcc-arm-none-eabi-10.3-2021.10', 'bin')
+         template = template.replace ('%define_CC%', 'CC = %s' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-gcc').replace ('\\', '/'))
+         template = template.replace ('%define_CXX%', 'CXX = %s' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-g++').replace ('\\', '/'))
+         template = template.replace ('%define_GDB%', 'GDB = %s' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-gdb').replace ('\\', '/'))
+         template = template.replace ('%define_AS%', 'AS = %s -x assembler-with-cpp' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-gcc').replace ('\\', '/'))
+         template = template.replace ('%define_CP%', 'CP = %s' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-objcopy').replace ('\\', '/'))
+         template = template.replace ('%define_SZ%', 'SZ = %s' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-size').replace ('\\', '/'))
+         template = template.replace ('%define_HEX%', 'HEX = %s -O ihex' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-objcopy').replace ('\\', '/'))
+         template = template.replace ('%define_BIN%', 'BIN = %s -O binary -S' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-objcopy').replace ('\\', '/'))
+      else:
+         template = template.replace ('%define_CC%', 'CC = arm-none-eabi-gcc')
+         template = template.replace ('%define_CXX%', 'CXX = arm-none-eabi-g++')
+         template = template.replace ('%define_GDB%', 'GDB = arm-none-eabi-gdb')
+         template = template.replace ('%define_AS%', 'AS = arm-none-eabi-gcc -x assembler-with-cpp')
+         template = template.replace ('%define_CP%', 'CP = arm-none-eabi-objcopy')
+         template = template.replace ('%define_SZ%', 'SZ = arm-none-eabi-size')
+         template = template.replace ('%define_HEX%', 'HEX = arm-none-eabi-objcopy -O ihex')
+         template = template.replace ('%define_BIN%', 'BIN = arm-none-eabi-objcopy -O binary -S')
+
       template = template.replace ('%LDS_PATH%', path_lds)
       template = self.replace_warnings (template, strict)
       template = self.replace_defines (template, module, module.defines)

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -184,7 +184,7 @@ def setup ():
    elif platform.system () == 'Windows':
       setup.install_msys2_mingw64 ()
       setup.install_kicad_windows ()
-      subprocess.check_call ('choco install gcc-arm-embedded', shell=True)
+      setup.install_gnu_arm_embedded_windows ()
       subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)
       subprocess.check_call ('cp include/erb/vcvrack/design/d-din/*.otf c:/windows/fonts', shell=True, cwd=PATH_ROOT)
       subprocess.check_call ('cp include/erb/vcvrack/design/indie-flower/*.ttf c:/windows/fonts', shell=True, cwd=PATH_ROOT)

--- a/build-system/setup/__init__.py
+++ b/build-system/setup/__init__.py
@@ -96,5 +96,24 @@ def install_msys2_mingw64 ():
    )
 
    print ('Extracting %s...            ' % name)
-   with zipfile.ZipFile (os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64.zip'), 'r') as zip_ref:
+   with zipfile.ZipFile (os.path.join (PATH_TOOLCHAIN, name), 'r') as zip_ref:
       zip_ref.extractall (os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64'))
+
+
+
+"""
+==============================================================================
+Name: install_gnu_arm_embedded_windows
+==============================================================================
+"""
+
+def install_gnu_arm_embedded_windows ():
+   name = 'gcc-arm-none-eabi-10.3-2021.10-win32.zip'
+   download (
+      'https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/%s' % name,
+      name
+   )
+
+   print ('Extracting %s...            ' % name)
+   with zipfile.ZipFile (os.path.join (PATH_TOOLCHAIN, name), 'r') as zip_ref:
+      zip_ref.extractall (PATH_TOOLCHAIN)

--- a/documentation/faust/setup.md
+++ b/documentation/faust/setup.md
@@ -25,7 +25,6 @@ You then only need minimum knowledge on how the terminal works to get going.
 
 - Windows at least version 10
 - The [Git Bash](https://git-scm.com/download) shell
-- The [Chocolatey](https://chocolatey.org) package manager
 
 All commands on Windows are expecting the use of Git Bash.
 They are not compatible with Cmd or PowerShell.

--- a/documentation/getting-started/setup.md
+++ b/documentation/getting-started/setup.md
@@ -25,7 +25,6 @@ You then only need minimum knowledge on how the terminal works to get going.
 
 - Windows at least version 10
 - The [Git Bash](https://git-scm.com/download) shell
-- The [Chocolatey](https://chocolatey.org) package manager
 
 All commands on Windows are expecting the use of Git Bash.
 They are not compatible with Cmd or PowerShell.

--- a/documentation/max/setup.md
+++ b/documentation/max/setup.md
@@ -22,7 +22,6 @@ You then only need minimum knowledge on how the terminal works to get going.
 
 - Windows at least version 10
 - The [Git Bash](https://git-scm.com/download) shell
-- The [Chocolatey](https://chocolatey.org) package manager
 
 All commands on Windows are expecting the use of Git Bash.
 They are not compatible with Cmd or PowerShell.


### PR DESCRIPTION
This PR adds the GCC ARM embedded toolchain to `erbb setup`, which was previously installed using Chocolatey.

This finally allows us to get rid of Chocolatey, which was too complicated for users to install.
