### PR TITLE
Remove libffi brew install

### DIFF
--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -168,7 +168,7 @@ def setup ():
    if platform.system () == 'Darwin':
       setup.install_kicad_macos ()
       setup.install_gnu_arm_embedded_macos ()
-      subprocess.check_call ('HOMEBREW_NO_AUTO_UPDATE=1 brew install cairo libffi dfu-util openocd', shell=True)
+      subprocess.check_call ('HOMEBREW_NO_AUTO_UPDATE=1 brew install cairo dfu-util openocd', shell=True)
 
    elif platform.system () == 'Linux':
       subprocess.check_call ('sudo apt-get update', shell=True)


### PR DESCRIPTION
This PR removes `libffi` install on macOS with `brew`.

`brew` reports:

```
libffi is keg-only, which means it was not symlinked into /usr/local,
because macOS already provides this software and installing another version in
parallel can cause all kinds of trouble.

For compilers to find libffi you may need to set:
  export LDFLAGS="-L/usr/local/opt/libffi/lib"
  export CPPFLAGS="-I/usr/local/opt/libffi/include"
```

So this is not used, and can be removed from install.
