### PR TITLE
Move class keyword manufacturer control to arg

### DIFF
--- a/build-system/erbui/analysers/style.py
+++ b/build-system/erbui/analysers/style.py
@@ -185,7 +185,7 @@ class AnalyserStyle:
       for control in manufacturer.controls:
          for kind in control.kinds:
             manufacturer_data ['controls'][kind].append (
-               {'styles': control.style, 'parts': control.parts, 'class': control.class_, 'args': control.args_as_dict}
+               {'styles': control.style, 'parts': control.parts, 'args': control.args_as_dict}
             )
 
       return manufacturer_data
@@ -234,7 +234,6 @@ class AnalyserStyle:
             if keyword.value == unknown:
                raise error.incompatible_style (keyword, cur_styles_parts ['styles'])
 
-      control.simulator_class = cur_styles_parts ['class']
       control.args = cur_styles_parts ['args']
 
       component_list = cur_styles_parts ['parts']

--- a/build-system/erbui/ast.py
+++ b/build-system/erbui/ast.py
@@ -236,9 +236,6 @@ class Node:
    @property
    def is_manufacturer_control_parts (self): return isinstance (self, ManufacturerControlParts)
 
-   @property
-   def is_manufacturer_control_class (self): return isinstance (self, ManufacturerControlClass)
-
 
 
 # -- Scope -------------------------------------------------------------------
@@ -1490,7 +1487,6 @@ class Control (Scope):
       self.identifier_name = identifier_name
       self.keyword_kind = keyword_kind
       self.parts = []
-      self.simulator_class = None
       self.args = {}
 
    @staticmethod
@@ -2276,12 +2272,6 @@ class ManufacturerControl (Scope):
       return [e.value for e in keyword_names]
 
    @property
-   def class_ (self):
-      entities = [e for e in self.entities if e.is_manufacturer_control_class]
-      assert len (entities) == 1
-      return entities [0].name
-
-   @property
    def args_as_dict (self):
       dict = {e.name: e.value for e in self.entities if e.is_arg}
       return dict
@@ -2297,15 +2287,3 @@ class ManufacturerControlParts (Scope):
 
    @staticmethod
    def typename (): return 'parts'
-
-
-# -- ManufacturerControlClass ------------------------------------------------
-
-class ManufacturerControlClass (Node):
-   def __init__ (self, string_literal):
-      assert isinstance (string_literal, StringLiteral)
-      super (ManufacturerControlClass, self).__init__ ()
-      self.string_literal = string_literal
-
-   @property
-   def name (self): return self.string_literal.value

--- a/build-system/erbui/generators/front_pcb/DiyManual.erbui
+++ b/build-system/erbui/generators/front_pcb/DiyManual.erbui
@@ -31,43 +31,43 @@ manufacturer DiyManual {
    control AudioIn, AudioOut, CvIn, CvOut, GateIn, GateOut {
       style thonk.pj398sm.knurled, knurled
       parts thonk.pj398sm.manual, thonk.pj398sm.knurled
-      class "erb::ThonkPj398SmKnurled"
+      arg simulator_class "erb::ThonkPj398SmKnurled"
    }
 
    control AudioIn, CvIn, GateIn {
       style thonk.pj398sm.knurled, knurled, erb.normalling.nothing
       parts thonk.pj398sm.manual.npr, thonk.pj398sm.knurled
-      class "erb::ThonkPj398SmKnurled"
+      arg simulator_class "erb::ThonkPj398SmKnurled"
    }
 
    control AudioIn, AudioOut, CvIn, CvOut, GateIn, GateOut {
       style thonk.pj398sm.hex, hex
       parts thonk.pj398sm.manual, thonk.pj398sm.hex
-      class "erb::ThonkPj398SmHex"
+      arg simulator_class "erb::ThonkPj398SmHex"
    }
 
    control AudioIn, CvIn, GateIn {
       style thonk.pj398sm.hex, hex, erb.normalling.nothing
       parts thonk.pj398sm.manual.npr, thonk.pj398sm.hex
-      class "erb::ThonkPj398SmHex"
+      arg simulator_class "erb::ThonkPj398SmHex"
    }
 
    control Button {
       style tl1105, small, black
       parts tl1105.manual, 1rblk
-      class "erb::Tl1105"
+      arg simulator_class "erb::Tl1105"
    }
 
    control Button {
       style ck.d6r.black, ck, d6r, black
       parts ck.d6r.black.manual
-      class "erb::Ckd6r"
+      arg simulator_class "erb::Ckd6r"
    }
 
    control Display {
       style eastrising, 128x64
       parts er.display.spi.128x64.manual
-      class "erb::OledModule <erb::Panel_ER_OLEDM015_2>"
+      arg simulator_class "erb::OledModule <erb::Panel_ER_OLEDM015_2>"
       arg display_width "128"
       arg display_height "64"
    }
@@ -75,164 +75,164 @@ manufacturer DiyManual {
    control Encoder {
       style rogan.1s, rogan, 1s, small, skirt, d_shaft
       parts bourns.pec11rn.manual, rogan.1s
-      class "erb::BournsPec11R <erb::Rogan1S, false>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan1S, false>"
    }
 
    control Encoder {
       style rogan.1s.black, rogan, 1s, black, small, skirt, d_shaft
       parts bourns.pec11rn.manual, rogan.1s.black
-      class "erb::BournsPec11R <erb::Rogan1SBlack, false>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan1SBlack, false>"
    }
 
    control Encoder {
       style rogan.2s.black, rogan, 2s, black, medium, skirt, d_shaft
       parts bourns.pec11rn.manual, rogan.2s.black
-      class "erb::BournsPec11R <erb::Rogan2SBlack, false>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan2SBlack, false>"
    }
 
    control Encoder {
       style rogan.3s, rogan, 3s, large, skirt, d_shaft
       parts bourns.pec11rn.manual, rogan.3s
-      class "erb::BournsPec11R <erb::Rogan3S, false>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan3S, false>"
    }
 
    control EncoderButton {
       style rogan.1s, rogan, 1s, small, skirt, d_shaft
       parts bourns.pec11rs.manual, rogan.1s
-      class "erb::BournsPec11R <erb::Rogan1S, true>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan1S, true>"
    }
 
    control EncoderButton {
       style rogan.1s.black, rogan, 1s, black, small, skirt, d_shaft
       parts bourns.pec11rs.manual, rogan.1s.black
-      class "erb::BournsPec11R <erb::Rogan1SBlack, true>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan1SBlack, true>"
    }
 
    control EncoderButton {
       style rogan.2s.black, rogan, 2s, black, medium, skirt, d_shaft
       parts bourns.pec11rs.manual, rogan.2s.black
-      class "erb::BournsPec11R <erb::Rogan2SBlack, true>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan2SBlack, true>"
    }
 
    control EncoderButton {
       style rogan.3s, rogan, 3s, large, skirt, d_shaft
       parts bourns.pec11rs.manual, rogan.3s
-      class "erb::BournsPec11R <erb::Rogan3S, true>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan3S, true>"
    }
 
    control Led {
       style led.3mm.red, 3mm, red
       parts led.3mm.red.manual
-      class "erb::Led3mm <RedLight>"
+      arg simulator_class "erb::Led3mm <RedLight>"
    }
 
    control Led {
       style led.3mm.green, 3mm, green
       parts led.3mm.green.manual
-      class "erb::Led3mm <GreenLight>"
+      arg simulator_class "erb::Led3mm <GreenLight>"
    }
 
    control Led {
       style led.3mm.yellow, 3mm, yellow
       parts led.3mm.yellow.manual
-      class "erb::Led3mm <YellowLight>"
+      arg simulator_class "erb::Led3mm <YellowLight>"
    }
 
    control Led {
       style led.3mm.orange, 3mm, orange
       parts led.3mm.orange.manual
-      class "erb::Led3mm <YellowLight>" // Orange missing
+      arg simulator_class "erb::Led3mm <YellowLight>" // Orange missing
    }
 
    control LedBi {
       style led.3mm.green_red, 3mm, green_red
       parts led.3mm.bi.green_red.manual
-      class "erb::Led3mm <GreenRedLight>"
+      arg simulator_class "erb::Led3mm <GreenRedLight>"
    }
 
    control LedRgb {
       style led.3mm.rgb, 3mm, rgb
       parts led.3mm.rgb.manual
-      class "erb::Led3mm <RedGreenBlueLight>"
+      arg simulator_class "erb::Led3mm <RedGreenBlueLight>"
    }
 
    control Led {
       style led.smt.red, red, behind
       parts led.smt.red.manual
-      class "erb::LedBehindPanel <RedLight>"
+      arg simulator_class "erb::LedBehindPanel <RedLight>"
    }
 
    control Pot {
       style rogan.2ps, rogan, 2ps, medium, skirt, d_shaft
       parts alpha.9mm.manual, rogan.2ps
-      class "erb::AlphaPot <erb::Rogan2Ps>"
+      arg simulator_class "erb::AlphaPot <erb::Rogan2Ps>"
    }
 
    control Pot {
       style rogan.3ps, rogan, 3ps, large, skirt, d_shaft
       parts alpha.9mm.manual, rogan.3ps
-      class "erb::AlphaPot <erb::Rogan3Ps>"
+      arg simulator_class "erb::AlphaPot <erb::Rogan3Ps>"
    }
 
    control Pot {
       style rogan.1ps, rogan, 1ps, small, skirt, d_shaft
       parts alpha.9mm.manual, rogan.1ps
-      class "erb::AlphaPot <erb::Rogan1Ps>"
+      arg simulator_class "erb::AlphaPot <erb::Rogan1Ps>"
    }
 
    control Pot {
       style rogan.1p, rogan, 1p, small, no_skirt, d_shaft
       parts alpha.9mm.manual, rogan.1p
-      class "erb::AlphaPot <erb::Rogan1P>"
+      arg simulator_class "erb::AlphaPot <erb::Rogan1P>"
    }
 
    control Pot {
       style rogan.6ps, rogan, 6ps, xlarge, skirt, d_shaft
       parts alpha.9mm.manual, rogan.6ps
-      class "erb::AlphaPot <erb::Rogan6Ps>"
+      arg simulator_class "erb::AlphaPot <erb::Rogan6Ps>"
    }
 
    control Pot {
       style rogan.5ps, rogan, 5ps, larger, skirt, d_shaft
       parts alpha.9mm.manual, rogan.5ps
-      class "erb::AlphaPot <erb::Rogan5Ps>"
+      arg simulator_class "erb::AlphaPot <erb::Rogan5Ps>"
    }
 
    control Pot {
       style sifam.drn111.white, sifam, selco, small, skirt, d_shaft, white
       parts alpha.9mm.manual, sifam.drn111.white
-      class "erb::AlphaPot <erb::SifamDrn111>"
+      arg simulator_class "erb::AlphaPot <erb::SifamDrn111>"
    }
 
    control Pot {
       style sifam.dbn151.white, sifam, selco, large, skirt, d_shaft, white
       parts alpha.9mm.manual, sifam.dbn151.white
-      class "erb::AlphaPot <erb::SifamDbn151>"
+      arg simulator_class "erb::AlphaPot <erb::SifamDbn151>"
    }
 
    control Pot {
       style davies, 1900h, d_shaft, black
       parts alpha.9mm.manual, davies.1900h.black
-      class "erb::Davies1900hBlack"
+      arg simulator_class "erb::Davies1900hBlack"
    }
 
    control Switch {
       style dailywell.2ms1, on_on
       parts dailywell.2ms1.manual
-      class "erb::Dailywell2Ms1"
+      arg simulator_class "erb::Dailywell2Ms1"
       arg nbr_positions "2"
    }
 
    control Switch {
       style dailywell.2ms3, on_off_on
       parts dailywell.2ms3.manual
-      class "erb::Dailywell2Ms3"
+      arg simulator_class "erb::Dailywell2Ms3"
       arg nbr_positions "3"
    }
 
    control Trim {
       style songhuei.9mm, tall
       parts songhuei.9mm.manual
-      class "erb::SongHuei9"
+      arg simulator_class "erb::SongHuei9"
    }
 }

--- a/build-system/erbui/generators/front_pcb/DiyWire.erbui
+++ b/build-system/erbui/generators/front_pcb/DiyWire.erbui
@@ -31,194 +31,194 @@ manufacturer DiyWire {
    control AudioIn, AudioOut, CvIn, CvOut, GateIn, GateOut {
       style thonk.pj398sm.knurled, knurled
       parts thonk.pj398sm.wire, thonk.pj398sm.knurled
-      class "erb::ThonkPj398SmKnurled"
+      arg simulator_class "erb::ThonkPj398SmKnurled"
    }
 
    control AudioIn, CvIn, GateIn {
       style thonk.pj398sm.knurled, knurled, erb.normalling.nothing
       parts thonk.pj398sm.wire.npr, thonk.pj398sm.knurled
-      class "erb::ThonkPj398SmKnurled"
+      arg simulator_class "erb::ThonkPj398SmKnurled"
    }
 
    control AudioIn, AudioOut, CvIn, CvOut, GateIn, GateOut {
       style thonk.pj398sm.hex, hex
       parts thonk.pj398sm.wire, thonk.pj398sm.hex
-      class "erb::ThonkPj398SmHex"
+      arg simulator_class "erb::ThonkPj398SmHex"
    }
 
    control AudioIn, CvIn, GateIn {
       style thonk.pj398sm.hex, hex, erb.normalling.nothing
       parts thonk.pj398sm.wire.npr, thonk.pj398sm.hex
-      class "erb::ThonkPj398SmHex"
+      arg simulator_class "erb::ThonkPj398SmHex"
    }
 
    control Button {
       style tl1105, small, black
       parts tl1105.wire, 1rblk
-      class "erb::Tl1105"
+      arg simulator_class "erb::Tl1105"
    }
 
    control Button {
       style ck.d6r.black, ck, d6r, black
       parts ck.d6r.black.wire
-      class "erb::Ckd6r"
+      arg simulator_class "erb::Ckd6r"
    }
 
    control Encoder {
       style rogan.1s, rogan, 1s, small, skirt, d_shaft
       parts bourns.pec11rn.wire, rogan.1s
-      class "erb::BournsPec11R <erb::Rogan1S, false>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan1S, false>"
    }
 
    control Encoder {
       style rogan.1s.black, rogan, 1s, black, small, skirt, d_shaft
       parts bourns.pec11rn.wire, rogan.1s.black
-      class "erb::BournsPec11R <erb::Rogan1SBlack, false>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan1SBlack, false>"
    }
 
    control Encoder {
       style rogan.2s.black, rogan, 2s, black, medium, skirt, d_shaft
       parts bourns.pec11rn.wire, rogan.2s.black
-      class "erb::BournsPec11R <erb::Rogan2SBlack, false>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan2SBlack, false>"
    }
 
    control Encoder {
       style rogan.3s, rogan, 3s, large, skirt, d_shaft
       parts bourns.pec11rn.wire, rogan.3s
-      class "erb::BournsPec11R <erb::Rogan3S, false>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan3S, false>"
    }
 
    control EncoderButton {
       style rogan.1s, rogan, 1s, small, skirt, d_shaft
       parts bourns.pec11rs.wire, rogan.1s
-      class "erb::BournsPec11R <erb::Rogan1S, true>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan1S, true>"
    }
 
    control EncoderButton {
       style rogan.1s.black, rogan, 1s, black, small, skirt, d_shaft
       parts bourns.pec11rs.wire, rogan.1s.black
-      class "erb::BournsPec11R <erb::Rogan1SBlack, true>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan1SBlack, true>"
    }
 
    control EncoderButton {
       style rogan.2s.black, rogan, 2s, black, medium, skirt, d_shaft
       parts bourns.pec11rs.wire, rogan.2s.black
-      class "erb::BournsPec11R <erb::Rogan2SBlack, true>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan2SBlack, true>"
    }
 
    control EncoderButton {
       style rogan.3s, rogan, 3s, large, skirt, d_shaft
       parts bourns.pec11rs.wire, rogan.3s
-      class "erb::BournsPec11R <erb::Rogan3S, true>"
+      arg simulator_class "erb::BournsPec11R <erb::Rogan3S, true>"
    }
 
    control Led {
       style led.3mm.red, 3mm, red
       parts led.3mm.red.wire
-      class "erb::Led3mm <RedLight>"
+      arg simulator_class "erb::Led3mm <RedLight>"
    }
 
    control Led {
       style led.3mm.green, 3mm, green
       parts led.3mm.green.wire
-      class "erb::Led3mm <GreenLight>"
+      arg simulator_class "erb::Led3mm <GreenLight>"
    }
 
    control Led {
       style led.3mm.yellow, 3mm, yellow
       parts led.3mm.yellow.wire
-      class "erb::Led3mm <YellowLight>"
+      arg simulator_class "erb::Led3mm <YellowLight>"
    }
 
    control Led {
       style led.3mm.orange, 3mm, orange
       parts led.3mm.orange.wire
-      class "erb::Led3mm <YellowLight>" // Orange missing
+      arg simulator_class "erb::Led3mm <YellowLight>" // Orange missing
    }
 
    control LedBi {
       style led.3mm.green_red, 3mm, green_red
       parts led.3mm.bi.green_red.wire
-      class "erb::Led3mm <GreenRedLight>"
+      arg simulator_class "erb::Led3mm <GreenRedLight>"
    }
 
    control LedRgb {
       style led.3mm.rgb, 3mm, rgb
       parts led.3mm.rgb.wire
-      class "erb::Led3mm <RedGreenBlueLight>"
+      arg simulator_class "erb::Led3mm <RedGreenBlueLight>"
    }
 
    control Pot {
       style rogan.2ps, rogan, 2ps, medium, skirt, d_shaft
       parts alpha.9mm.wire, rogan.2ps
-      class "erb::AlphaPot <erb::Rogan2Ps>"
+      arg simulator_class "erb::AlphaPot <erb::Rogan2Ps>"
    }
 
    control Pot {
       style rogan.3ps, rogan, 3ps, large, skirt, d_shaft
       parts alpha.9mm.wire, rogan.3ps
-      class "erb::AlphaPot <erb::Rogan3Ps>"
+      arg simulator_class "erb::AlphaPot <erb::Rogan3Ps>"
    }
 
    control Pot {
       style rogan.1ps, rogan, 1ps, small, skirt, d_shaft
       parts alpha.9mm.wire, rogan.1ps
-      class "erb::AlphaPot <erb::Rogan1Ps>"
+      arg simulator_class "erb::AlphaPot <erb::Rogan1Ps>"
    }
 
    control Pot {
       style rogan.1p, rogan, 1p, small, no_skirt, d_shaft
       parts alpha.9mm.wire, rogan.1p
-      class "erb::AlphaPot <erb::Rogan1P>"
+      arg simulator_class "erb::AlphaPot <erb::Rogan1P>"
    }
 
    control Pot {
       style rogan.6ps, rogan, 6ps, xlarge, skirt, d_shaft
       parts alpha.9mm.wire, rogan.6ps
-      class "erb::AlphaPot <erb::Rogan6Ps>"
+      arg simulator_class "erb::AlphaPot <erb::Rogan6Ps>"
    }
 
    control Pot {
       style rogan.5ps, rogan, 5ps, larger, skirt, d_shaft
       parts alpha.9mm.wire, rogan.5ps
-      class "erb::AlphaPot <erb::Rogan5Ps>"
+      arg simulator_class "erb::AlphaPot <erb::Rogan5Ps>"
    }
 
    control Pot {
       style sifam.drn111.white, sifam, selco, small, skirt, d_shaft, white
       parts alpha.9mm.wire, sifam.drn111.white
-      class "erb::AlphaPot <erb::SifamDrn111>"
+      arg simulator_class "erb::AlphaPot <erb::SifamDrn111>"
    }
 
    control Pot {
       style sifam.dbn151.white, sifam, selco, large, skirt, d_shaft, white
       parts alpha.9mm.wire, sifam.dbn151.white
-      class "erb::AlphaPot <erb::SifamDbn151>"
+      arg simulator_class "erb::AlphaPot <erb::SifamDbn151>"
    }
 
    control Pot {
       style davies, 1900h, d_shaft, black
       parts alpha.9mm.wire, davies.1900h.black
-      class "erb::Davies1900hBlack"
+      arg simulator_class "erb::Davies1900hBlack"
    }
 
    control Switch {
       style dailywell.2ms1, on_on
       parts dailywell.2ms1.wire
-      class "erb::Dailywell2Ms1"
+      arg simulator_class "erb::Dailywell2Ms1"
       arg nbr_positions "2"
    }
 
    control Switch {
       style dailywell.2ms3, on_off_on
       parts dailywell.2ms3.wire
-      class "erb::Dailywell2Ms3"
+      arg simulator_class "erb::Dailywell2Ms3"
       arg nbr_positions "3"
    }
 
    control Trim {
       style songhuei.9mm, tall
       parts songhuei.9mm.wire
-      class "erb::SongHuei9"
+      arg simulator_class "erb::SongHuei9"
    }
 }

--- a/build-system/erbui/generators/vcvrack/code.py
+++ b/build-system/erbui/generators/vcvrack/code.py
@@ -194,7 +194,7 @@ class Code:
             if category in ['Param', 'Input', 'Output', 'Light']:
                lines += '   {\n'
                lines += '      auto control_ptr = create%sCentered <%s> (mm2px (Vec (%ff, %ff)), module_, %d);\n' % (
-                  category, control.simulator_class, control.position.x.mm + offset_x, control.position.y.mm + offset_y, index
+                  category, control.args ['simulator_class'], control.position.x.mm + offset_x, control.position.y.mm + offset_y, index
                )
                lines += '      control_ptr->rotate (float (%f));\n' % rotation_rad
                lines += '      add%s (control_ptr);\n' % func_category
@@ -204,7 +204,7 @@ class Code:
                lines += '   if (module_ptr != nullptr)\n'
                lines += '   {\n'
                lines += '      auto control_ptr = erb::createWidgetCentered <%s> (mm2px (Vec (%ff, %ff)), module_ptr->module_uptr->ui.%s);\n' % (
-                  control.simulator_class, control.position.x.mm + offset_x, control.position.y.mm + offset_y, control.name
+                  control.args ['simulator_class'], control.position.x.mm + offset_x, control.position.y.mm + offset_y, control.name
                )
                lines += '      control_ptr->rotate (float (%f));\n' % rotation_rad
                lines += '      addChild (control_ptr);\n'

--- a/build-system/erbui/grammar.py
+++ b/build-system/erbui/grammar.py
@@ -246,10 +246,9 @@ def generator_name ():                 return string_literal
 def generator_declaration ():          return 'generator', generator_name, Optional (generator_body)
 
 # Manufacturer Control
-def manufacturer_control_class ():        return 'class', string_literal
 def manufacturer_control_part_name ():    return _(r'(?!\b({})\b)((\w|\.)*)')
 def manufacturer_control_parts ():        return 'parts', manufacturer_control_part_name, ZeroOrMore (',', manufacturer_control_part_name)
-def manufacturer_control_entities ():     return style_declaration, manufacturer_control_parts, manufacturer_control_class, ZeroOrMore ([arg_declaration])
+def manufacturer_control_entities ():     return style_declaration, manufacturer_control_parts, ZeroOrMore ([arg_declaration])
 def manufacturer_control_body ():         return '{', manufacturer_control_entities, '}'
 def manufacturer_control_kind ():         return list (CONTROL_KINDS)
 def manufacturer_control_kinds ():        return manufacturer_control_kind, ZeroOrMore (',', manufacturer_control_kind)

--- a/build-system/erbui/visitor.py
+++ b/build-system/erbui/visitor.py
@@ -877,7 +877,3 @@ class Visitor (PTNodeVisitor):
 
    def visit_manufacturer_control_part_name (self, node, children):
       return self.to_keyword (node)
-
-   def visit_manufacturer_control_class (self, node, children):
-      string_literal = children.string_literal [0]
-      return ast.ManufacturerControlClass (string_literal)

--- a/samples/custom/manufacturer/ElectroDemo.erbui
+++ b/samples/custom/manufacturer/ElectroDemo.erbui
@@ -62,18 +62,18 @@ manufacturer ElectroDemo {
    control AudioIn, AudioOut, CvIn, CvOut, GateIn, GateOut {
       style jack
       parts ed.jack, ed.nut
-      class "erb::ThonkPj398SmKnurled"
+      arg simulator_class "erb::ThonkPj398SmKnurled"
    }
 
    control Pot {
       style rogan, 6ps, xlarge, skirt
       parts ed.pot, rogan.6ps
-      class "erb::AlphaPot <erb::Rogan6Ps>"
+      arg simulator_class "erb::AlphaPot <erb::Rogan6Ps>"
    }
 
    control Led {
       style red, behind
       parts led.red
-      class "erb::LedBehindPanel <RedLight>"
+      arg simulator_class "erb::LedBehindPanel <RedLight>"
    }
 }


### PR DESCRIPTION
This PR moves the definition of the simulator class from the `class` keyword to `arg simulator_class`. This makes it more explicit and less weird.

⚠️ This is a breaking change. One will need to change their custom manufacturer defintion from `class "Foo"` to `arg simulator_class "Foo"`
