### PR TITLE
Fix front panel rectangular hole

### DIFF
--- a/build-system/erbui/generators/front_panel/dxf.py
+++ b/build-system/erbui/generators/front_panel/dxf.py
@@ -108,10 +108,14 @@ class Dxf:
             )
 
          elif isinstance (gr_shape, pcb.GrRect) and gr_shape.layer == 'Eco1.User':
+            start_x = min (gr_shape.start.x, gr_shape.end.x)
+            end_x = max (gr_shape.start.x, gr_shape.end.x)
+            start_y = min (gr_shape.start.y, gr_shape.end.y)
+            end_y = max (gr_shape.start.y, gr_shape.end.y)
             self.add_rounded_rectangle (
                msp,
-               gr_shape.start.x, PANEL_HEIGHT - gr_shape.start.y,
-               gr_shape.end.x, PANEL_HEIGHT - gr_shape.end.y,
+               start_x, PANEL_HEIGHT - start_y,
+               end_x, PANEL_HEIGHT - end_y,
                1.5   # drill bit 3mm
             )
 


### PR DESCRIPTION
This PR fixes a bug where rectangular holes in the front panel, typically coming from a `Display`, were not taking properly rotation of the control into account.