### PR TITLE
Bootloader v6

### DIFF
--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -694,10 +694,10 @@ Name : deploy_bootloader
 
 def deploy_bootloader ():
    libdaisy_bootloader_bin = os.path.join (
-      PATH_ROOT, 'submodules', 'libDaisy', 'core', 'dsy_bootloader_v5_4.bin'
+      PATH_ROOT, 'submodules', 'libDaisy', 'core', 'dsy_bootloader_v6_2-intdfu-2000ms.bin'
    )
 
-   deploy_dfu_util ('dsy_bootloader_v5_4', 'flash', libdaisy_bootloader_bin)
+   deploy_dfu_util ('dsy_bootloader_v6_2-intdfu-2000ms', 'flash', libdaisy_bootloader_bin)
 
 
 

--- a/build-system/erbui/generators/daisy/code_template.cpp
+++ b/build-system/erbui/generators/daisy/code_template.cpp
@@ -57,9 +57,14 @@ int main ()
    config.Boost ();
 
    auto program_memory_section = daisy::System::GetProgramMemoryRegion ();
+   auto boot_version = daisy::System::GetBootloaderVersion ();
 
-   // When using the bootloader, clocks have been already configured
-   if (program_memory_section != daisy::System::MemoryRegion::INTERNAL_FLASH)
+   // When using the bootloader prior to v6, clocks have been already configured
+
+   if (
+      (boot_version == daisy::System::BootInfo::Version::LT_v6_0)
+      && (program_memory_section != daisy::System::MemoryRegion::INTERNAL_FLASH)
+      )
    {
       config.skip_clocks = true;
    }
@@ -68,8 +73,15 @@ int main ()
 
    // Init SDRAM
 
-   // When using the bootloader, SDRAM has been already configured
-   if (program_memory_section == daisy::System::MemoryRegion::INTERNAL_FLASH)
+   // When using the bootloader priori to v6, SDRAM has been already configured
+
+   if (
+      (boot_version != daisy::System::BootInfo::Version::LT_v6_0)
+      || (
+         (boot_version == daisy::System::BootInfo::Version::LT_v6_0)
+         && (program_memory_section == daisy::System::MemoryRegion::INTERNAL_FLASH)
+         )
+      )
    {
       SdramHandle sdram;
       sdram.Init ();

--- a/build-system/erbui/generators/perf/code_template.cpp
+++ b/build-system/erbui/generators/perf/code_template.cpp
@@ -127,9 +127,14 @@ int main ()
    config.Boost ();
 
    auto program_memory_section = daisy::System::GetProgramMemoryRegion ();
+   auto boot_version = daisy::System::GetBootloaderVersion ();
 
-   // When using the bootloader, clocks have been already configured
-   if (program_memory_section != daisy::System::MemoryRegion::INTERNAL_FLASH)
+   // When using the bootloader prior to v6, clocks have been already configured
+
+   if (
+      (boot_version == daisy::System::BootInfo::Version::LT_v6_0)
+      && (program_memory_section != daisy::System::MemoryRegion::INTERNAL_FLASH)
+      )
    {
       config.skip_clocks = true;
    }
@@ -138,8 +143,15 @@ int main ()
 
    // Init SDRAM
 
-   // When using the bootloader, SDRAM has been already configured
-   if (program_memory_section == daisy::System::MemoryRegion::INTERNAL_FLASH)
+   // When using the bootloader priori to v6, SDRAM has been already configured
+
+   if (
+      (boot_version != daisy::System::BootInfo::Version::LT_v6_0)
+      || (
+         (boot_version == daisy::System::BootInfo::Version::LT_v6_0)
+         && (program_memory_section == daisy::System::MemoryRegion::INTERNAL_FLASH)
+         )
+      )
    {
       SdramHandle sdram;
       sdram.Init ();


### PR DESCRIPTION
This PR updates to the version of libDaisy with bootloader v6, which fixes a "stuck GPIO pin" issue for SRAM and QSPI stored programs.

## To do

- [x] Test on real hardware