### PR TITLE
Toolchain macos gcc arm none eabi

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -398,7 +398,7 @@ def build_libdaisy ():
       '--directory=%s' % os.path.join (PATH_ROOT, 'submodules', 'libDaisy'),
    ]
 
-   if platform.system () == 'Windows':
+   if platform.system () in ['Darwin', 'Windows']:
       PATH_ARM_BIN = os.path.join (PATH_TOOLCHAIN, 'gcc-arm-none-eabi-10.3-2021.10', 'bin')
       env = dict (
          os.environ,

--- a/build-system/erbb/generators/daisy/make.py
+++ b/build-system/erbb/generators/daisy/make.py
@@ -62,7 +62,18 @@ class Make:
       template = template.replace ('%define_PATH_ROOT%', 'PATH_ROOT ?= %s' % path_root.replace ('\\', '/'))
       template = template.replace ('%define_PATH_LIBDAISY%', 'LIBDAISY_DIR ?= %s' % path_libdaisy.replace ('\\', '/'))
 
-      if platform.system () == 'Windows':
+      if platform.system () == 'Darwin':
+         PATH_ARM_BIN = os.path.join (PATH_TOOLCHAIN, 'gcc-arm-none-eabi-10.3-2021.10', 'bin')
+         template = template.replace ('%define_CC%', 'CC = %s' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-gcc'))
+         template = template.replace ('%define_CXX%', 'CXX = %s' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-g++'))
+         template = template.replace ('%define_GDB%', 'GDB = %s' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-gdb'))
+         template = template.replace ('%define_AS%', 'AS = %s -x assembler-with-cpp' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-gcc'))
+         template = template.replace ('%define_CP%', 'CP = %s' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-objcopy'))
+         template = template.replace ('%define_SZ%', 'SZ = %s' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-size'))
+         template = template.replace ('%define_HEX%', 'HEX = %s -O ihex' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-objcopy'))
+         template = template.replace ('%define_BIN%', 'BIN = %s -O binary -S' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-objcopy'))
+
+      elif platform.system () == 'Windows':
          PATH_ARM_BIN = os.path.join (PATH_TOOLCHAIN, 'gcc-arm-none-eabi-10.3-2021.10', 'bin')
          template = template.replace ('%define_CC%', 'CC = %s' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-gcc').replace ('\\', '/'))
          template = template.replace ('%define_CXX%', 'CXX = %s' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-g++').replace ('\\', '/'))
@@ -72,6 +83,7 @@ class Make:
          template = template.replace ('%define_SZ%', 'SZ = %s' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-size').replace ('\\', '/'))
          template = template.replace ('%define_HEX%', 'HEX = %s -O ihex' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-objcopy').replace ('\\', '/'))
          template = template.replace ('%define_BIN%', 'BIN = %s -O binary -S' % os.path.join (PATH_ARM_BIN, 'arm-none-eabi-objcopy').replace ('\\', '/'))
+
       else:
          template = template.replace ('%define_CC%', 'CC = arm-none-eabi-gcc')
          template = template.replace ('%define_CXX%', 'CXX = arm-none-eabi-g++')

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -167,7 +167,8 @@ def setup ():
 
    if platform.system () == 'Darwin':
       setup.install_kicad_macos ()
-      subprocess.check_call ('HOMEBREW_NO_AUTO_UPDATE=1 brew install armmbed/formulae/arm-none-eabi-gcc cairo libffi dfu-util openocd', shell=True)
+      setup.install_gnu_arm_embedded_macos ()
+      subprocess.check_call ('HOMEBREW_NO_AUTO_UPDATE=1 brew install cairo libffi dfu-util openocd', shell=True)
 
    elif platform.system () == 'Linux':
       subprocess.check_call ('sudo apt-get update', shell=True)

--- a/build-system/setup/__init__.py
+++ b/build-system/setup/__init__.py
@@ -108,6 +108,25 @@ def install_msys2_mingw64 ():
 
 """
 ==============================================================================
+Name: install_gnu_arm_embedded_macos
+==============================================================================
+"""
+
+def install_gnu_arm_embedded_macos ():
+   name = 'gcc-arm-none-eabi-10.3-2021.10-mac.tar.bz2'
+   download (
+      'https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/%s' % name,
+      name
+   )
+
+   print ('Extracting %s...            ' % name)
+   with tarfile.open (os.path.join (PATH_TOOLCHAIN, name), mode='r:bz2') as tf:
+      tf.extractall (PATH_TOOLCHAIN)
+
+
+
+"""
+==============================================================================
 Name: install_gnu_arm_embedded_windows
 ==============================================================================
 """


### PR DESCRIPTION
This PR adds the GCC ARM embedded toolchain to erbb setup, which was previously installed using `brew`, but was using a `git` repository that was just uncompressing the official archive.

`arm-none-eabi-*` are x86_64 only, but given the projects tend to be small, the rosetta emulation is fast enough for now.
