### PR TITLE
Fix audio in subscript prototype

### DIFF
--- a/include/erb/AudioIn.h
+++ b/include/erb/AudioIn.h
@@ -41,7 +41,7 @@ public:
    inline std::size_t
                   size () const;
    inline const float &
-                  operator [] (std::size_t index);
+                  operator [] (std::size_t index) const;
 
 
 

--- a/include/erb/AudioIn.hpp
+++ b/include/erb/AudioIn.hpp
@@ -67,7 +67,7 @@ Name : operator []
 ==============================================================================
 */
 
-const float &  AudioIn::operator [] (std::size_t index)
+const float &  AudioIn::operator [] (std::size_t index) const
 {
    return impl_data [index];
 }


### PR DESCRIPTION
This PR fixes the `erb::AudioIn` subscript prototype.