### PR TITLE
Erbui extra 3v3 power pins

### DIFF
--- a/build-system/erbui/analysers/style.py
+++ b/build-system/erbui/analysers/style.py
@@ -352,6 +352,9 @@ class AnalyserStyle:
 
       name_map ['GND'] = 'GND'
       name_map ['+3V3'] = '+3V3'
+      name_map ['3V3A'] = '3V3A'
+      name_map ['3V3D'] = '3V3D'
+      name_map ['3V3SW'] = '3V3SW'
 
       if control.normalling_from is None:
          name_map ['Normalling0'] = 'GND'


### PR DESCRIPTION
This PR adds support for additional power pins:
- `3V3A` and `3V3D` for Daisy Seed, and upcoming Seed2 DFM support,
- `3V3SW` for OLED displays switching power supplies.
