### PR TITLE
Use bss section for sramptr

### DIFF
--- a/src/detail/Sram.cpp
+++ b/src/detail/Sram.cpp
@@ -30,7 +30,7 @@ namespace erb
 
 
 #if defined (erb_TARGET_DAISY)
-std::aligned_storage <erb_SRAM_MEM_POOL_SIZE>::type __attribute__((section(".heap")))
+std::aligned_storage <erb_SRAM_MEM_POOL_SIZE>::type __attribute__((section(".bss")))
    erb_sram_memory_pool_storage;
 #endif
 


### PR DESCRIPTION
This PR use the `.bss` section instead of `.heap` to place our `SramPtr` memory pool in SRAM.
We were using heap before, but then we saw that allocating through malloc would overlap with our addresses.
In all cases, that's really a bss so a better section to describe it.

> **Note**
> bss section is mapped to SRAM for both flash and qspi linker scripts, but that's not the case for the sram lds.
