### PR TITLE
Add support for simulator plugin install

### DIFF
--- a/build-system/completion/__init__.py
+++ b/build-system/completion/__init__.py
@@ -33,6 +33,7 @@ def build_hardware ():                 return 'hardware', ZeroOrMore ([only_gerb
 
 def install_firmware ():               return 'firmware', ZeroOrMore ([configuration, programmer])
 def install_bootloader ():             return 'bootloader'
+def install_simulator ():              return 'simulator', ZeroOrMore ([configuration])
 
 def setup ():
    if platform.system () == 'Darwin':
@@ -45,7 +46,7 @@ def setup ():
 def init ():                           return 'init', ZeroOrMore ([name, language])
 def configure ():                      return 'configure'
 def build ():                          return 'build', [build_simulator, build_firmware, build_hardware]
-def install ():                        return 'install', [install_firmware, install_bootloader]
+def install ():                        return 'install', [install_firmware, install_bootloader, install_simulator]
 
 def commands ():                       return [setup, init, configure, build, install]
 

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -364,6 +364,8 @@ def install (args):
       install_firmware (args)
    elif target == 'bootloader':
       install_bootloader (args)
+   elif target == 'simulator':
+      install_simulator (args)
 
 
 
@@ -399,6 +401,26 @@ def install_bootloader (args):
    import erbb
 
    erbb.deploy_bootloader ()
+
+
+
+#-- install_simulator ---------------------------------------------------------
+
+def install_simulator (args):
+   import erbb
+
+   cwd = os.getcwd ()
+
+   if not hasattr (args, 'configuration'):
+      configuration = 'Release'
+   elif args.configuration == 'release':
+      configuration = 'Release'
+   elif args.configuration == 'debug':
+      configuration = 'Debug'
+
+   ast_erbb = read_erbb_ast (find_erbb ())
+   module = ast_erbb.modules [0].name
+   erbb.deploy_simulator (module, cwd, configuration)
 
 
 
@@ -571,6 +593,18 @@ def parse_args_install (parent):
    parser_bootloader = subparsers.add_parser (
       'bootloader',
       help='install the bootloader'
+   )
+
+   parser_simulator = subparsers.add_parser (
+      'simulator',
+      help='install the simulator'
+   )
+
+   parser_simulator.add_argument(
+      '--configuration', '-c',
+      default = 'release',
+      choices = ['debug', 'release'],
+      help = 'the build configuration to use, defaults to release'
    )
 
 


### PR DESCRIPTION
This PR introduces the `simulator` mode for the `erbb install` command.

It allows to use `erbb install` for closed-source modules.
In particular on macOS, it will resign the binary to run on the local computer.

> **Warning**
> Don't merge before testing with Frohmage on all platforms!

- Resolves #537 

### Todo

- [x] Add erbb cli completions
- [x] Test with Frohmage on macOS
- [ ] Test with Frohmage on Windows
- [ ] Test with Frohmage on Linux

