### PR TITLE
Ssd130x offset support

### DIFF
--- a/boards/seed2_dfm_eval_euro/firmware/BoardSeed2DfmEvalEuro.h
+++ b/boards/seed2_dfm_eval_euro/firmware/BoardSeed2DfmEvalEuro.h
@@ -224,7 +224,7 @@ private:
                   _display_transport;
    FormatSsd130x <128, 64>::Storage
                   _oled_buffer;
-   OledSsd130x <128, 64, daisy::SSD130x4WireSpiTransport>
+   OledSsd130x <128, 64, 0, 0, daisy::SSD130x4WireSpiTransport>
                   _display;
 
 

--- a/include/erb/daisy/OledSsd130x.h
+++ b/include/erb/daisy/OledSsd130x.h
@@ -33,7 +33,7 @@ namespace erb
 
 
 
-template <size_t Width, size_t Height, typename Transport>
+template <size_t Width, size_t Height, size_t XOffset, size_t PageOffset, typename Transport>
 class OledSsd130x
 {
 


### PR DESCRIPTION
This PR adds support for OLED modules using SSD1306 or SSD1309 (which natively drives 128x64 pixels), but for which the actual pixels is only a portion of the full accessible pixels. This is done by introducing an X-offset and page offset.
The X-offset implementation could probably be done better (as it might be directly supported by the controller), but this solution is good enough for now.