### PR TITLE
Toolchain macos

### DIFF
--- a/.github/workflows/macos_11.yml
+++ b/.github/workflows/macos_11.yml
@@ -146,15 +146,15 @@ jobs:
   erbb_tests:
     name: Erbb/Erbui Tests
     runs-on: macos-11
+    defaults:
+      run:
+        shell: bash -l {0} # Source profile for each step
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: brew install cairo libffi
-      - run: pip3 install -r requirements.txt
-      - run: mkdir -p ~/Library/Fonts
-      - run: cp include/erb/vcvrack/design/d-din/*.otf ~/Library/Fonts
-      - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/Library/Fonts
+      - run: python3 build-system/install.py
+      - run: erbb setup
       - run: python3 -m pip install coverage
       - run: python3 build-system/test.py
       - run: python3 build-system/cover.py

--- a/.github/workflows/macos_11.yml
+++ b/.github/workflows/macos_11.yml
@@ -155,6 +155,7 @@ jobs:
       - run: mkdir -p ~/Library/Fonts
       - run: cp include/erb/vcvrack/design/d-din/*.otf ~/Library/Fonts
       - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/Library/Fonts
+      - run: python3 -m pip install coverage
       - run: python3 build-system/test.py
       - run: python3 build-system/cover.py
       - run: python3 test/vcvrack/configure.py

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -142,7 +142,8 @@ jobs:
       - run: sudo apt install libcairo2-dev libffi-dev python3-dev
       - run: sudo apt-get install kicad
       - run: sudo apt-get install libsndfile1
-      - run: pip3 install -r requirements.txt
+      - run: python -m pip install -r requirements.txt
+      - run: python -m pip install coverage
       - run: mkdir -p ~/.local/share/fonts/
       - run: cp include/erb/vcvrack/design/d-din/*.otf ~/.local/share/fonts
       - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/.local/share/fonts

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -142,7 +142,8 @@ jobs:
       - run: sudo apt install libcairo2-dev libffi-dev python3-dev
       - run: sudo apt-get install kicad
       - run: sudo apt-get install libsndfile1
-      - run: pip3 install -r requirements.txt
+      - run: python -m pip install -r requirements.txt
+      - run: python -m pip install coverage
       - run: mkdir -p ~/.local/share/fonts/
       - run: cp include/erb/vcvrack/design/d-din/*.otf ~/.local/share/fonts
       - run: cp include/erb/vcvrack/design/indie-flower/*.ttf ~/.local/share/fonts

--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -25,7 +25,7 @@ if platform.system () == 'Windows':
    MAKE_CMD = os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64', 'bin', 'mingw32-make.exe')
    DFU_CMD = os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64', 'bin', 'dfu-util.exe')
    OPENOCD_CMD = os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64', 'bin', 'openocd.exe')
-   OPENOCD_SCRIPTS = os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64', 'share', 'openocd', 'script')
+   OPENOCD_SCRIPTS = os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64', 'share', 'openocd', 'scripts')
 else:
    MAKE_CMD = 'make'
    DFU_CMD = 'dfu-util'

--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -21,7 +21,13 @@ PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
 PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (PATH_THIS))
 PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
 
-if platform.system () == 'Windows':
+if platform.system () == 'Darwin':
+   MAKE_CMD = 'make'
+   DFU_CMD = os.path.join (PATH_TOOLCHAIN, 'bin', 'dfu-util')
+   OPENOCD_CMD = os.path.join (PATH_TOOLCHAIN, 'bin', 'openocd')
+   OPENOCD_SCRIPTS = os.path.join (PATH_TOOLCHAIN, 'share', 'openocd', 'scripts')
+
+elif platform.system () == 'Windows':
    MAKE_CMD = os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64', 'bin', 'mingw32-make.exe')
    DFU_CMD = os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64', 'bin', 'dfu-util.exe')
    OPENOCD_CMD = os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64', 'bin', 'openocd.exe')

--- a/build-system/erbui/generators/detail/panel.py
+++ b/build-system/erbui/generators/detail/panel.py
@@ -24,7 +24,9 @@ PATH_ROOT = os.path.abspath (os.path.dirname (PATH_BUILD_SYSTEM))
 PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
 PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
 
-if platform.system () == 'Windows':
+if platform.system () == 'Darwin':
+   os.environ ['DYLD_FALLBACK_LIBRARY_PATH'] = os.path.join (PATH_TOOLCHAIN, 'bin')
+elif platform.system () == 'Windows':
    bin_dir = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin')
    os.environ ['PATH'] = '%s;%s' % (bin_dir, os.environ ['PATH'])
    if sys.version_info >= (3, 8):

--- a/build-system/erbui/generators/front_panel/pcb.py
+++ b/build-system/erbui/generators/front_panel/pcb.py
@@ -25,7 +25,9 @@ PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (os.path.dirname (os.path.d
 PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
 PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
 
-if platform.system () == 'Windows':
+if platform.system () == 'Darwin':
+   os.environ ['DYLD_FALLBACK_LIBRARY_PATH'] = os.path.join (PATH_TOOLCHAIN, 'bin')
+elif platform.system () == 'Windows':
    bin_dir = os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64', 'bin')
    os.environ ['PATH'] = '%s;%s' % (bin_dir, os.environ ['PATH'])
    if sys.version_info >= (3, 8):

--- a/build-system/erbui/generators/front_panel/pdf.py
+++ b/build-system/erbui/generators/front_panel/pdf.py
@@ -19,7 +19,9 @@ PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (os.path.dirname (os.path.d
 PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
 PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
 
-if platform.system () == 'Windows':
+if platform.system () == 'Darwin':
+   os.environ ['DYLD_FALLBACK_LIBRARY_PATH'] = os.path.join (PATH_TOOLCHAIN, 'bin')
+elif platform.system () == 'Windows':
    bin_dir = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin')
    os.environ ['PATH'] = '%s;%s' % (bin_dir, os.environ ['PATH'])
    if sys.version_info >= (3, 8):

--- a/build-system/erbui/generators/vcvrack/panel.py
+++ b/build-system/erbui/generators/vcvrack/panel.py
@@ -19,7 +19,9 @@ PATH_BUILD_SYSTEM = os.path.abspath (os.path.dirname (os.path.dirname (os.path.d
 PATH_TOOLCHAIN = os.path.join (PATH_BUILD_SYSTEM, 'toolchain')
 PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
 
-if platform.system () == 'Windows':
+if platform.system () == 'Darwin':
+   os.environ ['DYLD_FALLBACK_LIBRARY_PATH'] = os.path.join (PATH_TOOLCHAIN, 'bin')
+elif platform.system () == 'Windows':
    bin_dir = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin')
    os.environ ['PATH'] = '%s;%s' % (bin_dir, os.environ ['PATH'])
    if sys.version_info >= (3, 8):

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -184,7 +184,7 @@ def setup ():
       sys.exit (1)
 
    setup.install_python_requirements ()
-   setup.check ()
+   setup.check_toolchain ()
 
 
 

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -170,7 +170,7 @@ def setup ():
    if platform.system () == 'Darwin':
       setup.install_kicad_macos ()
       setup.install_gnu_arm_embedded_macos ()
-      subprocess.check_call ('HOMEBREW_NO_AUTO_UPDATE=1 brew install cairo dfu-util openocd', shell=True)
+      setup.install_toolchain_macos ()
 
    elif platform.system () == 'Linux':
       subprocess.check_call ('sudo apt-get update', shell=True)

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -160,6 +160,8 @@ def usage ():
 def setup ():
    import setup
 
+   setup.check_environment ()
+
    PATH_TOOLCHAIN = os.path.abspath (os.path.join (PATH_ROOT, 'build-system', 'toolchain'))
    if os.path.exists (PATH_TOOLCHAIN):
       shutil.rmtree (PATH_TOOLCHAIN)

--- a/build-system/setup/__init__.py
+++ b/build-system/setup/__init__.py
@@ -195,11 +195,11 @@ def install_python_requirements ():
 
 """
 ==============================================================================
-Name: check
+Name: check_toolchain
 ==============================================================================
 """
 
-def check ():
+def check_toolchain ():
    print ('Checking toolchain...')
 
    if platform.system () == 'Windows':

--- a/build-system/setup/__init__.py
+++ b/build-system/setup/__init__.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
 import time
 import urllib.request
 import zipfile
@@ -139,6 +140,137 @@ def install_kicad_windows ():
 
 """
 ==============================================================================
+Name: install_toolchain_macos
+==============================================================================
+"""
+
+def install_toolchain_macos ():
+   macos_version = platform.mac_ver ()[0].split ('.')
+   macos_version_major = int (macos_version [0])
+   macos_version_minor = int (macos_version [1])
+
+   if macos_version_major >= 11:
+      name = 'toolchain_big_sur.tar.gz'
+   elif macos_version_major == 10 and macos_version_minor == 15:
+      name = 'toolchain_catalina.tar.gz'
+   else:
+      assert False
+
+   download (
+      'https://github.com/ohmtech-rdi/erb-toolchain-macos/releases/download/v0.1/%s' % name,
+      name
+   )
+
+   print ('Extracting %s...            ' % name)
+   with tarfile.open (os.path.join (PATH_TOOLCHAIN, name), mode='r:gz') as tf:
+      tf.extractall (PATH_TOOLCHAIN)
+
+   class LibraryNode:
+      def __init__ (self, filepath):
+         self.filepath = filepath
+         self.children = []
+         self.marked = False
+
+   library_nodes = []
+
+   for file in os.listdir (os.fsencode (os.path.join (PATH_TOOLCHAIN, 'bin'))):
+      filename = os.fsdecode (file)
+      filepath = os.path.join (PATH_TOOLCHAIN, 'bin', filename)
+      if os.path.islink (filepath): continue # skip symlinks
+
+      subprocess.check_call (
+         ['install_name_tool', '-id', filepath, filepath],
+         stderr=subprocess.DEVNULL
+      )
+      library_node = LibraryNode (filepath)
+      output = subprocess.check_output (['otool', '-L', filepath]).decode (sys.stdout.encoding)
+      lines = output.split ('\n')
+      for line in lines:
+         line = line.strip ()
+         path = line.split (' ')[0]
+         if '@@ERB@@' in path:
+            lib = path.split ('/')[-1]
+            lib_path = os.path.join (PATH_TOOLCHAIN, 'bin', lib)
+            subprocess.check_call (
+               ['install_name_tool', '-change', path, lib_path, filepath],
+               stderr=subprocess.DEVNULL
+            )
+            library_node.children.append (lib_path)
+      library_nodes.append (library_node)
+
+   # code signing requires children of a dylib to be already signed before
+   # signing the parent dylib.
+   # Use topological sort to achieve this.
+
+   library_sorted = []
+
+   def visit (node): # assume no cycles
+      if node.marked: return
+      for child in node.children:
+         for library_node in library_nodes:
+            if library_node.filepath == child:
+               visit (library_node)
+      node.marked = True
+      library_sorted.insert (0, node)
+
+   for library_node in library_nodes:
+      visit (library_node)
+
+   library_sorted.reverse ()
+
+   for lib in library_sorted:
+      codesign_adhoc_macos (lib.filepath)
+
+
+
+"""
+==============================================================================
+Name: codesign_adhoc_macos
+==============================================================================
+"""
+
+def codesign_adhoc_macos (filepath):
+
+   if os.path.islink (filepath):
+      return
+
+   ret = subprocess.call (
+      [
+         'codesign', '--sign', '-',
+         '--force',
+         filepath
+      ],
+      stderr=subprocess.DEVNULL,
+      stdout=subprocess.DEVNULL
+   )
+   if ret == 0:
+      return # OK
+
+   # (this comment from homebrew signing process)
+   # If codesigning fail, it may be a bug in Apple's codesign utility
+   # A known workaround is to copy the file to another inode, then move it back
+   # erasing the previous file. Then sign again.
+
+   filename = filepath.split ('/')[-1]
+
+   with tempfile.TemporaryDirectory () as dir:
+      shutil.copy (filepath, os.path.join (dir, filename))
+      shutil.move (os.path.join (dir, filename), filepath)
+
+   subprocess.check_call (
+      [
+         'codesign', '--sign', '-',
+         '--force',
+         filepath
+      ],
+      stderr=subprocess.DEVNULL,
+      stdout=subprocess.DEVNULL
+   )
+
+
+
+"""
+==============================================================================
 Name: install_msys2_mingw64
 ==============================================================================
 """
@@ -252,7 +384,10 @@ Name: check_toolchain
 def check_toolchain ():
    print ('Checking toolchain...')
 
-   if platform.system () == 'Windows':
+   if platform.system () == 'Darwin':
+      os.environ ['DYLD_FALLBACK_LIBRARY_PATH'] = os.path.join (PATH_TOOLCHAIN, 'bin')
+
+   elif platform.system () == 'Windows':
       bin_dir = os.path.join (PATH_TOOLCHAIN, 'msys2_mingw64', 'bin')
       os.environ ['PATH'] = '%s;%s' % (bin_dir, os.environ ['PATH'])
       if sys.version_info >= (3, 8):

--- a/build-system/setup/__init__.py
+++ b/build-system/setup/__init__.py
@@ -27,6 +27,56 @@ PATH_PY3_PACKAGES = os.path.join (PATH_TOOLCHAIN, 'python3-packages')
 
 """
 ==============================================================================
+Name: check_environment
+==============================================================================
+"""
+
+def check_environment ():
+   if platform.system () == 'Darwin':
+      check_environment_macos ()
+
+
+
+"""
+==============================================================================
+Name: check_environment_macos
+==============================================================================
+"""
+
+def check_environment_macos ():
+   macos_version = platform.mac_ver ()[0].split ('.')
+   macos_version_major = int (macos_version [0])
+   macos_version_minor = int (macos_version [1])
+
+   if macos_version_major >= 11:
+      pass # all good
+   elif macos_version_major == 10 and macos_version_minor == 15:
+      print ('\033[33mWarning: macOS %d.%d has limited support.\033[0m' % (macos_version_major, macos_version_minor))
+      print ('\033[90mDebugging with a ST-link v3 might not work properly, for example.')
+      print ('Please consider upgrading to macOS Big Sur or later.\033[0m')
+   else:
+      print ('\033[91mSorry, macOS %d.%d is not supported.\033[0m' % (macos_version_major, macos_version_minor))
+      print ('Please consider upgrading to macOS Big Sur or later.')
+      sys.exit (1)
+
+   try:
+      subprocess.check_call (
+         ['/usr/bin/xcodebuild', '-version'],
+         stdout=subprocess.DEVNULL,
+         stderr=subprocess.DEVNULL
+      )
+   except:
+      print ('\033[91mError: Xcode is not installed.\033[0m')
+      print ('\033[90mXcode tools like make or xcodebuild are required.')
+      print ('You can find it here:\033[0m')
+      print ('\033[94mhttps://developer.apple.com/xcode/\033[0m')
+      print ('Please install Xcode.')
+      sys.exit (1)
+
+
+
+"""
+==============================================================================
 Name: download
 ==============================================================================
 """

--- a/documentation/faust/setup.md
+++ b/documentation/faust/setup.md
@@ -13,9 +13,14 @@ You then only need minimum knowledge on how the terminal works to get going.
 
 ### macOS
 
-- macOS at least version 10.15 (Catalina)
-- The [Homebrew](https://brew.sh) package manager
+- macOS 10.11 (Big Sur) or later recommended
+- The [Homebrew](https://brew.sh) package manager if installing Faust using this package manager
 - The [Xcode](https://developer.apple.com/xcode/) IDE and build environment
+
+```{note}
+macOS 10.15 (Catalina) has limited support. Some tools do not always work
+properly, so macOS 11 (Big Sur) or later is recommended.
+```
 
 ### Linux
 

--- a/documentation/getting-started/setup.md
+++ b/documentation/getting-started/setup.md
@@ -13,9 +13,13 @@ You then only need minimum knowledge on how the terminal works to get going.
 
 ### macOS
 
-- macOS at least version 10.15 (Catalina)
-- The [Homebrew](https://brew.sh) package manager
+- macOS 10.11 (Big Sur) or later recommended
 - The [Xcode](https://developer.apple.com/xcode/) IDE and build environment
+
+```{note}
+macOS 10.15 (Catalina) has limited support. Some tools do not always work
+properly, so macOS 11 (Big Sur) or later is recommended.
+```
 
 ### Linux
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -39,8 +39,8 @@ You should be familiar with either C++, Max or Faust.
 
 You should know how to use a terminal and a shell like `bash`, but their usage are quite limited.
 
-Some knowledge of `git` and a package manager such as `apt` or `brew` is also adviced,
-while not strictly necessary.
+Some knowledge of `git` and a package manager such as `apt` or `brew` when using Faust
+is also adviced, while not strictly necessary.
 
 
 ## Getting Started

--- a/documentation/max/setup.md
+++ b/documentation/max/setup.md
@@ -14,9 +14,13 @@ You then only need minimum knowledge on how the terminal works to get going.
 
 ### macOS
 
-- macOS at least version 10.15 (Catalina)
-- The [Homebrew](https://brew.sh) package manager
+- macOS 10.11 (Big Sur) or later recommended
 - The [Xcode](https://developer.apple.com/xcode/) IDE and build environment
+
+```{note}
+macOS 10.15 (Catalina) has limited support. Some tools do not always work
+properly, so macOS 11 (Big Sur) or later is recommended.
+```
 
 ### Windows
 

--- a/requirements/build-system.txt
+++ b/requirements/build-system.txt
@@ -18,7 +18,3 @@ svg2mod>=1.2
 
 SoundFile>=0.12.1
 numpy>=1.21.0
-
-# Coverage
-
-coverage


### PR DESCRIPTION
This PR removes the need of the `brew` package manager.
It installs `cairo`, `openocd` and `dfu-util`.

In particular, we made 2 versions of the toolchain:
- One for macOS 10.15 (Catalina) as it still represents around [7% of the brew user base](https://formulae.brew.sh/analytics/os-version/365d/),
- One for macOS 11 (Big Sur) or later, which supports ARM-based Mac computers.

Python is instrumented to use our versions of the dynamic libraries instead of typically the `brew` ones, by using `DYLD_FALLBACK_LIBRARY_PATH`: this is the same method that `brew` use [when building Python](https://github.com/Homebrew/homebrew-core/blob/ed6d3f73a6cd3d779d0254f4ae5ba39b99d3217b/Formula/python@3.10.rb#L185-L192).

All executables and libraries are code-signed ad-hoc to work on the user's computer, like `brew` does.

## Todo

- [x] Test on macOS 10.15
- [x] Test on macOS 11 on M1
