### PR TITLE
Increase wait time before updating clock and reading GPIO to 400 ticks

### DIFF
--- a/boards/kivu12/firmware/BoardKivu12.hpp
+++ b/boards/kivu12/firmware/BoardKivu12.hpp
@@ -131,14 +131,14 @@ void  BoardKivu12::impl_preprocess ()
    for (std::size_t i = 0 ; i < 8 ; ++i)
    {
       _gpio_b_sr4021_clock.write (false);
-      daisy::System::DelayTicks (100);
+      daisy::System::DelayTicks (400);
 
       // GI: BJT => inverted
       _digital_inputs [gpio0_order [i]] = !_gpio_inputs [0].read ();
       _digital_inputs [gpio1_order [i]] = !_gpio_inputs [1].read ();
 
       _gpio_b_sr4021_clock.write (true);
-      daisy::System::DelayTicks (100);
+      daisy::System::DelayTicks (400);
    }
 
 #elif defined (erb_USE_DAISY_IMPL)


### PR DESCRIPTION
This PR increases the delay when using the shift register:
- between the clock pulses
- before reading the GPIO

The previous 100 ticks doesn't seem to work on every Daisy Patch SM for some unknown reason.

The following combinaison of timings are not working either. Usually one value overlaps on the next value:
- 200/200 doesn't work
- 200/400 doesn't work
- 400/200 doesn't work
- 300/300 doesn't work
