### PR TITLE
User idle

### DIFF
--- a/build-system/erbui/generators/daisy/code_template.cpp
+++ b/build-system/erbui/generators/daisy/code_template.cpp
@@ -11,7 +11,7 @@
 
 #include "%module.name%.h"
 
-#include "erb/module_init.h"
+#include "erb/module_fnc.h"
 
 #include "erb/def.h"
 

--- a/build-system/erbui/generators/daisy/code_template.cpp
+++ b/build-system/erbui/generators/daisy/code_template.cpp
@@ -135,6 +135,7 @@ int main ()
    {
       auto ts_beg = daisy::System::GetTick ();
 
+      erb::module_idle (module);
       module.ui.board.impl_idle ();
 
       // busy wait so that the idle loop is at least 6ms

--- a/build-system/erbui/generators/perf/code_template.cpp
+++ b/build-system/erbui/generators/perf/code_template.cpp
@@ -261,6 +261,7 @@ int main ()
       postprocess = std::max (postprocess, tsl_4 - tsl_3);
       total = std::max (total, tsl_4 - tsl_1);
 
+      erb::module_idle (module);
       module.ui.board.impl_idle ();
 
       ++cnt;

--- a/build-system/erbui/generators/perf/code_template.cpp
+++ b/build-system/erbui/generators/perf/code_template.cpp
@@ -11,7 +11,7 @@
 
 #include "%module.name%.h"
 
-#include "erb/module_init.h"
+#include "erb/module_fnc.h"
 
 #include "erb/def.h"
 

--- a/build-system/erbui/generators/vcvrack/code_template.cpp
+++ b/build-system/erbui/generators/vcvrack/code_template.cpp
@@ -52,6 +52,9 @@ struct ErbWidget
 {
                   ErbWidget (ErbModule * module);
 
+   void           step () override;
+
+   ErbModule *    module_ptr = nullptr;
 }; // struct ErbWidget
 
 
@@ -169,6 +172,7 @@ Name : ErbWidget::ctor
 */
 
 ErbWidget::ErbWidget (ErbModule * module_)
+:  module_ptr (module_)
 {
    using namespace rack;
 
@@ -190,6 +194,21 @@ ErbWidget::ErbWidget (ErbModule * module_)
    // controls
 
 %  controls_widget%
+}
+
+
+
+/*
+==============================================================================
+Name : ErbWidget::step
+==============================================================================
+*/
+
+void  ErbWidget::step ()
+{
+   rack::Widget::step ();
+
+   erb::module_idle (*module_ptr->module_uptr);
 }
 
 

--- a/build-system/erbui/generators/vcvrack/code_template.cpp
+++ b/build-system/erbui/generators/vcvrack/code_template.cpp
@@ -15,7 +15,7 @@
 
 #include "%module.name%.h"
 
-#include "erb/module_init.h"
+#include "erb/module_fnc.h"
 #include "erb/vcvrack/ModuleBoard.h"
 #include "erb/vcvrack/VcvWidgets.h"
 

--- a/include/erb/erb-src.gypi
+++ b/include/erb/erb-src.gypi
@@ -63,7 +63,7 @@
       'config.h',
       'def.h',
       'erb.h',
-      'module_init.h',
+      'module_fnc.h',
 
       'detail/Animation.h',
       'detail/Animation.hpp',

--- a/include/erb/module_fnc.h
+++ b/include/erb/module_fnc.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 
-      module_init.h
+      module_fnc.h
       Copyright (c) 2020 Raphael DINGE
 
 *Tab=3***********************************************************************/
@@ -43,6 +43,31 @@ typename std::enable_if <has_init <T>::value>::type module_init (T & t)
 
 template <typename T>
 typename std::enable_if <!has_init <T>::value>::type module_init (T &)
+{
+    // nothing
+}
+
+
+
+template <typename T>
+struct has_idle
+{
+   template <typename U, void (U::*) ()> struct sfinae {};
+
+   template <typename U> static char test (sfinae <U, &U::idle> *);
+   template <typename U> static long test (...);
+
+   enum { value = (sizeof test <T> (nullptr) == 1) };
+};
+
+template <typename T>
+typename std::enable_if <has_idle <T>::value>::type module_idle (T & t)
+{
+    t.idle ();
+}
+
+template <typename T>
+typename std::enable_if <!has_idle <T>::value>::type module_idle (T &)
 {
     // nothing
 }


### PR DESCRIPTION
This PR brings the concept of an "idle" function that the user can used to perform non-realtime computations, typically blocking IO transmissions, such as reading from SD card, updating a display, etc.
