### PR TITLE
Sram alloc linker

### DIFF
--- a/include/erb/config.h
+++ b/include/erb/config.h
@@ -31,7 +31,7 @@
 // If not defined, it will take the entire Daisy AXI SRAM memory, so 512KB.
 
 #if !defined (erb_SRAM_MEM_POOL_SIZE)
-   #define erb_SRAM_MEM_POOL_SIZE 0x80000
+   #define erb_SRAM_MEM_POOL_SIZE 0x7d000
 #endif
 
 

--- a/src/detail/Sdram.cpp
+++ b/src/detail/Sdram.cpp
@@ -15,10 +15,6 @@
 #include <cstdlib>
 #include <type_traits>
 
-#if defined (erb_TARGET_DAISY)
-   #include "dev/sdram.h"
-#endif
-
 
 
 namespace erb
@@ -27,7 +23,7 @@ namespace erb
 
 
 #if defined (erb_TARGET_DAISY)
-std::aligned_storage <erb_SDRAM_MEM_POOL_SIZE>::type DSY_SDRAM_BSS
+std::aligned_storage <erb_SDRAM_MEM_POOL_SIZE>::type __attribute__((section(".sdram_bss")))
    erb_sdram_memory_pool_storage;
 #endif
 

--- a/src/detail/Sram.cpp
+++ b/src/detail/Sram.cpp
@@ -26,6 +26,13 @@ namespace erb
 
 
 
+#if defined (erb_TARGET_DAISY)
+std::aligned_storage <erb_SRAM_MEM_POOL_SIZE>::type __attribute__((section(".heap")))
+   erb_sram_memory_pool_storage;
+#endif
+
+
+
 /*\\\ PUBLIC \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 
@@ -44,7 +51,7 @@ Name : ctor
 
 Sram::Sram ()
 #if defined (erb_TARGET_DAISY)
-:  _sram_memory_pool_storage (new uint8_t [erb_SRAM_MEM_POOL_SIZE])
+:  _sram_memory_pool_storage (reinterpret_cast <uint8_t *> (&erb_sram_memory_pool_storage))
 #endif
 {
 }


### PR DESCRIPTION
This PR uses the linker to allocate a portion of memory for `SramPtr` instead of relying on `operator new`.

It also uniformises the approach we take with SDRAM.
Finally it corrects a problem where for real, not the full 512KB section of SRAM was available, as around 2% was already taken. It makes sure that the linker would catch section overflow errors early.  

This PR is preparation work for the upcoming semihosting support, for which `operator new` doesn't seem to be supported for some reason.
