### PR TITLE
Panel freetype

### DIFF
--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -169,25 +169,17 @@ def setup ():
       setup.install_kicad_macos ()
       subprocess.check_call ('HOMEBREW_NO_AUTO_UPDATE=1 brew install armmbed/formulae/arm-none-eabi-gcc cairo libffi dfu-util openocd', shell=True)
       subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)
-      subprocess.check_call ('mkdir -p ~/Library/Fonts', shell=True)
-      subprocess.check_call ('cp include/erb/vcvrack/design/d-din/*.otf ~/Library/Fonts', shell=True, cwd=PATH_ROOT)
-      subprocess.check_call ('cp include/erb/vcvrack/design/indie-flower/*.ttf ~/Library/Fonts', shell=True, cwd=PATH_ROOT)
 
    elif platform.system () == 'Linux':
       subprocess.check_call ('sudo apt-get update', shell=True)
       subprocess.check_call ('sudo apt-get install -y gcc-arm-none-eabi libglu1-mesa-dev libcairo2-dev libffi-dev python3-dev kicad dfu-util openocd', shell=True)
       subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)
-      subprocess.check_call ('mkdir -p ~/.local/share/fonts/', shell=True)
-      subprocess.check_call ('cp include/erb/vcvrack/design/d-din/*.otf ~/.local/share/fonts', shell=True, cwd=PATH_ROOT)
-      subprocess.check_call ('cp include/erb/vcvrack/design/indie-flower/*.ttf ~/.local/share/fonts', shell=True, cwd=PATH_ROOT)
 
    elif platform.system () == 'Windows':
       setup.install_msys2_mingw64 ()
       setup.install_kicad_windows ()
       setup.install_gnu_arm_embedded_windows ()
       subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)
-      subprocess.check_call ('cp include/erb/vcvrack/design/d-din/*.otf c:/windows/fonts', shell=True, cwd=PATH_ROOT)
-      subprocess.check_call ('cp include/erb/vcvrack/design/indie-flower/*.ttf c:/windows/fonts', shell=True, cwd=PATH_ROOT)
 
    else:
       print ('Error: Platform %s unsupported' % platform.system ())

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -168,6 +168,15 @@ def setup ():
    if platform.system () == 'Darwin':
       setup.install_kicad_macos ()
       subprocess.check_call ('HOMEBREW_NO_AUTO_UPDATE=1 brew install armmbed/formulae/arm-none-eabi-gcc cairo libffi dfu-util openocd', shell=True)
+      pip_verbose_with_tags = subprocess.check_output (
+         [sys.executable, '-m', 'pip', 'debug', '--verbose'],
+         stderr=subprocess.DEVNULL
+      ).decode (sys.stdout.encoding)
+      # for freetype-py, libfreetype.dylib is part of the wheel iff tags are
+      # compatible with py3-none-macosx_10_9_universal2, which is not always
+      # the case. If not, install freetype.
+      if 'py3-none-macosx_10_9_universal2\n' not in pip_verbose_with_tags:
+         subprocess.check_call ('HOMEBREW_NO_AUTO_UPDATE=1 brew install freetype', shell=True)
 
    elif platform.system () == 'Linux':
       subprocess.check_call ('sudo apt-get update', shell=True)

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -168,22 +168,21 @@ def setup ():
    if platform.system () == 'Darwin':
       setup.install_kicad_macos ()
       subprocess.check_call ('HOMEBREW_NO_AUTO_UPDATE=1 brew install armmbed/formulae/arm-none-eabi-gcc cairo libffi dfu-util openocd', shell=True)
-      subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)
 
    elif platform.system () == 'Linux':
       subprocess.check_call ('sudo apt-get update', shell=True)
       subprocess.check_call ('sudo apt-get install -y gcc-arm-none-eabi libglu1-mesa-dev libcairo2-dev libffi-dev python3-dev kicad dfu-util openocd', shell=True)
-      subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)
 
    elif platform.system () == 'Windows':
       setup.install_msys2_mingw64 ()
       setup.install_kicad_windows ()
       setup.install_gnu_arm_embedded_windows ()
-      subprocess.check_call ('pip3 install -r requirements.txt', shell=True, cwd=PATH_ROOT)
 
    else:
       print ('Error: Platform %s unsupported' % platform.system ())
       sys.exit (1)
+
+   subprocess.check_call ('python3 -m pip install -r requirements.txt', shell=True, cwd=PATH_ROOT)
 
 
 

--- a/requirements/build-system.txt
+++ b/requirements/build-system.txt
@@ -4,6 +4,7 @@
 
 cairocffi>=1.4.0,<1.5.0
 CairoSVG>=2.6.0
+freetype-py>=2.4.0
 
 # DXF generation
 


### PR DESCRIPTION
This PR uses `freetype` to fix multiple problems with the current toy API from cairo:
- It ensures the font metrics and appearance are consistent between platforms,
- It allows to reference a font by path rather by family name, which make the installation simpler and therefore more robust.

Placement of glyphs slightly changes, as we base the ascent of the font on the character set most likely to be used when prototyping. We believe it is better, as it is based on visual properties of the font face.

Finally, this also simplify installation and avoid font problems, as we do not need to copy the fonts anymore, and reference a font face explicitly with an absolute path, rather than relying on font families and variants which might change from one font manager implementation to another.

> **Note**
> The outlines of Truetype fonts is not perfect, but since we use them only for stickers, this is good enough.

- Fixes #481 

Todo:
- [x] Make sure freetype dynamic library is installed
   - [x] on macOS Intel (it's not, but we have a fix)
   - [x] on macOS M1
   - [x] on Windows
   - [x] on Linux
- [x] Make sure it works on macOS Intel and compare
- [x] Make sure it works on macOS M1 and compare
- [x] Make sure it works on Windows and compare
- [x] Make sure it works on Linux and compare