### PR TITLE
Add invisible vcv widget

### DIFF
--- a/include/erb/vcvrack/VcvWidgets.h
+++ b/include/erb/vcvrack/VcvWidgets.h
@@ -582,6 +582,12 @@ private:
 };
 
 
+struct Invisible : rack::ParamWidget
+{
+   Invisible () = default;
+   void  rotate (float) {}
+};
+
 
 template <typename Widget, typename T>
 Widget * createWidgetCentered (rack::math::Vec pos, T & control)


### PR DESCRIPTION
This PR adds an invisible widget for the simulator running in VCV Rack. This is typically used for parts on the PCB that are not supposed to be accessible to the end-user while using the module in their system, such as a "FLASH" button.