### PR TITLE
Expose the build-system folder in fish shell

### DIFF
--- a/build-system/init.fish
+++ b/build-system/init.fish
@@ -1,5 +1,11 @@
 #!/usr/bin/env fish
 
+set PREVIOUS_DIR (pwd)
+set BUILD_SYSTEM_DIR (cd (dirname (status -f)); and pwd)
+cd $PREVIOUS_DIR
+
+set -x -g PATH $PATH $BUILD_SYSTEM_DIR/scripts
+
 function __fish__eurorack-blocks_build-system_scripts_erbb_complete
    set -x ERBB_COMPLETION_FISH 1
    set -x COMP_LINE (commandline -p)


### PR DESCRIPTION
This PR fixes a bug where the `erbb` script was not available in the `PATH`.