### PR TITLE
Remove debug and release macro to avoid clash with vcv rack debug macro

### DIFF
--- a/build-system/erbb/generators/daisy/Makefile_template
+++ b/build-system/erbb/generators/daisy/Makefile_template
@@ -62,11 +62,11 @@ FLAGS += -finline -finline-functions-called-once -fshort-enums -fno-move-loop-in
 
 # Optimization
 ifeq ($(CONFIGURATION),Debug)
-FLAGS += -O0 -g -ggdb -DDEBUG=1 -funsafe-math-optimizations
+FLAGS += -O0 -g -ggdb -funsafe-math-optimizations
 endif
 
 ifeq ($(CONFIGURATION),Release)
-FLAGS += -O3 -DNDEBUG=1 -DRELEASE=1 -funsafe-math-optimizations
+FLAGS += -O3 -DNDEBUG=1 -funsafe-math-optimizations
 endif
 
 ifdef SEMIHOSTING

--- a/build-system/erbb/generators/simulator/Makefile_template
+++ b/build-system/erbb/generators/simulator/Makefile_template
@@ -71,11 +71,11 @@ endif
 
 # Optimization
 ifeq ($(CONFIGURATION),Debug)
-FLAGS += -O0 -g -DDEBUG=1 -march=nocona -funsafe-math-optimizations
+FLAGS += -O0 -g -march=nocona -funsafe-math-optimizations
 endif
 
 ifeq ($(CONFIGURATION),Release)
-FLAGS += -O3 -DNDEBUG=1 -DRELEASE=1 -march=nocona -funsafe-math-optimizations
+FLAGS += -O3 -DNDEBUG=1 -march=nocona -funsafe-math-optimizations
 endif
 
 %warnings%

--- a/include/erb/daisy.gypi
+++ b/include/erb/daisy.gypi
@@ -13,10 +13,6 @@
       {
          'Debug':
          {
-            'defines': [
-               'DEBUG=1',
-            ],
-
             'cflags': [
                '-O0',
                '-g',
@@ -27,7 +23,6 @@
          {
             'defines': [
                'NDEBUG=1',
-               'RELEASE=1',
             ],
 
             'cflags': [

--- a/include/erb/linux.gypi
+++ b/include/erb/linux.gypi
@@ -13,10 +13,6 @@
       {
          'Debug':
          {
-            'defines': [
-               'DEBUG=1',
-            ],
-
             'cflags':
             [
                '-O0',
@@ -28,7 +24,6 @@
          {
             'defines': [
                'NDEBUG=1',
-               'RELEASE=1',
             ],
 
             'cflags':


### PR DESCRIPTION
This PR removes the `DEBUG` and `RELEASE` macros from our build, as `DEBUG` is clashing with another definition on Windows for VCV Rack.

Anyway, they were used to mimic libDaisy configuration, but are not needed into our code.
