### PR TITLE
Vcv rack sdk 2.4.0

### DIFF
--- a/.github/workflows/macos_11.yml
+++ b/.github/workflows/macos_11.yml
@@ -17,6 +17,8 @@ jobs:
           submodules: recursive
       - run: brew install faust
       - run: brew install --cask vcv-rack
+      - name: VCV Rack headless first run
+        run: /Applications/VCV\ Rack\ 2\ Free.app/Contents/MacOS/Rack -h <<< '\n'
       - run: python3 build-system/install.py
       - run: erbb setup --with-xcode-support
       - name: test/micropatch
@@ -79,6 +81,8 @@ jobs:
         with:
           submodules: recursive
       - run: brew install --cask vcv-rack
+      - name: VCV Rack headless first run
+        run: /Applications/VCV\ Rack\ 2\ Free.app/Contents/MacOS/Rack -h <<< '\n'
       - run: python3 build-system/install.py
       - run: erbb setup
       - name: test/max
@@ -104,6 +108,8 @@ jobs:
           submodules: recursive
       - run: brew install faust
       - run: brew install --cask vcv-rack
+      - name: VCV Rack headless first run
+        run: /Applications/VCV\ Rack\ 2\ Free.app/Contents/MacOS/Rack -h <<< '\n'
       - run: python3 build-system/install.py
       - run: erbb setup
       - name: samples/faust

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -15,10 +15,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: curl https://vcvrack.com/downloads/RackFree-2.1.2-lin.zip | jar xv
+      - run: curl https://vcvrack.com/downloads/RackFree-2.4.0-lin-x64.zip | jar xv
       - run: chmod u+x ./Rack2Free/Rack
       - run: sudo apt-get update
       - run: sudo apt-get install libjack-jackd2-dev libpulse-dev
+      - name: VCV Rack headless first run
+        run: ./Rack -h <<< '\n'
+        working-directory: Rack2Free
       - run: python3 build-system/install.py
       - run: erbb setup --with-apt
       - run: python build-system/install.py
@@ -82,10 +85,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: curl https://vcvrack.com/downloads/RackFree-2.1.2-lin.zip | jar xv
+      - run: curl https://vcvrack.com/downloads/RackFree-2.4.0-lin-x64.zip | jar xv
       - run: chmod u+x ./Rack2Free/Rack
       - run: sudo apt-get update
       - run: sudo apt-get install libjack-jackd2-dev libpulse-dev faust
+      - name: VCV Rack headless first run
+        run: ./Rack -h <<< '\n'
+        working-directory: Rack2Free
       - run: python3 build-system/install.py
       - run: erbb setup --with-apt
       - name: samples/faust

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -15,10 +15,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: curl https://vcvrack.com/downloads/RackFree-2.1.2-lin.zip | jar xv
+      - run: curl https://vcvrack.com/downloads/RackFree-2.4.0-lin-x64.zip | jar xv
       - run: chmod u+x ./Rack2Free/Rack
       - run: sudo apt-get update
       - run: sudo apt-get install libjack-jackd2-dev libpulse-dev
+      - name: VCV Rack headless first run
+        run: ./Rack -h <<< '\n'
+        working-directory: Rack2Free
       - run: python3 build-system/install.py
       - run: erbb setup --with-apt
       - run: python build-system/install.py
@@ -82,10 +85,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: curl https://vcvrack.com/downloads/RackFree-2.1.2-lin.zip | jar xv
+      - run: curl https://vcvrack.com/downloads/RackFree-2.4.0-lin-x64.zip | jar xv
       - run: chmod u+x ./Rack2Free/Rack
       - run: sudo apt-get update
       - run: sudo apt-get install libjack-jackd2-dev libpulse-dev faust
+      - name: VCV Rack headless first run
+        run: ./Rack -h <<< '\n'
+        working-directory: Rack2Free
       - run: python3 build-system/install.py
       - run: erbb setup --with-apt
       - name: samples/faust

--- a/.github/workflows/windows_2019.yml
+++ b/.github/workflows/windows_2019.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           submodules: recursive
       - run: choco install vcvrack
+      - name: VCV Rack headless first run
+        run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n'
       - run: python3 build-system/install.py
       - run: erbb setup
       - name: test/micropatch
@@ -78,6 +80,8 @@ jobs:
         with:
           submodules: recursive
       - run: choco install vcvrack
+      - name: VCV Rack headless first run
+        run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n'
       - run: python3 build-system/install.py
       - run: erbb setup
       - name: test/max
@@ -106,6 +110,8 @@ jobs:
       - run: echo 'export PATH=$PATH:/c/Program\ Files/Faust/bin' >> ~/.bash_profile
       - run: cat ~/.bash_profile
       - run: choco install vcvrack
+      - name: VCV Rack headless first run
+        run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n'
       - run: python3 build-system/install.py
       - run: erbb setup
       - name: samples/faust
@@ -142,6 +148,8 @@ jobs:
       - run: echo 'export PATH=$PATH:/c/Program\ Files/Faust/bin' >> ~/.bash_profile
       - run: cat ~/.bash_profile
       - run: choco install vcvrack
+      - name: VCV Rack headless first run
+        run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n'
       - run: python3 build-system/install.py
       - run: erbb setup
       - name: samples/faust

--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -783,18 +783,25 @@ def deploy_simulator (name, path, configuration):
       sys.exit ('Unknown target %s' % name)
 
    if platform.system () == 'Darwin':
-      vcv_plugins_path = os.path.abspath (
-         os.path.join (os.path.expanduser ("~"), 'Documents', 'Rack2', 'plugins')
-      )
+      if platform.machine () == 'x86_64':
+         vcv_plugins_path = os.path.abspath (
+            os.path.join (os.path.expanduser ("~"), 'Documents', 'Rack2', 'plugins-mac-x64')
+         )
+      elif platform.machine () == 'arm64':
+         vcv_plugins_path = os.path.abspath (
+            os.path.join (os.path.expanduser ("~"), 'Documents', 'Rack2', 'plugins-mac-arm64')
+         )
+      else:
+         sys.exit (1)
 
    elif platform.system () == 'Windows':
       vcv_plugins_path = os.path.abspath (
-         os.path.join (os.environ ['USERPROFILE'], 'Documents', 'Rack2', 'plugins')
+         os.path.join (os.environ ['USERPROFILE'], 'Documents', 'Rack2', 'plugins-win-x64')
       )
 
    elif platform.system () == 'Linux':
       vcv_plugins_path = os.path.abspath (
-         os.path.join (os.path.expanduser ("~"), '.Rack2', 'plugins')
+         os.path.join (os.path.expanduser ("~"), '.Rack2', 'plugins-lin-x64')
       )
 
    vcv_plugin_path = os.path.join (vcv_plugins_path, name)

--- a/build-system/erbb/generators/action/action_vcvrack_install_template.py
+++ b/build-system/erbb/generators/action/action_vcvrack_install_template.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-#     deploy_vcvrack.py
+#     action_vcvrack_install.py
 #     Copyright (c) 2020 Raphael Dinge
 #
 #Tab=3########################################################################
@@ -18,10 +18,18 @@ PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
 
 if platform.system () == 'Darwin':
-   PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.path.expanduser ("~"), 'Documents', 'Rack2', 'plugins'))
+   if platform.machine () == 'x86_64':
+      PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.path.expanduser ("~"), 'Documents', 'Rack2', 'plugins-mac-x64'))
+   elif platform.machine () == 'arm64':
+      PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.path.expanduser ("~"), 'Documents', 'Rack2', 'plugins-mac-arm64'))
+   else:
+      sys.exit (1)
 
 elif platform.system () == 'Linux':
-   PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.path.expanduser ("~"), '.Rack2', 'plugins'))
+   PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.path.expanduser ("~"), '.Rack2', 'plugins-lin-x64'))
+
+elif platform.system () == 'Windows':
+   PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.environ ['USERPROFILE'], 'Documents', 'Rack2', 'plugins-win-x64'))
 
 PATH_VCV_PLUGIN = os.path.abspath (os.path.join (PATH_VCV_PLUGINS, '%module.name%'))
 PATH_VCV_PLUGIN_RES = os.path.abspath (os.path.join (PATH_VCV_PLUGIN, 'res'))
@@ -47,6 +55,13 @@ if __name__ == '__main__':
          os.path.join (TARGET_BUILD_DIR, 'plugin.dylib'),
          os.path.join (PATH_VCV_PLUGIN, 'plugin.dylib')
       )
+
+      subprocess.check_call ([
+         '/usr/bin/codesign',
+         '--force',
+         '--sign', '-', # ad-hoc signing
+         os.path.join (PATH_VCV_PLUGIN, 'plugin.dylib'),
+      ])
 
       shutil.copyfile (
          os.path.join (TARGET_BUILD_DIR, 'plugin.json'),

--- a/build-system/erbb/generators/simulator/Makefile_template
+++ b/build-system/erbb/generators/simulator/Makefile_template
@@ -31,7 +31,7 @@ FLAGS += -I$(RACK_DIR)/include
 FLAGS += -I$(RACK_DIR)/dep/include
 
 LDFLAGS += -shared
-LDFLAGS += -L$(RACK_DIR) -lRack
+LDFLAGS += -L$(RACK_DIR)/$(ARCH_OS)-$(ARCH_CPU) -lRack
 
 ifdef ARCH_MAC
 	LDFLAGS += -undefined dynamic_lookup
@@ -69,13 +69,23 @@ ifdef ARCH_WIN
 	CXXFLAGS += -Wsuggest-override
 endif
 
+ifdef ARCH_X64
+	FLAGS += -DARCH_X64
+	FLAGS += -march=nehalem
+endif
+
+ifdef ARCH_ARM64
+	FLAGS += -DARCH_ARM64
+	FLAGS += -march=armv8-a+fp+simd
+endif
+
 # Optimization
 ifeq ($(CONFIGURATION),Debug)
-FLAGS += -O0 -g -march=nehalem -funsafe-math-optimizations
+FLAGS += -O0 -g -funsafe-math-optimizations
 endif
 
 ifeq ($(CONFIGURATION),Release)
-FLAGS += -O3 -DNDEBUG=1 -march=nehalem -funsafe-math-optimizations
+FLAGS += -O3 -DNDEBUG=1 -funsafe-math-optimizations
 endif
 
 %warnings%
@@ -112,9 +122,12 @@ endif
 	@cp ../panel_vcvrack.svg $(CONFIGURATION)/package/res/panel_vcvrack.svg
 
 install: package
-	@echo "INSTALL $(RACK_USER_DIR)/plugins/%module.name%/"
-	@mkdir -p $(RACK_USER_DIR)/plugins/%module.name%
-	@cp -r $(CONFIGURATION)/package/* $(RACK_USER_DIR)/plugins/%module.name%/
+	@echo "INSTALL $(RACK_USER_DIR)/plugins-$(ARCH_OS)-$(ARCH_CPU)/%module.name%/"
+	@mkdir -p $(RACK_USER_DIR)/plugins-$(ARCH_OS)-$(ARCH_CPU)/%module.name%
+	@cp -r $(CONFIGURATION)/package/* $(RACK_USER_DIR)/plugins-$(ARCH_OS)-$(ARCH_CPU)/%module.name%/
+ifdef ARCH_MAC
+	@codesign --force --sign - $(RACK_USER_DIR)/plugins-$(ARCH_OS)-$(ARCH_CPU)/%module.name%/plugin.dylib > /dev/null 2>&1
+endif
 
 .PHONY: package install resources
 .DEFAULT_GOAL := all

--- a/build-system/erbb/generators/simulator/make.py
+++ b/build-system/erbb/generators/simulator/make.py
@@ -49,15 +49,23 @@ class Make:
       path_rack_dir = os.path.relpath (PATH_RACK, path_simulator)
 
       if platform.system () == 'Darwin':
-         arch = 'ARCH_MAC := 1\nARCH := mac'
-         cxx = 'CXX = arch -x86_64 clang'
+         if platform.machine () == 'x86_64':
+            arch = 'ARCH_MAC := 1\nARCH_OS := mac\nARCH_CPU := x64\nARCH_NAME := mac-x64'
+            cxx = 'CXX = arch -x86_64 clang'
+         elif platform.machine () == 'arm64':
+            arch = 'ARCH_MAC := 1\nARCH_OS := mac\nARCH_CPU := arm64\nARCH_NAME := mac-arm64'
+            cxx = 'CXX = arch -arm64 clang'
+         else:
+            sys.exit (1)
+
       elif platform.system () == 'Linux':
-         arch = 'ARCH_LIN := 1\nARCH := lin'
+         arch = 'ARCH_LIN := 1\nARCH_OS := lin\nARCH_CPU := x64\nARCH_NAME := lin-x64'
          cxx = '' # default
+
       elif platform.system () == 'Windows':
          PATH_GPP = os.path.join (PATH_BUILD_SYSTEM, 'toolchain', 'msys2_mingw64', 'bin', 'g++.exe')
          path_cxx = os.path.relpath (PATH_GPP, path_simulator)
-         arch = 'ARCH_WIN := 1\nARCH := win\nARCH_WIN_64 := 1\nBITS := 64'
+         arch = 'ARCH_WIN := 1\nARCH_OS := win\nARCH_WIN_64 := 1\nBITS := 64\nARCH_CPU := x64\nARCH_NAME := win-x64'
          cxx = 'CXX = %s' % path_cxx.replace ('\\', '/')
 
       template = template.replace ('%module.name%', module.name)

--- a/documentation/setup/linux-cpp-cli.md
+++ b/documentation/setup/linux-cpp-cli.md
@@ -11,7 +11,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 
 - [`git`](https://git-scm.com/download)
 - [Python 3](https://www.python.org/downloads/)
-- [VCV Rack version 2](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 
@@ -143,7 +143,7 @@ COPY include/erb/vcvrack/resource/rogan.6ps.svg
 ...
 LINK plugin.dylib
 PACKAGE Release Drop
-INSTALL /Users/raf/Documents/Rack2/plugins/Drop/
+INSTALL /Users/raf/Documents/Rack2/plugins-lin-x64/Drop/
 ```
 
 You can then run VCV Rack and play with your module.
@@ -160,7 +160,7 @@ COPY include/erb/vcvrack/resource/rogan.6ps.svg
 ...
 LINK plugin.dylib
 PACKAGE Debug Drop
-INSTALL /Users/raf/Documents/Rack2/plugins/Drop/
+INSTALL /Users/raf/Documents/Rack2/plugins-lin-x64/Drop/
 ```
 
 You can build the firmware by running:

--- a/documentation/setup/linux-cpp-vscode.md
+++ b/documentation/setup/linux-cpp-vscode.md
@@ -12,7 +12,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download)
 - [Python 3](https://www.python.org/downloads/)
 - [Visual Studio Code](https://code.visualstudio.com/download)
-- [VCV Rack version 2](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/linux-faust.md
+++ b/documentation/setup/linux-faust.md
@@ -12,7 +12,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download)
 - [Python 3](https://www.python.org/downloads/)
 - [Faust](https://faust.grame.fr)
-- [VCV Rack version 2](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 
@@ -160,7 +160,7 @@ COPY include/erb/vcvrack/resource/rogan.6ps.svg
 ...
 LINK plugin.dylib
 PACKAGE Release Flanger
-INSTALL /Users/raf/Documents/Rack2/plugins/Flanger/
+INSTALL /Users/raf/Documents/Rack2/plugins-lin-x64/Flanger/
 ```
 
 You can then run VCV Rack and play with your module.

--- a/documentation/setup/macos-cpp-cli.md
+++ b/documentation/setup/macos-cpp-cli.md
@@ -13,7 +13,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download)
 - [Python 3](https://www.python.org/downloads/)
 - [Xcode command line tools](https://developer.apple.com/xcode/)
-- [VCV Rack version 2](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 
@@ -140,7 +140,7 @@ COPY include/erb/vcvrack/resource/rogan.6ps.svg
 ...
 LINK plugin.dylib
 PACKAGE Release Drop
-INSTALL /Users/raf/Documents/Rack2/plugins/Drop/
+INSTALL /Users/raf/Documents/Rack2/plugins-mac-x64/Drop/
 ```
 
 You can then run VCV Rack and play with your module.
@@ -157,7 +157,7 @@ COPY include/erb/vcvrack/resource/rogan.6ps.svg
 ...
 LINK plugin.dylib
 PACKAGE Debug Drop
-INSTALL /Users/raf/Documents/Rack2/plugins/Drop/
+INSTALL /Users/raf/Documents/Rack2/plugins-mac-x64/Drop/
 ```
 
 You can build the firmware by running:

--- a/documentation/setup/macos-cpp-vscode.md
+++ b/documentation/setup/macos-cpp-vscode.md
@@ -14,7 +14,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [Python 3](https://www.python.org/downloads/)
 - [Xcode command line tools](https://developer.apple.com/xcode/)
 - [Visual Studio Code](https://code.visualstudio.com/download)
-- [VCV Rack version 2](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/macos-cpp-xcode.md
+++ b/documentation/setup/macos-cpp-xcode.md
@@ -13,7 +13,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download)
 - [Python 3](https://www.python.org/downloads/)
 - [Xcode version 11 or later](https://developer.apple.com/xcode/)
-- [VCV Rack version 2](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/macos-faust.md
+++ b/documentation/setup/macos-faust.md
@@ -14,7 +14,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [Python 3](https://www.python.org/downloads/)
 - [Xcode command line tools](https://developer.apple.com/xcode/)
 - [Faust](https://faust.grame.fr)
-- [VCV Rack version 2](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 
@@ -157,7 +157,7 @@ COPY include/erb/vcvrack/resource/rogan.6ps.svg
 ...
 LINK plugin.dylib
 PACKAGE Release Flanger
-INSTALL /Users/raf/Documents/Rack2/plugins/Flanger/
+INSTALL /Users/raf/Documents/Rack2/plugins-mac-x64/Flanger/
 ```
 
 You can then run VCV Rack and play with your module.

--- a/documentation/setup/macos-max.md
+++ b/documentation/setup/macos-max.md
@@ -14,7 +14,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [Python 3](https://www.python.org/downloads/)
 - [Xcode command line tools](https://developer.apple.com/xcode/)
 - [Max](https://cycling74.com/products/max) at least version 8
-- [VCV Rack version 2](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/windows-cpp-cli.md
+++ b/documentation/setup/windows-cpp-cli.md
@@ -11,7 +11,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 
 - [`git`](https://git-scm.com/download) and in particular the Git Bash shell
 - [Python 3](https://www.python.org/downloads/)
-- [VCV Rack version 2](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 
@@ -123,7 +123,7 @@ COPY include/erb/vcvrack/resource/rogan.6ps.svg
 ...
 LINK plugin.dylib
 PACKAGE Release Drop
-INSTALL /Users/raf/Documents/Rack2/plugins/Drop/
+INSTALL /Users/raf/Documents/Rack2/plugins-win-x64/Drop/
 ```
 
 You can then run VCV Rack and play with your module.
@@ -140,7 +140,7 @@ COPY include/erb/vcvrack/resource/rogan.6ps.svg
 ...
 LINK plugin.dylib
 PACKAGE Debug Drop
-INSTALL /Users/raf/Documents/Rack2/plugins/Drop/
+INSTALL /Users/raf/Documents/Rack2/plugins-win-x64/Drop/
 ```
 
 You can build the firmware by running:

--- a/documentation/setup/windows-cpp-vscode.md
+++ b/documentation/setup/windows-cpp-vscode.md
@@ -12,7 +12,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download) and in particular the Git Bash shell
 - [Python 3](https://www.python.org/downloads/)
 - [Visual Studio Code](https://code.visualstudio.com/download)
-- [VCV Rack version 2](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/windows-faust.md
+++ b/documentation/setup/windows-faust.md
@@ -12,7 +12,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download) and in particular the Git Bash shell
 - [Python 3](https://www.python.org/downloads/)
 - [Faust](https://faust.grame.fr)
-- [VCV Rack version 2](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 
@@ -140,7 +140,7 @@ COPY include/erb/vcvrack/resource/rogan.6ps.svg
 ...
 LINK plugin.dylib
 PACKAGE Release Flanger
-INSTALL /Users/raf/Documents/Rack2/plugins/Flanger/
+INSTALL /Users/raf/Documents/Rack2/plugins-win-x64/Flanger/
 ```
 
 You can then run VCV Rack and play with your module.

--- a/documentation/setup/windows-max.md
+++ b/documentation/setup/windows-max.md
@@ -12,7 +12,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download) and in particular the Git Bash shell
 - [Python 3](https://www.python.org/downloads/)
 - [Max](https://cycling74.com/products/max) at least version 8
-- [VCV Rack version 2](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/include/erb/xcode.gypi
+++ b/include/erb/xcode.gypi
@@ -32,7 +32,8 @@
       },
       'xcode_settings':
       {
-         'ARCHS': ['x86_64'],
+         'ARCHS': ['$(ARCHS_STANDARD)'],
+         'ONLY_ACTIVE_ARCH': 'YES',
          'MACOSX_DEPLOYMENT_TARGET': '10.14',
 
          'CLANG_CXX_LANGUAGE_STANDARD': 'c++2a',


### PR DESCRIPTION
This PR updates the `vcv-rack-sdk` submodule to version 2.4.0 since this version introduces a breaking change in the way plug-ins are loaded, and in particular their path. It also now supports the ARM64 architecture, and fixes a bug in the action system where the Windows binary was not installed.

- Fixes #619 
- Fixes #627 

## Todo

- [x] Check on macOS `x86_64`
- [x] Check on macOS `arm64`
