### PR TITLE
Erbui refactor gen multi pass

### DIFF
--- a/build-system/erbui/__init__.py
+++ b/build-system/erbui/__init__.py
@@ -188,20 +188,12 @@ def generate_hardware (path, ast):
    if not os.path.exists (path_hardware):
       os.makedirs (path_hardware)
 
-   for generator in ast.modules [0].manufacturer_data ['generators']:
-      generator_id = generator ['id']
-      if generator_id == 'front_panel/dxf':
-         generate_front_panel_dxf (path_hardware, ast)
-      elif generator_id == 'front_panel/pdf':
-         generate_front_panel_pdf (path_hardware, ast)
-      elif generator_id == 'front_panel/pcb':
-         generate_front_panel_pcb (path_hardware, ast)
-      elif generator_id == 'front_pcb/kicad_pcb':
-         generate_front_pcb_kicad_pcb (path_hardware, ast)
-      elif generator_id == 'front_pcb/bom':
-         generate_front_pcb_bom (path_hardware, ast)
-      elif generator_id == 'front_pcb/centroid':
-         generate_front_pcb_centroid (path_hardware, ast)
+   generate_front_panel_dxf (path_hardware, ast)
+   generate_front_panel_pdf (path_hardware, ast)
+   generate_front_panel_pcb (path_hardware, ast)
+   generate_front_pcb_kicad_pcb (path_hardware, ast)
+   generate_front_pcb_bom (path_hardware, ast)
+   generate_front_pcb_centroid (path_hardware, ast)
 
 
 

--- a/build-system/erbui/generators/front_panel/dxf.py
+++ b/build-system/erbui/generators/front_panel/dxf.py
@@ -41,25 +41,27 @@ class Dxf:
    def generate_module (self, path, module):
       if module.material.is_pcb: return # not needed
 
-      path_dxf = os.path.join (path, '%s.dxf' % module.name)
+      for generator in module.manufacturer_data ['generators']:
+         if generator ['id'] == 'front_panel/dxf':
+            path_dxf = os.path.join (path, '%s.dxf' % module.name)
 
-      doc = ezdxf.new (units=ezdxf.units.MM)
-      msp = doc.modelspace ()
+            doc = ezdxf.new (units=ezdxf.units.MM)
+            msp = doc.modelspace ()
 
-      width_hp = round (module.width.mm / HP_TO_MM)
-      final_width = self.get_final_width (width_hp)
+            width_hp = round (module.width.mm / HP_TO_MM)
+            final_width = self.get_final_width (width_hp)
 
-      msp.add_line ((0, 0), (final_width, 0))
-      msp.add_line ((final_width, 0), (final_width, PANEL_HEIGHT))
-      msp.add_line ((final_width, PANEL_HEIGHT), (0, PANEL_HEIGHT))
-      msp.add_line ((0, PANEL_HEIGHT), (0, 0))
+            msp.add_line ((0, 0), (final_width, 0))
+            msp.add_line ((final_width, 0), (final_width, PANEL_HEIGHT))
+            msp.add_line ((final_width, PANEL_HEIGHT), (0, PANEL_HEIGHT))
+            msp.add_line ((0, PANEL_HEIGHT), (0, 0))
 
-      self.generate_mounting_holes (msp, module)
+            self.generate_mounting_holes (msp, module)
 
-      for control in module.controls:
-         self.generate_control (msp,  control)
+            for control in module.controls:
+               self.generate_control (msp,  control)
 
-      doc.saveas (path_dxf)
+            doc.saveas (path_dxf)
 
 
    #--------------------------------------------------------------------------

--- a/build-system/erbui/generators/front_panel/pcb.py
+++ b/build-system/erbui/generators/front_panel/pcb.py
@@ -62,11 +62,13 @@ class Pcb:
    def generate_module (self, path, module):
       if not module.material.is_pcb: return # not needed
 
-      self.generate_module_kicad_mod (path, module)
-      self.generate_module_fp_lib_table (path, module)
-      self.generate_module_kicad_pcb (path, module)
-      self.fill_zones (path, module)
-      self.generate_module_gerber (path, module)
+      for generator in module.manufacturer_data ['generators']:
+         if generator ['id'] == 'front_panel/pcb':
+            self.generate_module_kicad_mod (path, module)
+            self.generate_module_fp_lib_table (path, module)
+            self.generate_module_kicad_pcb (path, module)
+            self.fill_zones (path, module)
+            self.generate_module_gerber (path, module)
 
 
    #--------------------------------------------------------------------------

--- a/build-system/erbui/generators/front_panel/pdf.py
+++ b/build-system/erbui/generators/front_panel/pdf.py
@@ -51,12 +51,14 @@ class Pdf:
    def generate_module (self, path, module):
       if module.material.is_pcb: return # not needed
 
-      path_pdf = os.path.join (path, '%s.pdf' % module.name)
+      for generator in module.manufacturer_data ['generators']:
+         if generator ['id'] == 'front_panel/pdf':
+            path_pdf = os.path.join (path, '%s.pdf' % module.name)
 
-      surface = cairocffi.PDFSurface (path_pdf, module.width.pt, MODULE_HEIGHT * MM_TO_PT)
-      context = cairocffi.Context (surface)
+            surface = cairocffi.PDFSurface (path_pdf, module.width.pt, MODULE_HEIGHT * MM_TO_PT)
+            context = cairocffi.Context (surface)
 
-      panel = detailPanel ()
-      panel.generate_module (context, module)
+            panel = detailPanel ()
+            panel.generate_module (context, module)
 
-      surface.finish ()
+            surface.finish ()

--- a/build-system/erbui/generators/front_pcb/bom.py
+++ b/build-system/erbui/generators/front_pcb/bom.py
@@ -34,19 +34,20 @@ class Bom:
          if generator ['id'] == 'front_pcb/bom':
             generator_args = generator ['args']
 
-      line_format = generator_args ['line_format']
-      header_map = generator_args ['header_map']
-      include_non_empty = generator_args ['include_non_empty']
-      projection = generator_args ['projection']
+            file_format = generator_args.get ('file_format', '{module.name}.bom.csv')
+            line_format = generator_args ['line_format']
+            header_map = generator_args ['header_map']
+            include_non_empty = generator_args ['include_non_empty']
+            projection = generator_args ['projection']
+            excluded_references = module.excluded_references
 
-      excluded_references = module.excluded_references
+            bom = self.make_bom (module.sch_symbols, line_format, header_map, include_non_empty, projection, excluded_references)
 
-      bom = self.make_bom (module.sch_symbols, line_format, header_map, include_non_empty, projection, excluded_references)
+            filename = file_format.format (module=module)
+            path_bom = os.path.join (path, filename)
 
-      path_bom = os.path.join (path, '%s.bom.csv' % module.name)
-
-      with open (path_bom, 'w', encoding='utf-8') as file:
-         file.write (bom)
+            with open (path_bom, 'w', encoding='utf-8') as file:
+               file.write (bom)
 
 
    #--------------------------------------------------------------------------

--- a/build-system/erbui/generators/front_pcb/centroid.py
+++ b/build-system/erbui/generators/front_pcb/centroid.py
@@ -28,19 +28,21 @@ class Centroid:
          if generator ['id'] == 'front_pcb/centroid':
             generator_args = generator ['args']
 
-      line_format = generator_args ['line_format']
-      header_map = generator_args ['header_map']
-      layer_map = generator_args ['layer_map']
-      mounting_key = generator_args ['mounting_key']
-      mounting_value = generator_args ['mounting_value']
-      distance_format = generator_args ['distance_format']
+            file_format = generator_args.get ('file_format', '{module.name}.centroid.csv')
+            line_format = generator_args ['line_format']
+            header_map = generator_args ['header_map']
+            layer_map = generator_args ['layer_map']
+            mounting_key = generator_args ['mounting_key']
+            mounting_value = generator_args ['mounting_value']
+            distance_format = generator_args ['distance_format']
 
-      centroid = self.make_centroid (generator_args, module.pcb, module.sch_symbols)
+            centroid = self.make_centroid (generator_args, module.pcb, module.sch_symbols)
 
-      path_centroid = os.path.join (path, '%s.centroid.csv' % module.name)
+            filename = file_format.format (module=module)
+            path_centroid = os.path.join (path, filename)
 
-      with open (path_centroid, 'w', encoding='utf-8') as file:
-         file.write (centroid)
+            with open (path_centroid, 'w', encoding='utf-8') as file:
+               file.write (centroid)
 
 
    #--------------------------------------------------------------------------

--- a/build-system/erbui/generators/front_pcb/kicad_pcb.py
+++ b/build-system/erbui/generators/front_pcb/kicad_pcb.py
@@ -45,31 +45,33 @@ class KicadPcb:
 
    def generate_module (self, path, module):
 
-      remove_all_pads = not module.route.is_wire
-      self.remove_board_pads (module, remove_all_pads)
+      for generator in module.manufacturer_data ['generators']:
+         if generator ['id'] == 'front_pcb/kicad_pcb':
+            remove_all_pads = not module.route.is_wire
+            self.remove_board_pads (module, remove_all_pads)
 
-      for control in module.controls:
-         self.generate_control (module, control)
+            for control in module.controls:
+               self.generate_control (module, control)
 
-      path_pcb = os.path.join (path, '%s.kicad_pcb' % module.name)
+            path_pcb = os.path.join (path, '%s.kicad_pcb' % module.name)
 
-      if os.path.exists (path_pcb) and module.route.is_manual:
-         ## update pcb rather than overwrite
+            if os.path.exists (path_pcb) and module.route.is_manual:
+               ## update pcb rather than overwrite
 
-         kicad_pcb = pcb.Root.read (os.path.abspath (path_pcb))
+               kicad_pcb = pcb.Root.read (os.path.abspath (path_pcb))
 
-         # only footprints for now
-         kicad_pcb.footprints = module.pcb.footprints
+               # only footprints for now
+               kicad_pcb.footprints = module.pcb.footprints
 
-         kicad_pcb.write (path_pcb)
+               kicad_pcb.write (path_pcb)
 
-      else:
-         module.pcb.write (path_pcb)
+            else:
+               module.pcb.write (path_pcb)
 
-      if module.route.is_wire:
-         self.fill_zones (path, module)
+            if module.route.is_wire:
+               self.fill_zones (path, module)
 
-      self.generate_module_gerber (path, module)
+            self.generate_module_gerber (path, module)
 
 
    #--------------------------------------------------------------------------


### PR DESCRIPTION
This PR allows to invoke a generator (pcb, centroid, bom, etc.) multiple times, in particular for custom boards.
This allows to have multiple outputs with different arguments, allowing to for example output different files depending on different manufacturer needs, during different stages of development (eg. prototyping and production)
