### PR TITLE
Fix bootloader version in erbb install

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -694,10 +694,10 @@ Name : deploy_bootloader
 
 def deploy_bootloader ():
    libdaisy_bootloader_bin = os.path.join (
-      PATH_ROOT, 'submodules', 'libDaisy', 'core', 'dsy_bootloader_v4.bin'
+      PATH_ROOT, 'submodules', 'libDaisy', 'core', 'dsy_bootloader_v5_4.bin'
    )
 
-   deploy_dfu_util ('dsy_bootloader_v4', 'flash', libdaisy_bootloader_bin)
+   deploy_dfu_util ('dsy_bootloader_v5_4', 'flash', libdaisy_bootloader_bin)
 
 
 


### PR DESCRIPTION
This PR fixes a mistake, where the bootloader path was not changed when transitioning from v4 to v5.4.