### PR TITLE
Add support for bootloader targets debugging

### DIFF
--- a/build-system/erbb/generators/vscode/launch.py
+++ b/build-system/erbb/generators/vscode/launch.py
@@ -86,11 +86,21 @@ class Launch:
          os_launch_debug_config += '            "program": "%s"\n' % rack_path
          os_launch_debug_config += '         }'
 
+      openocd_launch_commands = '            "init",\n'
+
+      if module.section.name == 'flash':
+         openocd_launch_commands += '            "reset init"\n'
+      elif module.section.name == 'sram' or module.section.name == 'qspi':
+         openocd_launch_commands += '            "reset init",\n'
+         openocd_launch_commands += '            "gdb_breakpoint_override hard"\n'
+      else:
+         assert False
 
       template = template.replace ('%executable_release%', file_elf_release.replace ('\\', '/'))
       template = template.replace ('%executable_debug%', file_elf_debug.replace ('\\', '/'))
       template = template.replace ('%svd_file%', file_svd.replace ('\\', '/'))
       template = template.replace ('%        os_launch_debug_config%', os_launch_debug_config)
+      template = template.replace ('%           openocd_launch_commands%', openocd_launch_commands)
 
       with open (path_dst, 'w', encoding='utf-8') as file:
          file.write (template)

--- a/build-system/erbb/generators/vscode/launch_template.json
+++ b/build-system/erbb/generators/vscode/launch_template.json
@@ -15,12 +15,10 @@
          "executable": "%executable_release%",
          "interface": "swd",
          "openOCDLaunchCommands": [
-            "init",
-            "reset init"
+%           openocd_launch_commands%
          ],
-         "preLaunchTask": "Build Firmware - Release",
+         "preLaunchTask": "Build and Flash Firmware - Release",
          "preRestartCommands": [
-            "load",
             "enable breakpoint",
             "monitor reset"
          ],
@@ -48,12 +46,10 @@
          "executable": "%executable_debug%",
          "interface": "swd",
          "openOCDLaunchCommands": [
-            "init",
-            "reset init"
+%           openocd_launch_commands%
          ],
-         "preLaunchTask": "Build Firmware - Debug",
+         "preLaunchTask": "Build and Flash Firmware - Debug",
          "preRestartCommands": [
-            "load",
             "enable breakpoint",
             "monitor reset"
          ],

--- a/build-system/erbb/generators/vscode/tasks_template.json
+++ b/build-system/erbb/generators/vscode/tasks_template.json
@@ -36,9 +36,9 @@
          ]
       },
       {
-         "label": "Build Firmware - Debug",
+         "label": "Build and Flash Firmware - Debug",
          "type": "shell",
-         "command": "erbb build firmware --configuration debug --semihosting",
+         "command": "erbb build firmware --configuration debug --semihosting && erbb install firmware --configuration debug",
          "group": {
             "kind": "build",
             "isDefault": true,
@@ -51,9 +51,9 @@
          ]
       },
       {
-         "label": "Build Firmware - Release",
+         "label": "Build and Flash Firmware - Release",
          "type": "shell",
-         "command": "erbb build firmware --configuration release --semihosting",
+         "command": "erbb build firmware --configuration release --semihosting && erbb install firmware --configuration release",
          "group": "build",
          "options": {
            "cwd": "${workspaceFolder}"


### PR DESCRIPTION
This PR adds support for STLink debugging when using SRAM or QSPI targets.

This is done by flashing the firmware ourselves, as the OpenOCD "load" command will fail for SRAM and QSPI.

> [!IMPORTANT]  
> To use, please note that you need the Daisy module to be connected both using JTAG and USB, because the firmware in that case will get uploaded using DFU.
> Also, the daisy module must be flashed with bootloader priori to debugging, using `erbb install bootloader`.
