### PR TITLE
Fix stack size check

### DIFF
--- a/build-system/erbui/generators/daisy/code_template.cpp
+++ b/build-system/erbui/generators/daisy/code_template.cpp
@@ -103,9 +103,9 @@ int main ()
    // When more memory is needed, move the big buffers like
    // delay lines or samples to the SDRAM, which is 64M.
    // Since we have some heap allocations, we keep a bit of margin
-   // and complain when we reach 384K of stack space.
+   // and complain when we reach 128K of stack space.
 
-   static_assert (sizeof (module) < 384 * 1024 /* 384K */, "");
+   static_assert (sizeof (module) < 128 * 1024 /* 128 */, "");
 
    // The SDRAM is compararively slow compared to the SRAM,
    // So try to keep all memory that is accessed often in SRAM.

--- a/build-system/erbui/generators/vcvrack/code_template.cpp
+++ b/build-system/erbui/generators/vcvrack/code_template.cpp
@@ -100,9 +100,9 @@ ErbModule::ErbModule ()
    // When more memory is needed, move the big buffers like
    // delay lines or samples to the SDRAM, which is 64M.
    // Since we have some heap allocations, we keep a bit of margin
-   // and complain when we reach 384K of stack space.
+   // and complain when we reach 128K of stack space.
 
-   static_assert (sizeof (module) < 384 * 1024 /* 384K */, "");
+   static_assert (sizeof (module) < 128 * 1024 /* 128K */, "");
 
    // The SDRAM is compararively slow compared to the SRAM,
    // So try to keep all memory that is accessed often in SRAM.


### PR DESCRIPTION
This PR fixes the stack size check to 128K, as we are using for now the `DTCMRAM` section for both the `flash` and `qspi` erbb `section` variants.

This is not exactly precise, as the stack is a bit used prior to the check, but should be good enough for checks.
Also, when running on a 64-bit platform, the stack might be a bigger on the simulator, but then it's the user responsibility to put explicit types (for example `std::int32_t` instead of `int`)
