### PR TITLE
Update libdaisy v540

### DIFF
--- a/src/daisy/SubmoduleDaisyPatchSm.cpp
+++ b/src/daisy/SubmoduleDaisyPatchSm.cpp
@@ -91,11 +91,7 @@ void  SubmoduleDaisyPatchSm::init_audio ()
    _codec.Init (i2c2);
 
    _audio.Init (
-      {
-         .blocksize = 48,
-         .samplerate = SaiHandle::Config::SampleRate::SAI_48KHZ,
-         .postgain = 1.f,
-      },
+      AudioHandle::Config {}, // block 48 @48kHz, unit gains
       sai_1_handle
    );
 


### PR DESCRIPTION
This PR updates libDaisy submodule to v5.4.0 tag.
This is preparation work for the upcoming Display control and Seed2 DFM support.
