### PR TITLE
Add sram section support

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -698,7 +698,7 @@ def deploy_dfu_util (name, section, file_bin):
    if section == 'flash':
       print ('Enter the system bootloader by holding the BOOT button down,')
       print ('and then pressing, and releasing the RESET button.')
-   elif section == 'qspi':
+   elif section == 'qspi' or section == 'sram':
       print ('Enter the Daisy bootloader by pressing the RESET button.')
    else:
       assert False
@@ -709,7 +709,7 @@ def deploy_dfu_util (name, section, file_bin):
 
    if section == 'flash':
       section_address = '0x08000000'
-   elif section == 'qspi':
+   elif section == 'qspi' or section == 'sram':
       section_address = '0x90040000'
    else:
       assert False

--- a/build-system/erbb/generators/daisy/make.py
+++ b/build-system/erbb/generators/daisy/make.py
@@ -53,6 +53,8 @@ class Make:
          lds_path = os.path.join (PATH_LIBDAISY, 'core', 'STM32H750IB_flash.lds')
       elif module.section.name == 'qspi':
          lds_path = os.path.join (PATH_LIBDAISY, 'core', 'STM32H750IB_qspi.lds')
+      elif module.section.name == 'sram':
+         lds_path = os.path.join (PATH_LIBDAISY, 'core', 'STM32H750IB_sram.lds')
       else:
          assert False
 

--- a/build-system/erbb/generators/perf/make.py
+++ b/build-system/erbb/generators/perf/make.py
@@ -53,6 +53,8 @@ class Make:
          lds_path = os.path.join (PATH_LIBDAISY, 'core', 'STM32H750IB_flash.lds')
       elif module.section.name == 'qspi':
          lds_path = os.path.join (PATH_LIBDAISY, 'core', 'STM32H750IB_qspi.lds')
+      elif module.section.name == 'sram':
+         lds_path = os.path.join (PATH_LIBDAISY, 'core', 'STM32H750IB_sram.lds')
       else:
          assert False
 

--- a/build-system/erbb/grammar.py
+++ b/build-system/erbb/grammar.py
@@ -13,7 +13,7 @@ from .arpeggio import Optional, ZeroOrMore, EOF, Combine, And
 KEYWORDS = (
    'module',
    'import', 'define', 'sources', 'resources', 'section',
-   'file', 'data', 'flash', 'qspi', 'stream', 'mono', 'interleaved', 'planar'
+   'file', 'data', 'flash', 'qspi', 'sram', 'stream', 'mono', 'interleaved', 'planar'
 )
 
 SYMBOLS = (',', '{', '}', '=')
@@ -75,7 +75,7 @@ def resources_declaration ():          return 'resources', resources_body
 def base_declaration ():               return 'base', string_literal
 
 # Base
-def section_name ():                   return ['flash', 'qspi']
+def section_name ():                   return ['flash', 'qspi', 'sram']
 def section_declaration ():            return 'section', section_name
 
 # Module

--- a/build-system/setup/vscode/syntaxes/erbb.tmLanguage.json
+++ b/build-system/setup/vscode/syntaxes/erbb.tmLanguage.json
@@ -24,7 +24,7 @@
 				},
             {
 					"name": "keyword.control.erbb",
-					"match": "\\b(flash|qspi|mono|interleaved|planar)\\b"
+					"match": "\\b(flash|qspi|sram|mono|interleaved|planar)\\b"
 				},
 				{
 					"name": "keyword.type.erbb",

--- a/build-system/setup/xcode/Erbb.xclangspec
+++ b/build-system/setup/xcode/Erbb.xclangspec
@@ -13,7 +13,7 @@
             Chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
             Words = (
                 "module", "import", "define", "sources", "file", "resources", "data",
-                "section", "flash", "qspi",
+                "section", "flash", "qspi", "sram",
                 "stream", "mono", "interleaved", "planar",
                 "faust", "bind", "address",
                 "use", "strict",


### PR DESCRIPTION
This PR adds support for the SRAM daisy linker script.

Not everything seems to work properly with that target, but we will investigate it later. Basically here, we are adding all the needed support from erbb to link with the `STM32H750IB_sram.lds` linker script.