### PR TITLE
Fix erbb setup download typo

### DIFF
--- a/build-system/setup/__init__.py
+++ b/build-system/setup/__init__.py
@@ -133,7 +133,7 @@ def download (url, name):
             content.write (buffer)
             size += len (buffer)
             percent = int ((size / length)*100)
-            print (f'Downloading {name}... {percent}%%  ', end='\r')
+            print (f'Downloading {name}... {percent}%  ', end='\r')
          return content.getvalue ()
 
    import ssl


### PR DESCRIPTION
This PR fixes an incorrect percent escape, when we change the download string from old-style python string interpolation to f-strings.