### PR TITLE
Add bootloader fast boot option

### DIFF
--- a/build-system/completion/__init__.py
+++ b/build-system/completion/__init__.py
@@ -22,6 +22,7 @@ def programmer ():                     return '--programmer', ['dfu', 'stlink']
 def logger ():                         return '--logger', ['usb', 'semihosting']
 def xcode ():                          return '--xcode'
 def semihosting ():                    return '--semihosting'
+def fast_boot ():                      return '--fast-boot'
 def only_gerber ():                    return '--only-gerber'
 def with_xcode_support ():             return '--with-xcode-support'
 def with_vscode_support ():            return '--with-vscode-support'
@@ -35,7 +36,7 @@ def build_hardware ():                 return 'hardware', ZeroOrMore ([only_gerb
 
 def install_firmware ():               return 'firmware', ZeroOrMore ([configuration, programmer])
 def install_performance ():            return 'performance'
-def install_bootloader ():             return 'bootloader'
+def install_bootloader ():             return 'bootloader', ZeroOrMore ([fast_boot])
 def install_simulator ():              return 'simulator', ZeroOrMore ([configuration])
 
 def run_performance ():                return 'performance'
@@ -81,6 +82,7 @@ DESCRIPTION = {
    '--semihosting': 'enable semihosting',
    'hardware': 'the files to manufacture the module',
    '--only-gerber': 'generate gerber from pcb layout only',
+   '--fast-boot': 'install fast boot variant',
    'install': 'install the firmware or bootloader',
    '--programmer': 'the programmer to use, defaults to automatic selection',
    'performance': 'the performance analysis firmware',

--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -692,12 +692,12 @@ Name : deploy_bootloader
 ==============================================================================
 """
 
-def deploy_bootloader ():
+def deploy_bootloader (variant):
    libdaisy_bootloader_bin = os.path.join (
-      PATH_ROOT, 'submodules', 'libDaisy', 'core', 'dsy_bootloader_v6_2-intdfu-2000ms.bin'
+      PATH_ROOT, 'submodules', 'libDaisy', 'core', 'dsy_bootloader_v6_2-%s.bin' % variant
    )
 
-   deploy_dfu_util ('dsy_bootloader_v6_2-intdfu-2000ms', 'flash', libdaisy_bootloader_bin)
+   deploy_dfu_util ('dsy_bootloader_v6_2-%s' % variant, 'flash', libdaisy_bootloader_bin)
 
 
 

--- a/build-system/scripts/erbb
+++ b/build-system/scripts/erbb
@@ -447,7 +447,12 @@ def install_performance (args):
 def install_bootloader (args):
    import erbb
 
-   erbb.deploy_bootloader ()
+   if args.fast_boot:
+      variant = 'intdfu-10ms'
+   else:
+      variant = 'intdfu-2000ms'
+
+   erbb.deploy_bootloader (variant)
 
 
 
@@ -673,6 +678,12 @@ def parse_args_install (parent):
    parser_bootloader = subparsers.add_parser (
       'bootloader',
       help='install the bootloader'
+   )
+
+   parser_bootloader.add_argument(
+      '--fast-boot',
+      action = 'store_true',
+      help = 'install fast boot variant'
    )
 
    parser_performance = subparsers.add_parser (


### PR DESCRIPTION
This PR adds a `--fast-boot` option to the `erbb install bootloader` command, which allows to upload a special version of the bootloader that "only waits" 10ms before launching the user program, instead of 2s without that option.

This is done so that the hardware looks like it is starting immediately, as without it the end user could sometimes think there is a problem with the module.

## To do

- [x] Test on real hardware