### PR TITLE
Fix kicad pcb sch cache key

### DIFF
--- a/build-system/erbui/analysers/style.py
+++ b/build-system/erbui/analysers/style.py
@@ -52,8 +52,8 @@ class AnalyserStyle:
    def analyse_module (self, global_namespace, module):
 
       if module.board.pcb:
-         module.pcb = pcb.Root.read (module.board.pcb.path)
-         module.sch = sch.Root.read (module.board.sch.path)
+         module.pcb = pcb.Root.read (os.path.abspath (module.board.pcb.path))
+         module.sch = sch.Root.read (os.path.abspath (module.board.sch.path))
 
          # Retrieve already used board references for control reference allocations
          for footprint in module.pcb.footprints:
@@ -240,10 +240,10 @@ class AnalyserStyle:
 
    def load_kicad_pcb_sch (self, module, base_path, component_name):
 
-      kicad_pcb_path = os.path.join (base_path, component_name, '%s.kicad_pcb' % component_name)
+      kicad_pcb_path = os.path.abspath (os.path.join (base_path, component_name, '%s.kicad_pcb' % component_name))
       kicad_pcb = pcb.Root.read (kicad_pcb_path)
 
-      kicad_sch_path = os.path.join (base_path, component_name, '%s.kicad_sch' % component_name)
+      kicad_sch_path = os.path.abspath (os.path.join (base_path, component_name, '%s.kicad_sch' % component_name))
       kicad_sch = sch.Root.read (kicad_sch_path)
 
       ref_map = self.make_ref_map (module, kicad_pcb)
@@ -410,7 +410,7 @@ class AnalyserStyle:
 
       for sheet in module.sch.sheets:
          sheet_file = sheet.property ('Sheet file')
-         sheet_path = os.path.join (board_sch_base_path, sheet_file)
+         sheet_path = os.path.abspath (os.path.join (board_sch_base_path, sheet_file))
          sheet_sch = sch.Root.read (sheet_path)
          symbols.extend (sheet_sch.symbols)
 

--- a/build-system/erbui/generators/front_pcb/kicad_pcb.py
+++ b/build-system/erbui/generators/front_pcb/kicad_pcb.py
@@ -56,7 +56,7 @@ class KicadPcb:
       if os.path.exists (path_pcb) and module.route.is_manual:
          ## update pcb rather than overwrite
 
-         kicad_pcb = pcb.Root.read (path_pcb)
+         kicad_pcb = pcb.Root.read (os.path.abspath (path_pcb))
 
          # only footprints for now
          kicad_pcb.footprints = module.pcb.footprints

--- a/build-system/erbui/generators/kicad/pcb.py
+++ b/build-system/erbui/generators/kicad/pcb.py
@@ -38,6 +38,8 @@ class Root:
 
    @staticmethod
    def read (filepath):
+      assert os.path.isabs (filepath)
+
       if not os.path.exists (PATH_ARTIFACTS):
          os.makedirs (PATH_ARTIFACTS)
 

--- a/build-system/erbui/generators/kicad/sch.py
+++ b/build-system/erbui/generators/kicad/sch.py
@@ -37,6 +37,8 @@ class Root:
 
    @staticmethod
    def read (filepath):
+      assert os.path.isabs (filepath)
+
       if not os.path.exists (PATH_ARTIFACTS):
          os.makedirs (PATH_ARTIFACTS)
 


### PR DESCRIPTION
This PR fixes a bug where the cache key for the KiCad SCH and PCB parse optimisation was supposed to be an absolute path for ensure uniqueness in the cache, but this was not checked. In the case of custom manufacturers, the cache key could be relative instead of absolute.

This fixes this problem by ensuring that:
- A non-absolute cache key triggers an assertion
- All code is updated to provide an absolute path
