### PR TITLE
erbb setup: install Max package

### DIFF
--- a/build-system/completion/__init__.py
+++ b/build-system/completion/__init__.py
@@ -24,6 +24,7 @@ def semihosting ():                    return '--semihosting'
 def only_gerber ():                    return '--only-gerber'
 def with_xcode_support ():             return '--with-xcode-support'
 def with_vscode_support ():            return '--with-vscode-support'
+def with_max_support ():               return '--with-max-support'
 def with_apt ():                       return '--with-apt'
 
 def build_simulator ():                return 'simulator', ZeroOrMore ([configuration, xcode])
@@ -35,11 +36,12 @@ def install_bootloader ():             return 'bootloader'
 
 def setup ():
    if platform.system () == 'Darwin':
-                                       return 'setup', ZeroOrMore ([with_xcode_support, with_vscode_support])
+                                       return 'setup', ZeroOrMore ([with_xcode_support, with_vscode_support, with_max_support])
+   elif platform.system () == 'Windows':
+                                       return 'setup', ZeroOrMore ([with_vscode_support, with_max_support])
    elif platform.system () == 'Linux':
-                                       return 'setup', ZeroOrMore ([with_apt])
-   else:
-                                       return 'setup', ZeroOrMore ([with_vscode_support])
+                                       return 'setup', ZeroOrMore ([with_vscode_support, with_apt])
+
 def init ():                           return 'init', ZeroOrMore ([name, language])
 def configure ():                      return 'configure'
 def build ():                          return 'build', [build_simulator, build_firmware, build_hardware]
@@ -55,6 +57,7 @@ DESCRIPTION = {
    'setup': 'install all dependencies',
    '--with-xcode-support': 'for Xcode support',
    '--with-vscode-support': 'for Visual Studio Code support',
+   '--with-max-support': 'for Cycling\'74 Max support',
    '--with-apt': 'using the apt package manager',
    'init': 'create a new project in current directory',
    '--name': 'name of project, random name if not specified',

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -174,6 +174,8 @@ def setup (args):
       setup.install_toolchain_macos ()
       if args.with_xcode_support:
          setup.install_xcode_support ()
+      if args.with_max_support:
+         setup.install_max_package ()
 
    elif platform.system () == 'Linux':
       if args.with_apt:
@@ -185,6 +187,8 @@ def setup (args):
       setup.install_msys2_mingw64 ()
       setup.install_kicad_windows ()
       setup.install_gnu_arm_embedded_windows ()
+      if args.with_max_support:
+         setup.install_max_package ()
 
    else:
       print ('Error: Platform %s unsupported' % platform.system ())
@@ -426,6 +430,14 @@ def parse_args_setup (parent):
       action = 'store_true',
       help = 'add Visual Studio Code extra support such as erbui/erbb syntax coloring'
    )
+
+   if platform.system () == 'Darwin' or platform.system () == 'Windows':
+      parser.add_argument(
+         '--with-max-support',
+         action = 'store_true',
+         help = 'add Cycling\'74 Max extra support'
+      )
+
 
 
 #-- parse_args_init ----------------------------------------------------------


### PR DESCRIPTION
This PR adds a `--with-max-support` option to `erbb setup` that installs the `Eurorack-block` Max package on macOS and Windows. 

The package will only be installed if the path to the `Max 8/packages` exists, and thus Max is installed, on the target machine.
The installed package will be a `symlink` on macOS or a `junction` on Windows, linking to the cloned repository's [`max/Eurorack-blocks`](https://github.com/ohmtech-rdi/eurorack-blocks/tree/main/max/Eurorack-blocks) folder.