### PR TITLE
Kivu12 adc qspi

### DIFF
--- a/test/kivu12_adc/Kivu12.erbb
+++ b/test/kivu12_adc/Kivu12.erbb
@@ -8,6 +8,8 @@
 use strict
 
 module Kivu12 {
+   section qspi
+
    sources {
       file "Kivu12.cpp"
       file "Kivu12.h"

--- a/test/kivu12_adc/Kivu12.erbui
+++ b/test/kivu12_adc/Kivu12.erbui
@@ -14,14 +14,14 @@ module Kivu12 {
 
    control freq_pot Pot {
       position 7.33hp, 111mm
-      style knurled
+      style rogan
       label "FREQ"
       pin P1
    }
 
    control freq2_pot Pot {
       position 7.33hp, 111mm
-      style knurled
+      style rogan
       label "FREQ"
       pin P2
    }


### PR DESCRIPTION
This PR moves the kivu12 ADC test to the QSPI section and fixes erbui style.