### PR TITLE
Erb audio in tuple size

### DIFF
--- a/include/erb/AudioIn.h
+++ b/include/erb/AudioIn.h
@@ -16,6 +16,8 @@
 #include "erb/Buffer.h"
 
 #include <cstddef>
+#include <type_traits>
+#include <tuple>
 
 
 
@@ -83,6 +85,12 @@ private:
 
 
 }  // namespace erb
+
+
+
+template <>
+struct std::tuple_size <erb::AudioIn>
+: public integral_constant <std::size_t, erb_BUFFER_SIZE> {};
 
 
 


### PR DESCRIPTION
This PR adds `std::tuple_size` support to `erb::AudioIn`.

This allows to define a buffer concept that is compatible with `erb::AudioIn`.