### PR TITLE
Error on space in path

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -61,6 +61,22 @@ from .generators.faust.project import Project as faustProject
 
 """
 ==============================================================================
+Name: check_environment
+==============================================================================
+"""
+
+def check_environment (path):
+   if ' ' in path:
+      # make doesn't support spaces in paths
+      print ('\033[91mError: The path to this project contains an unsupported space character.\033[0m')
+      print ('\033[90mThe "make" program doesn\'t support it, unfortunately.\033[0m')
+      print ('Please move your project folder elsewhere and run this command again.')
+      sys.exit (1)
+
+
+
+"""
+==============================================================================
 Name: parse
 ==============================================================================
 """

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -197,6 +197,7 @@ def init ():
    import erbui
 
    cwd = os.getcwd ()
+   erbb.check_environment (cwd)
 
    name = 'Foo'
    if len (sys.argv) >= 3:
@@ -217,6 +218,7 @@ def configure ():
    import erbui
 
    cwd = os.getcwd ()
+   erbb.check_environment (cwd)
 
    ast_erbb = read_erbb_ast (find_erbb ())
    ast_erbui = read_erbui_ast (find_erbui ())
@@ -234,6 +236,7 @@ def build ():
    import erbui
 
    cwd = os.getcwd ()
+   erbb.check_environment (cwd)
 
    target = 'daisy'
    configuration = 'release'
@@ -362,6 +365,7 @@ def max_init ():
    import erbb
 
    cwd = os.getcwd ()
+   erbb.check_environment (cwd)
 
    name = 'Foo'
    if len (sys.argv) >= 4:
@@ -396,6 +400,7 @@ def faust_init ():
    import erbb
 
    cwd = os.getcwd ()
+   erbb.check_environment (cwd)
 
    name = 'Foo'
    if len (sys.argv) >= 4:

--- a/build-system/setup/__init__.py
+++ b/build-system/setup/__init__.py
@@ -33,6 +33,13 @@ Name: check_environment
 """
 
 def check_environment ():
+   if ' ' in PATH_ROOT:
+      # make doesn't support spaces in paths, and libDaisy depends on it
+      print ('\033[91mError: The path to eurorack-blocks contains an unsupported space character.\033[0m')
+      print ('\033[90mThe "make" program doesn\'t support it, unfortunately.\033[0m')
+      print ('Please move the eurorack-blocks folder elsewhere and run this command again.')
+      sys.exit (1)
+
    if platform.system () == 'Darwin':
       check_environment_macos ()
 


### PR DESCRIPTION
This PR emits an error when a user tries to either install Eurorack-blocks or configure a project with a space in it, as `make` doesn't unfortunately support that properly.

- Fixes #539 