### PR TITLE
Update erb toolchain to v0.2

### DIFF
--- a/build-system/setup/__init__.py
+++ b/build-system/setup/__init__.py
@@ -157,7 +157,7 @@ def install_toolchain_macos ():
       assert False
 
    download (
-      'https://github.com/ohmtech-rdi/erb-toolchain-macos/releases/download/v0.1/%s' % name,
+      'https://github.com/ohmtech-rdi/erb-toolchain-macos/releases/download/v0.2/%s' % name,
       name
    )
 


### PR DESCRIPTION
This solves a problem where libusb-compat was missing.

```console
$ erbb install openocd
dyld: Library not loaded: eurorack-blocks/build-system/toolchain/bin/libusb-0.1.4.dylib
  Referenced from: eurorack-blocks/build-system/toolchain/bin/openocd
```