### PR TITLE
Kivu12 led driver bg thread

### DIFF
--- a/boards/daisy_field/firmware/BoardDaisyField.h
+++ b/boards/daisy_field/firmware/BoardDaisyField.h
@@ -122,6 +122,8 @@ public:
    inline void    impl_postprocess (AudioOutPin pin);
    inline void    impl_postprocess ();
 
+   inline void    impl_idle () {}
+
 
 
 /*\\\ PROTECTED \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/boards/daisy_micropatch/firmware/BoardDaisyMicropatch.h
+++ b/boards/daisy_micropatch/firmware/BoardDaisyMicropatch.h
@@ -113,6 +113,8 @@ public:
    inline void    impl_postprocess (AudioOutPin pin);
    inline void    impl_postprocess () {}
 
+   inline void    impl_idle () {}
+
 
 
 /*\\\ PROTECTED \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/boards/kivu12/firmware/BoardKivu12.h
+++ b/boards/kivu12/firmware/BoardKivu12.h
@@ -20,6 +20,8 @@
 #include "erb/daisy/SubmoduleDaisyPatchSm.h"
 
 #include <array>
+#include <atomic>
+#include <cstdint>
 
 
 #undef erb_USE_DAISY_IMPL
@@ -168,6 +170,8 @@ public:
    inline void    impl_postprocess (AudioOutPin pin);
    inline void    impl_postprocess ();
 
+   inline void    impl_idle ();
+
 
 
 /*\\\ PROTECTED \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
@@ -259,6 +263,8 @@ private:
                      }
                   };
 
+   std::array <std::atomic <std::uint16_t>, 16>
+                  _leds_u12 = {};
    daisy::LedDriverPca9685 <1, true>
                   _led_driver;
 #if defined (erb_USE_DAISY_IMPL)

--- a/boards/kivu12/firmware/BoardKivu12.hpp
+++ b/boards/kivu12/firmware/BoardKivu12.hpp
@@ -300,9 +300,7 @@ void  BoardKivu12::impl_postprocess (DacPin pin)
          8, 9, 10, 11, 12, 13, 14, 15  // L9..16
       };
 
-      _led_driver.SetLedRaw (
-         led_order [pin.index - L1.index], linear_u12
-      );
+      _leds_u12 [led_order [pin.index - L1.index]] = linear_u12;
    }
 }
 
@@ -337,6 +335,24 @@ void  BoardKivu12::impl_postprocess ()
    _npr_rand_state = _npr_rand_state * 1103515245 + 12345;
    _npr = _npr_rand_state >> 31;
    _gpio_npr.write (_npr != 0);
+}
+
+
+
+/*
+==============================================================================
+Name : impl_idle
+==============================================================================
+*/
+
+void  BoardKivu12::impl_idle ()
+{
+   for (size_t i = 0 ; i < _leds_u12.size () ; ++i)
+   {
+      _led_driver.SetLedRaw (
+         i, _leds_u12 [i]
+      );
+   }
 
    _led_driver.SwapBuffersAndTransmit ();
 }

--- a/build-system/erbui/generators/daisy/code_template.cpp
+++ b/build-system/erbui/generators/daisy/code_template.cpp
@@ -128,4 +128,14 @@ int main ()
 %     board_postprocess%
       module.ui.board.impl_postprocess ();
    });
+
+   const auto tick_freq = daisy::System::GetTickFreq ();
+
+   for (;;)
+   {
+      auto ts_beg = daisy::System::GetTick ();
+
+      // busy wait so that the idle loop is at least 6ms
+      while (daisy::System::GetTick () - ts_beg < tick_freq * 6 / 1000) {}
+   }
 }

--- a/build-system/erbui/generators/daisy/code_template.cpp
+++ b/build-system/erbui/generators/daisy/code_template.cpp
@@ -135,6 +135,8 @@ int main ()
    {
       auto ts_beg = daisy::System::GetTick ();
 
+      module.ui.board.impl_idle ();
+
       // busy wait so that the idle loop is at least 6ms
       while (daisy::System::GetTick () - ts_beg < tick_freq * 6 / 1000) {}
    }

--- a/build-system/erbui/generators/perf/code_template.cpp
+++ b/build-system/erbui/generators/perf/code_template.cpp
@@ -245,6 +245,8 @@ int main ()
       postprocess = std::max (postprocess, tsl_4 - tsl_3);
       total = std::max (total, tsl_4 - tsl_1);
 
+      module.ui.board.impl_idle ();
+
       ++cnt;
 
       if (cnt >= 1000)

--- a/samples/custom/board/BoardFirmware.h
+++ b/samples/custom/board/BoardFirmware.h
@@ -53,6 +53,8 @@ public:
    inline void    impl_postprocess (AudioOutPin pin);
    inline void    impl_postprocess () {}
 
+   inline void    impl_idle () {}
+
 
 private:
 

--- a/src/daisy/SubmoduleDaisyPatchSm.cpp
+++ b/src/daisy/SubmoduleDaisyPatchSm.cpp
@@ -114,8 +114,6 @@ void  SubmoduleDaisyPatchSm::do_run ()
 {
    _adc.Start ();
    _audio.Start (audio_callback_proc);
-
-   for (;;) {}
 }
 
 

--- a/src/daisy/SubmoduleDaisySeed.cpp
+++ b/src/daisy/SubmoduleDaisySeed.cpp
@@ -99,8 +99,6 @@ void  SubmoduleDaisySeed::do_run ()
 {
    _seed.adc.Start ();
    _seed.StartAudio (audio_callback_proc);
-
-   for (;;) {}
 }
 
 


### PR DESCRIPTION
This PR moves the led driver update out of the audio thread, as it takes 60% of one frame when running at 48 samples @ 48kHz.