### PR TITLE
Always enable ram mem pool size simulator check

### DIFF
--- a/include/erb/config.h
+++ b/include/erb/config.h
@@ -35,23 +35,5 @@
 #endif
 
 
-// 'erb_RAM_MEM_POOL_SIZE_SIMULATOR_CHECK' will break into the debugger when
-// a module consumes more than the available pool size for the choosen memory
-// section in the simulator.
-// However, this only works when debugging one module, as instantiating
-// 2 or more modules will count the used pool size for all modules.
-// To workaround this, one might want to disable explicitly this flag to be
-// able to test more than one module in the simulator.
-
-#if !defined (erb_RAM_MEM_POOL_SIZE_SIMULATOR_CHECK)
-   #define erb_RAM_MEM_POOL_SIZE_SIMULATOR_CHECK 1
-#endif
-
-
-
-
-
-
-
 
 /*\\\ EOF \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/include/erb/detail/MonotonicMemoryPool.hpp
+++ b/include/erb/detail/MonotonicMemoryPool.hpp
@@ -13,8 +13,6 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-#include "erb/config.h"
-
 #include <new>
 
 
@@ -41,10 +39,8 @@ std::size_t MonotonicMemoryPool <MaxSize>::allocate (std::size_t alignment, size
    {
 #if defined (erb_TARGET_DAISY)
       asm ("bkpt 255");
-#elif (erb_RAM_MEM_POOL_SIZE_SIMULATOR_CHECK)
-      // Either:
-      // - The module is using too much memory,
-      // - Multiple modules are being debugged (check erb/config.h for workaround)
+#elif defined (erb_TARGET_VCV_RACK) || defined (erb_TARGET_UNIT_TEST)
+      // The module is consuming more memory than it can on the target platform
       throw std::bad_alloc ();
 #endif
    }

--- a/include/erb/detail/fnc.hpp
+++ b/include/erb/detail/fnc.hpp
@@ -13,7 +13,6 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-#include "erb/config.h"
 #include "erb/detail/Sram.h"
 #include "erb/detail/Sdram.h"
 
@@ -45,10 +44,8 @@ void *   allocate_bytes_auto (std::size_t size)
    {
 #if defined (erb_TARGET_DAISY)
       asm ("bkpt 255");
-#elif (erb_RAM_MEM_POOL_SIZE_SIMULATOR_CHECK)
-      // Either:
-      // - The module is using too much memory,
-      // - Multiple modules are being debugged (check erb/config.h for workaround)
+#elif defined (erb_TARGET_VCV_RACK) || defined (erb_TARGET_UNIT_TEST)
+      // The module is consuming more memory than it can on the target platform
       throw std::bad_alloc ();
 #endif
    }


### PR DESCRIPTION
Since the introduction of per module memory pools for the simulator, it is no longer required to remove the simulator check in order to debug multiple modules.

So we removed that check option by always enabling it.