### PR TITLE
Fix kivu12 number of pca9685 led drivers

### DIFF
--- a/boards/kivu12/firmware/BoardKivu12.h
+++ b/boards/kivu12/firmware/BoardKivu12.h
@@ -259,7 +259,7 @@ private:
                      }
                   };
 
-   daisy::LedDriverPca9685 <2, true>
+   daisy::LedDriverPca9685 <1, true>
                   _led_driver;
 #if defined (erb_USE_DAISY_IMPL)
    ShiftRegister  _shift_register;

--- a/boards/kivu12/firmware/BoardKivu12.hpp
+++ b/boards/kivu12/firmware/BoardKivu12.hpp
@@ -46,8 +46,6 @@ Name : ctor
 
 BoardKivu12::BoardKivu12 ()
 {
-   uint8_t addr [] = {0x00, 0x02};
-
    constexpr auto led_i2c_config = daisy::I2CHandle::Config {
       daisy::I2CHandle::Config::Peripheral::I2C_1,
       {
@@ -62,6 +60,7 @@ BoardKivu12::BoardKivu12 ()
 
    static DmaBuffer DMA_BUFFER_MEM_SECTION led_dma_buffer_a;
    static DmaBuffer DMA_BUFFER_MEM_SECTION led_dma_buffer_b;
+   const uint8_t addr [] = {0x00};
 
    daisy::I2CHandle i2c;
    i2c.Init (led_i2c_config);


### PR DESCRIPTION
This PR fixes the number of LED drivers in the kivu12 board. For some reason it was put to 2, most likely by copying the Daisy Field implementation a long time ago.