### PR TITLE
Python3 packages

### DIFF
--- a/build-system/erbb/generators/data/code.py
+++ b/build-system/erbb/generators/data/code.py
@@ -8,13 +8,19 @@
 
 
 import os
-from soundfile import SoundFile
+import sys
 
 from ... import error
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS)))))
 PATH_BOARDS = os.path.join (PATH_ROOT, 'boards')
+PATH_BUILD_SYSTEM = os.path.join (PATH_ROOT, 'build-system')
+PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
+PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
+
+sys.path.insert (0, PATH_PY3_PACKAGES)
+from soundfile import SoundFile
 
 
 

--- a/build-system/erbb/generators/faust/code.py
+++ b/build-system/erbb/generators/faust/code.py
@@ -12,12 +12,19 @@ import math
 import os
 import platform
 import subprocess
-from soundfile import SoundFile
+import sys
 
 from ... import error
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS)))))
+PATH_BUILD_SYSTEM = os.path.join (PATH_ROOT, 'build-system')
+PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
+PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
+
+sys.path.insert (0, PATH_PY3_PACKAGES)
+from soundfile import SoundFile
+
 
 
 class FaustDsp:

--- a/build-system/erbb/generators/max/code.py
+++ b/build-system/erbb/generators/max/code.py
@@ -12,12 +12,19 @@ import math
 import os
 import re
 import subprocess
-from soundfile import SoundFile
+import sys
 
 from ... import error
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS)))))
+PATH_BUILD_SYSTEM = os.path.join (PATH_ROOT, 'build-system')
+PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
+PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
+
+sys.path.insert (0, PATH_PY3_PACKAGES)
+from soundfile import SoundFile
+
 
 
 class Code:

--- a/build-system/erbui/generators/detail/panel.py
+++ b/build-system/erbui/generators/detail/panel.py
@@ -21,7 +21,8 @@ from ..kicad import pcb
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS))))
 PATH_ROOT = os.path.abspath (os.path.dirname (PATH_BUILD_SYSTEM))
-
+PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
+PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
 
 if platform.system () == 'Windows':
    bin_dir = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin')
@@ -32,6 +33,7 @@ if platform.system () == 'Windows':
 PATH_FONT_DDIN_BOLD = os.path.join (PATH_ROOT, 'include', 'erb', 'vcvrack', 'design', 'd-din', 'D-DIN-Bold.otf')
 PATH_FONT_SCRIPT = os.path.join (PATH_ROOT, 'include', 'erb', 'vcvrack', 'design', 'indie-flower', 'IndieFlower-Regular.ttf')
 
+sys.path.insert (0, PATH_PY3_PACKAGES)
 import cairocffi
 import cairosvg
 import freetype

--- a/build-system/erbui/generators/front_panel/dxf.py
+++ b/build-system/erbui/generators/front_panel/dxf.py
@@ -7,11 +7,20 @@
 
 
 
-import ezdxf
 import math
 import os
+import sys
 
 from ..kicad import pcb
+
+PATH_THIS = os.path.abspath (os.path.dirname (__file__))
+PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS)))))
+PATH_BUILD_SYSTEM = os.path.join (PATH_ROOT, 'build-system')
+PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
+PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
+
+sys.path.insert (0, PATH_PY3_PACKAGES)
+import ezdxf
 
 
 

--- a/build-system/erbui/generators/front_panel/pcb.py
+++ b/build-system/erbui/generators/front_panel/pcb.py
@@ -23,6 +23,7 @@ from ..kicad import s_expression
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS))))
 PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
+PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
 
 if platform.system () == 'Windows':
    bin_dir = os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64', 'bin')
@@ -30,6 +31,7 @@ if platform.system () == 'Windows':
    if sys.version_info >= (3, 8):
       os.add_dll_directory (bin_dir)
 
+sys.path.insert (0, PATH_PY3_PACKAGES)
 import cairocffi
 
 from svg2mod.importer import Svg2ModImport

--- a/build-system/erbui/generators/front_panel/pdf.py
+++ b/build-system/erbui/generators/front_panel/pdf.py
@@ -16,6 +16,8 @@ from ..detail.panel import Panel as detailPanel
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS))))
+PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
+PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
 
 if platform.system () == 'Windows':
    bin_dir = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin')
@@ -23,6 +25,7 @@ if platform.system () == 'Windows':
    if sys.version_info >= (3, 8):
       os.add_dll_directory (bin_dir)
 
+sys.path.insert (0, PATH_PY3_PACKAGES)
 import cairocffi
 
 

--- a/build-system/erbui/generators/max/code.py
+++ b/build-system/erbui/generators/max/code.py
@@ -11,12 +11,18 @@ import json
 import math
 import os
 import subprocess
-from soundfile import SoundFile
+import sys
 
 from ... import error
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS)))))
+PATH_BUILD_SYSTEM = os.path.join (PATH_ROOT, 'build-system')
+PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
+PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
+
+sys.path.insert (0, PATH_PY3_PACKAGES)
+from soundfile import SoundFile
 
 
 class Code:

--- a/build-system/erbui/generators/vcvrack/panel.py
+++ b/build-system/erbui/generators/vcvrack/panel.py
@@ -16,6 +16,8 @@ from ..detail.panel import Panel as detailPanel
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (os.path.dirname (os.path.dirname (PATH_THIS))))
+PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
+PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
 
 if platform.system () == 'Windows':
    bin_dir = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin')
@@ -23,6 +25,7 @@ if platform.system () == 'Windows':
    if sys.version_info >= (3, 8):
       os.add_dll_directory (bin_dir)
 
+sys.path.insert (0, PATH_PY3_PACKAGES)
 import cairocffi
 
 

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -191,7 +191,8 @@ def setup ():
       print ('Error: Platform %s unsupported' % platform.system ())
       sys.exit (1)
 
-   subprocess.check_call ('python3 -m pip install -r requirements.txt', shell=True, cwd=PATH_ROOT)
+   setup.install_python_requirements ()
+   setup.check ()
 
 
 

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -174,7 +174,7 @@ def setup ():
       ).decode (sys.stdout.encoding)
       # for freetype-py, libfreetype.dylib is part of the wheel iff tags are
       # compatible with py3-none-macosx_10_9_universal2, which is not always
-      # the case. If not, install freetype.
+      # the case, in particular for versions of pip before 22.2. If not, install freetype.
       if 'py3-none-macosx_10_9_universal2\n' not in pip_verbose_with_tags:
          subprocess.check_call ('HOMEBREW_NO_AUTO_UPDATE=1 brew install freetype', shell=True)
 

--- a/build-system/setup/__init__.py
+++ b/build-system/setup/__init__.py
@@ -8,6 +8,9 @@
 
 
 import os
+import platform
+import shutil
+import subprocess
 import sys
 import tarfile
 import time
@@ -18,6 +21,8 @@ PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
 PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (PATH_THIS))
 PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
+PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
+
 
 
 """
@@ -34,7 +39,7 @@ def download (url, name):
       if cur_time > prev_time + 1:
          prev_time = cur_time
          current = round (block_num * block_size / total_size * 100, 2)
-         print ('Downloading %s... %s%%' % (name, current), end='\r')
+         print ('Downloading %s... %s%%  ' % (name, current), end='\r')
 
    urllib.request.urlretrieve (
       url,
@@ -117,3 +122,79 @@ def install_gnu_arm_embedded_windows ():
    print ('Extracting %s...            ' % name)
    with zipfile.ZipFile (os.path.join (PATH_TOOLCHAIN, name), 'r') as zip_ref:
       zip_ref.extractall (PATH_TOOLCHAIN)
+
+
+
+"""
+==============================================================================
+Name: install_python_requirements
+==============================================================================
+"""
+
+def install_python_requirements ():
+   os.makedirs (PATH_PY3_PACKAGES)
+
+   print ('Installing python packages...')
+
+   # Start by installing a version of pip after 22.2. This version introduces
+   # the 'universal2' that some our dependencies, like freetype-py, depends
+   # on, in order to install the wheel we need.
+
+   subprocess.check_call (
+      [
+         sys.executable,
+         '-m', 'pip', 'install',
+         '--quiet', '--quiet', '--quiet',
+         '--disable-pip-version-check',
+         '--log', os.path.join (PATH_TOOLCHAIN, 'pip-install-pip.log.txt'),
+         '--target', PATH_PY3_PACKAGES,
+         'pip==23.1.2',
+      ]
+   )
+
+   # pip install --target does not support well shared namespaces. Here with
+   # the bin/ folder which is used for `pip` binaries, which we don't use
+   # so remove that folder before installing requirements.
+
+   shutil.rmtree (os.path.join (PATH_PY3_PACKAGES, 'bin'))
+
+   subprocess.check_call (
+      [
+         sys.executable,
+         '-m', 'pip', 'install',
+         '--quiet', '--quiet', '--quiet',
+         '--disable-pip-version-check',
+         '--log', os.path.join (PATH_TOOLCHAIN, 'pip-install-reqs.log.txt'),
+         '--target', PATH_PY3_PACKAGES,
+         '--report', os.path.join (PATH_TOOLCHAIN, 'pip-report.json'),
+         '--requirement', os.path.join (PATH_ROOT, 'requirements.txt'),
+      ],
+      cwd=PATH_PY3_PACKAGES
+   )
+
+
+
+"""
+==============================================================================
+Name: check
+==============================================================================
+"""
+
+def check ():
+   print ('Checking toolchain...')
+
+   if platform.system () == 'Windows':
+      bin_dir = os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64', 'bin')
+      os.environ ['PATH'] = '%s;%s' % (bin_dir, os.environ ['PATH'])
+      if sys.version_info >= (3, 8):
+         os.add_dll_directory (bin_dir)
+
+   sys.path.insert (0, PATH_PY3_PACKAGES)
+   import cairocffi
+   import cairosvg
+   import freetype
+   import svg2mod
+   import soundfile
+   import ezdxf
+
+   print ('OK.')


### PR DESCRIPTION
This PR isolates installations of python modules, more or less like a python virtual environment does, except we don't need to ask users to activate a virtual environment. This won't modify previous installations of the python packages we install, but when loading modules, we will load modules from the base installation: this is different from a some python virtual environment implementation, as this is not completely isolated.

In particular, this makes sure a recent version of `pip` is available, so the installation process can catch the proper wheels to install.
