### PR TITLE
Force cache precomputation for all front pcb parts during erbb setup

### DIFF
--- a/build-system/erbui/generators/kicad/pcb.py
+++ b/build-system/erbui/generators/kicad/pcb.py
@@ -11,6 +11,7 @@ import hashlib
 import math
 import os
 import pickle
+import tempfile
 from . import s_expression
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
@@ -63,8 +64,11 @@ class Root:
          root_node = parser.parse (content, filepath)
 
          ret = Root.parse (root_node)
-         with open (path_cache, 'wb') as file:
+         with tempfile.NamedTemporaryFile (mode='wb', delete=False, dir=PATH_ARTIFACTS) as file:
+            tmppath = file.name
             pickle.dump (ret, file)
+         os.replace (tmppath, path_cache)
+
          return ret
 
    @staticmethod

--- a/build-system/erbui/generators/kicad/sch.py
+++ b/build-system/erbui/generators/kicad/sch.py
@@ -10,6 +10,7 @@
 import hashlib
 import os
 import pickle
+import tempfile
 from . import s_expression
 
 PATH_THIS = os.path.abspath (os.path.dirname (__file__))
@@ -62,8 +63,11 @@ class Root:
          root_node = parser.parse (content, filepath)
 
          ret = Root.parse (root_node)
-         with open (path_cache, 'wb') as file:
+         with tempfile.NamedTemporaryFile (mode='wb', delete=False, dir=PATH_ARTIFACTS) as file:
+            tmppath = file.name
             pickle.dump (ret, file)
+         os.replace (tmppath, path_cache)
+
          return ret
 
    @staticmethod

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -186,6 +186,7 @@ def setup ():
       sys.exit (1)
 
    setup.install_python_requirements ()
+   setup.optimize_kicad_pcb_sch_read ()
    setup.check_toolchain ()
 
 


### PR DESCRIPTION
This PR precomputes KiCad PCH and SCH parser caches during `erbb setup` for the `kivu12` board and our libraries of parts for `route manual` and `route wire`.

This allows to have a more initial snappy experience when using `erbb` operations on projects, at the expense to make the `erbb setup` slightly longer.
