### PR TITLE
Fix case where module is not instantiated when using vcv module browser

### DIFF
--- a/build-system/erbui/generators/vcvrack/code_template.cpp
+++ b/build-system/erbui/generators/vcvrack/code_template.cpp
@@ -208,6 +208,9 @@ void  ErbWidget::step ()
 {
    rack::Widget::step ();
 
+   if (module_ptr == nullptr) return;
+   if (!module_ptr->module_uptr) return;
+
    erb::module_idle (*module_ptr->module_uptr);
 }
 


### PR DESCRIPTION
This PR fixes a bug where the module would crash the simulator when using the VCV module browser. In the browser not everything is instantiated, so we need to handle this case.