### PR TITLE
Add src to workspace

### DIFF
--- a/build-system/erbb/generators/vscode/workspace.py
+++ b/build-system/erbb/generators/vscode/workspace.py
@@ -41,6 +41,7 @@ class Workspace:
       paths.append (path)
 
       paths.append (os.path.join (PATH_ROOT, 'include', 'erb'))
+      paths.append (os.path.join (PATH_ROOT, 'src'))
 
       if module.source_language == 'max':
          paths.append (os.path.join (PATH_ROOT, 'include', 'gen_dsp'))


### PR DESCRIPTION
This PR adds the `src` folder to the VSCode workspace template for easier debugging.