### PR TITLE
Uniformize gyp settings with build system make files

### DIFF
--- a/eurorack-blocks.gypi
+++ b/eurorack-blocks.gypi
@@ -10,7 +10,7 @@
 {
    'target_defaults': {
       'xcode_settings': {
-         'CLANG_CXX_LANGUAGE_STANDARD': 'c++1z',
+         'CLANG_CXX_LANGUAGE_STANDARD': 'c++2a',
          'USE_HEADERMAP': 'NO',
          'WARNING_CFLAGS': [
             '-Wno-four-char-constants',
@@ -18,7 +18,7 @@
       },
 
       'cflags_cc': [
-         '-std=gnu++17',
+         '-std=gnu++2a',
       ],
 
       'cflags': [

--- a/include/erb/xcode.gypi
+++ b/include/erb/xcode.gypi
@@ -35,7 +35,7 @@
          'ARCHS': ['x86_64'],
          'MACOSX_DEPLOYMENT_TARGET': '10.14',
 
-         'CLANG_CXX_LANGUAGE_STANDARD': 'c++17',
+         'CLANG_CXX_LANGUAGE_STANDARD': 'c++2a',
          'CLANG_CXX_LIBRARY': 'libc++',
          'WARNING_CFLAGS': [
             '-Wno-c++98-compat',


### PR DESCRIPTION
This PR uniformises gyp settings for our Xcode projects with our generated make files to use C++ 20.