### PR TITLE
Add cortext-debug vscode extensions recommendation

### DIFF
--- a/build-system/erbb/generators/vscode/extensions_template.json
+++ b/build-system/erbb/generators/vscode/extensions_template.json
@@ -1,3 +1,3 @@
 {
-   "recommendations": ["ms-vscode.cpptools-extension-pack"]
+   "recommendations": ["ms-vscode.cpptools-extension-pack", "marus25.cortex-debug"]
 }


### PR DESCRIPTION
This PR adds `cortext-debug` as recommendations for the generated VS code projects, as debugging the firmware with the ST-link requires it.