### PR TITLE
Fix max path use user shell

### DIFF
--- a/max/Eurorack-blocks/javascript/erb.build.js
+++ b/max/Eurorack-blocks/javascript/erb.build.js
@@ -4,13 +4,40 @@ const path = require('path');
 const { spawn } = require("child_process");
 
 const PATH_EURORACK_BLOCKS = path.dirname(path.dirname(path.dirname(__dirname)));
-const PATH_ERBB = path.join(PATH_EURORACK_BLOCKS, 'build-system', 'scripts', 'erbb');
 
 function erbb(modulePath, ...command) {
-   const cmd = [PATH_ERBB, ...command];
+   const erbb_command = ['erbb', ...command];
+   script_arg = `${erbb_command.join(' ')}`
 
    return new Promise((resolve, reject) => {
-      const p = spawn('python3', cmd, { cwd: modulePath });
+      // Launch the shell using the user profile, to make sure that 'erbb'
+      // is executed like it is in a terminal (as Max replaces for example
+      // the path with its own).
+
+      let command = null;
+      let args = null;
+
+      if (process.platform === 'win32') {
+         command = 'C:/Program Files/Git/usr/bin/env.exe'
+         args = ['MSYSTEM=MINGW64', '/usr/bin/bash', '-l', '-c', script_arg]
+
+      } else {
+         // For bash, zsh and fish, '-l' is more or less a login shell
+         // This ensures that 'erbb' is launched as it is in a terminal, in particular
+         // for the PATH that Max replaces with its own.
+
+         command = process.env.SHELL;
+
+         if (command.includes('bash')) {
+            args = ['--login', '-c', script_arg]
+         } else if (command.includes('zsh')) {
+            args = ['--login', '-i', '-c', script_arg]
+         } else if (command.includes('fish')) {
+            args = ['--login', '-c', script_arg]
+         }
+      }
+
+      const p = spawn(command, args, { cwd: modulePath });
 
       try {
          p.stdout.on("data", data => {


### PR DESCRIPTION
This PR fixes an issue where `erbb` is not executed on Max like it is on the terminal.

This is because Max rewrites the `PATH` variable with its own, dropping on the way some of the important configuration we have.
Typically, a specific install of Python might not be seen, and another might be loaded. If the versions differs then it will fail to load the `cffi_backend`, as we only install the one for the version of Python that was used during `erbb setup`.

For this we launch the user default shell as a login shell, so that their configuration is loaded before we pass this environment to the `erbb` script.

- [x] Test on macOS with `bash`
- [x] Test on macOS with `zsh`
- [ ] ~~Test on macOS with `fish`~~
- [x] Test on Windows
