### PR TITLE
Use relative path to erbb from max module to configure and build

### DIFF
--- a/max/Eurorack-blocks/javascript/erb.build.js
+++ b/max/Eurorack-blocks/javascript/erb.build.js
@@ -1,35 +1,52 @@
 const maxApi = require("max-api");
 
+const path = require('path');
 const { spawn } = require("child_process");
 
-maxApi.post("Build starting");
+const PATH_EURORACK_BLOCKS = path.dirname(path.dirname(path.dirname(__dirname)));
+const PATH_ERBB = path.join(PATH_EURORACK_BLOCKS, 'build-system', 'scripts', 'erbb');
 
-let msgs = []
+function erbb(modulePath, ...command) {
+   const cmd = [PATH_ERBB, ...command];
 
-try {
+   return new Promise((resolve, reject) => {
+      const p = spawn('python3', cmd, { cwd: modulePath });
+
+      try {
+         p.stdout.on("data", data => {
+            maxApi.post(`${data}`);
+            maxApi.outlet(`${data}`);
+         });
+         p.stderr.on("data", data => {
+            maxApi.post(`Error: ${data}`);
+            maxApi.outlet(`Error: ${data}`);
+         });
+         p.on("close", code => {
+            maxApi.post(`child process exited with code ${code}`);
+            resolve();
+         });
+      } catch (e) {
+         reject(e);
+      }
+   });
+}
+
+const build = async (modulePath) => {
+   maxApi.post("Build starting");
+
    args = process.argv.slice(2)
    modulePath = args [0]
    maxApi.post(`module: ${modulePath}`);
-   const build = spawn(
-      'bash', ['-l', '-c', 'erbb configure; erbb build simulator'],
-      { cwd: modulePath }
-   )
 
-   build.stdout.on('data', (data) => {
-      maxApi.post(`${data}`);
-      maxApi.outlet(`${data}`);
-   });
-
-   build.stderr.on('data', (data) => {
-      maxApi.post(`Error: ${data}`);
-      maxApi.outlet(`Error: ${data}`);
-   });
-
-   build.on('close', (code) => {
-      maxApi.post(`child process exited with code ${code}`);
+   try {
+      maxApi.post(`Configuring...`);
+      await erbb(modulePath, 'configure');
+      maxApi.post(`Building...`);
+      await erbb(modulePath, 'build', 'simulator');
       maxApi.outlet('Done');
-   });
+   } catch(e) {
+      maxApi.post(e.message ? e.message : e, maxApi.POST_LEVELS.ERROR);
+   }
+};
 
-} catch(e) {
-   maxAPI.post(e.message ? e.message : e, maxAPI.POST_LEVELS.ERROR);
-}
+build();


### PR DESCRIPTION
This PR fixes #544 by using relative path to erbb from max module to configure and build in `erb.build.js` script.