### PR TITLE
Add stlink auto detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ raf:bypass$ erbb build 👈 Build the firmware
 ninja: Entering directory `.../eurorack-blocks/samples/bypass/artifacts/daisy/out/Release'
 [191/191] LINK Bypass
 OBJCOPY Bypass
-raf:bypass$ erbb install dfu 👈 Upload the firmware
+raf:bypass$ erbb install 👈 Upload the firmware
 Enter the system bootloader by holding the BOOT button down,
 and then pressing, and releasing the RESET button.
 Press Enter to continue...

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -313,7 +313,7 @@ def install ():
 
    cwd = os.getcwd ()
 
-   mode = 'openocd'
+   mode = 'auto'
    configuration = 'release'
    if len (sys.argv) >= 3:
       mode = sys.argv [2]
@@ -329,11 +329,7 @@ def install ():
       usage ()
       sys.exit (1)
 
-   if mode == 'openocd':
-      force_dfu_util = False
-   elif mode == 'dfu':
-      force_dfu_util = True
-   else:
+   if mode not in ['auto', 'openocd', 'dfu']:
       print ("Error: Unknown mode %s\n" % mode)
       usage ()
       sys.exit (1)
@@ -341,7 +337,7 @@ def install ():
    ast_erbb = read_erbb_ast (find_erbb ())
    module = ast_erbb.modules [0].name
    section = ast_erbb.modules [0].section.name
-   erbb.deploy (module, section, cwd, configuration, force_dfu_util=force_dfu_util)
+   erbb.deploy (module, section, cwd, configuration, mode)
 
 
 

--- a/documentation/max/setup.md
+++ b/documentation/max/setup.md
@@ -191,7 +191,7 @@ Memory region         Used Size  Region Size  %age Used
        QSPIFLASH:          0 GB         8 MB      0.00%
 OBJCOPY Release/Reverb.hex
 OBJCOPY Release/Reverb.bin
-~/eurorack-blocks/max/reverb/$ erbb install dfu
+~/eurorack-blocks/max/reverb/$ erbb install
 Enter the system bootloader by holding the BOOT button down,
 and then pressing, and releasing the RESET button.
 Press Enter to continue...

--- a/requirements/build-system.txt
+++ b/requirements/build-system.txt
@@ -18,3 +18,7 @@ svg2mod>=1.2
 
 SoundFile>=0.12.1
 numpy>=1.21.0
+
+# ST-link detection
+
+pyserial==3.5


### PR DESCRIPTION
When no mode is given for `erbb install`, this PR checks if the ST-link debugger is available and uses it if it is detected and for the flash section, and fallsback to DFU otherwise.

- Fixes #268 
- Fixes #528 
