### PR TITLE
Add leading type option to encoder

### DIFF
--- a/build-system/erbui/generators/front_pcb/DiyManual.erbui
+++ b/build-system/erbui/generators/front_pcb/DiyManual.erbui
@@ -76,48 +76,56 @@ manufacturer DiyManual {
       style rogan.1s, rogan, 1s, small, skirt, d_shaft
       parts bourns.pec11rn.manual, rogan.1s
       arg simulator_class "erb::BournsPec11R <erb::Rogan1S, false>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control Encoder {
       style rogan.1s.black, rogan, 1s, black, small, skirt, d_shaft
       parts bourns.pec11rn.manual, rogan.1s.black
       arg simulator_class "erb::BournsPec11R <erb::Rogan1SBlack, false>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control Encoder {
       style rogan.2s.black, rogan, 2s, black, medium, skirt, d_shaft
       parts bourns.pec11rn.manual, rogan.2s.black
       arg simulator_class "erb::BournsPec11R <erb::Rogan2SBlack, false>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control Encoder {
       style rogan.3s, rogan, 3s, large, skirt, d_shaft
       parts bourns.pec11rn.manual, rogan.3s
       arg simulator_class "erb::BournsPec11R <erb::Rogan3S, false>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control EncoderButton {
       style rogan.1s, rogan, 1s, small, skirt, d_shaft
       parts bourns.pec11rs.manual, rogan.1s
       arg simulator_class "erb::BournsPec11R <erb::Rogan1S, true>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control EncoderButton {
       style rogan.1s.black, rogan, 1s, black, small, skirt, d_shaft
       parts bourns.pec11rs.manual, rogan.1s.black
       arg simulator_class "erb::BournsPec11R <erb::Rogan1SBlack, true>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control EncoderButton {
       style rogan.2s.black, rogan, 2s, black, medium, skirt, d_shaft
       parts bourns.pec11rs.manual, rogan.2s.black
       arg simulator_class "erb::BournsPec11R <erb::Rogan2SBlack, true>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control EncoderButton {
       style rogan.3s, rogan, 3s, large, skirt, d_shaft
       parts bourns.pec11rs.manual, rogan.3s
       arg simulator_class "erb::BournsPec11R <erb::Rogan3S, true>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control Led {

--- a/build-system/erbui/generators/front_pcb/DiyWire.erbui
+++ b/build-system/erbui/generators/front_pcb/DiyWire.erbui
@@ -68,48 +68,56 @@ manufacturer DiyWire {
       style rogan.1s, rogan, 1s, small, skirt, d_shaft
       parts bourns.pec11rn.wire, rogan.1s
       arg simulator_class "erb::BournsPec11R <erb::Rogan1S, false>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control Encoder {
       style rogan.1s.black, rogan, 1s, black, small, skirt, d_shaft
       parts bourns.pec11rn.wire, rogan.1s.black
       arg simulator_class "erb::BournsPec11R <erb::Rogan1SBlack, false>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control Encoder {
       style rogan.2s.black, rogan, 2s, black, medium, skirt, d_shaft
       parts bourns.pec11rn.wire, rogan.2s.black
       arg simulator_class "erb::BournsPec11R <erb::Rogan2SBlack, false>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control Encoder {
       style rogan.3s, rogan, 3s, large, skirt, d_shaft
       parts bourns.pec11rn.wire, rogan.3s
       arg simulator_class "erb::BournsPec11R <erb::Rogan3S, false>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control EncoderButton {
       style rogan.1s, rogan, 1s, small, skirt, d_shaft
       parts bourns.pec11rs.wire, rogan.1s
       arg simulator_class "erb::BournsPec11R <erb::Rogan1S, true>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control EncoderButton {
       style rogan.1s.black, rogan, 1s, black, small, skirt, d_shaft
       parts bourns.pec11rs.wire, rogan.1s.black
       arg simulator_class "erb::BournsPec11R <erb::Rogan1SBlack, true>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control EncoderButton {
       style rogan.2s.black, rogan, 2s, black, medium, skirt, d_shaft
       parts bourns.pec11rs.wire, rogan.2s.black
       arg simulator_class "erb::BournsPec11R <erb::Rogan2SBlack, true>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control EncoderButton {
       style rogan.3s, rogan, 3s, large, skirt, d_shaft
       parts bourns.pec11rs.wire, rogan.3s
       arg simulator_class "erb::BournsPec11R <erb::Rogan3S, true>"
+      arg leading_type "erb::EncoderLeadingType::A"
    }
 
    control Led {

--- a/build-system/erbui/generators/ui/code.py
+++ b/build-system/erbui/generators/ui/code.py
@@ -97,6 +97,10 @@ class Code:
 
          control_type = '%s <%s>' % (base_control, range)
 
+      elif control.kind in ['Encoder', 'EncoderButton']:
+         leading_type = control.args ['leading_type']
+         control_type = '%s <%s>' % (control.kind, leading_type)
+
       elif control.kind in ['GateIn', 'AudioIn']:
          if control.normalling_from is not None and control.normalling_from.is_nothing:
             control_type = '%sJackDetection' % control.kind

--- a/include/erb/Encoder.h
+++ b/include/erb/Encoder.h
@@ -22,6 +22,13 @@ namespace erb
 
 
 
+enum class EncoderLeadingType
+{
+   A, B
+};
+
+
+template <EncoderLeadingType LeadingType>
 class Encoder
 {
 
@@ -82,6 +89,10 @@ private:
 
 
 }  // namespace erb
+
+
+
+#include "erb/Encoder.hpp"
 
 
 

--- a/include/erb/Encoder.hpp
+++ b/include/erb/Encoder.hpp
@@ -1,15 +1,17 @@
 /*****************************************************************************
 
-      Encoder.cpp
+      Encoder.hpp
       Copyright (c) 2020 Raphael DINGE
 
 *Tab=3***********************************************************************/
 
 
 
-/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+#pragma once
 
-#include "erb/Encoder.h"
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 
 
@@ -26,7 +28,8 @@ Name : ctor
 ==============================================================================
 */
 
-Encoder::Encoder (const uint8_t & data_a, const uint8_t & data_b)
+template <EncoderLeadingType LeadingType>
+Encoder <LeadingType>::Encoder (const uint8_t & data_a, const uint8_t & data_b)
 :  impl_data_a (data_a)
 ,  impl_data_b (data_b)
 {
@@ -40,7 +43,8 @@ Name : operator int
 ==============================================================================
 */
 
-Encoder::operator int () const
+template <EncoderLeadingType LeadingType>
+Encoder <LeadingType>::operator int () const
 {
    return _val;
 }
@@ -55,18 +59,33 @@ Name : impl_preprocess
 ==============================================================================
 */
 
-void  Encoder::impl_preprocess ()
+template <EncoderLeadingType LeadingType>
+void  Encoder <LeadingType>::impl_preprocess ()
 {
    _state_a = uint8_t (_state_a << 1) | (impl_data_a != 0);
    _state_b = uint8_t (_state_b << 1) | (impl_data_b != 0);
 
    if ((_state_a & 0x03) == 0x02 && (_state_b & 0x03) == 0x00)
    {
-      _val = -1;
+      if constexpr (LeadingType == EncoderLeadingType::A)
+      {
+         _val = -1;
+      }
+      else
+      {
+         _val = 1;
+      }
    }
    else if ((_state_b & 0x03) == 0x02 && (_state_a & 0x03) == 0x00)
    {
-      _val = 1;
+      if constexpr (LeadingType == EncoderLeadingType::A)
+      {
+         _val = 1;
+      }
+      else
+      {
+         _val = -1;
+      }
    }
    else
    {

--- a/include/erb/EncoderButton.h
+++ b/include/erb/EncoderButton.h
@@ -25,6 +25,7 @@ namespace erb
 
 
 
+template <EncoderLeadingType LeadingType>
 class EncoderButton
 {
 
@@ -37,7 +38,8 @@ public:
                   EncoderButton (const uint8_t & data_a, const uint8_t & data_b, const uint8_t & data_sw);
    virtual        ~EncoderButton () = default;
 
-   Encoder        encoder;
+   Encoder <LeadingType>
+                  encoder;
    Button         button;
 
 
@@ -66,8 +68,8 @@ private:
 private:
                   EncoderButton (const EncoderButton & rhs) = delete;
                   EncoderButton (EncoderButton && rhs) = delete;
-   EncoderButton &      operator = (const EncoderButton & rhs) = delete;
-   EncoderButton &      operator = (EncoderButton && rhs) = delete;
+   EncoderButton &operator = (const EncoderButton & rhs) = delete;
+   EncoderButton &operator = (EncoderButton && rhs) = delete;
    bool           operator == (const EncoderButton & rhs) const = delete;
    bool           operator != (const EncoderButton & rhs) const = delete;
 
@@ -78,6 +80,10 @@ private:
 
 
 }  // namespace erb
+
+
+
+#include "erb/EncoderButton.hpp"
 
 
 

--- a/include/erb/EncoderButton.hpp
+++ b/include/erb/EncoderButton.hpp
@@ -1,15 +1,17 @@
 /*****************************************************************************
 
-      EncoderButton.cpp
+      EncoderButton.hpp
       Copyright (c) 2020 Raphael DINGE
 
 *Tab=3***********************************************************************/
 
 
 
-/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+#pragma once
 
-#include "erb/EncoderButton.h"
+
+
+/*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 
 
@@ -26,7 +28,8 @@ Name : ctor
 ==============================================================================
 */
 
-EncoderButton::EncoderButton (const uint8_t & data_a, const uint8_t & data_b, const uint8_t & data_sw)
+template <EncoderLeadingType LeadingType>
+EncoderButton <LeadingType>::EncoderButton (const uint8_t & data_a, const uint8_t & data_b, const uint8_t & data_sw)
 :  encoder (data_a, data_b)
 ,  button (data_sw)
 {
@@ -42,7 +45,8 @@ Name : impl_preprocess
 ==============================================================================
 */
 
-void  EncoderButton::impl_preprocess ()
+template <EncoderLeadingType LeadingType>
+void  EncoderButton <LeadingType>::impl_preprocess ()
 {
    encoder.impl_preprocess ();
    button.impl_preprocess ();
@@ -56,7 +60,8 @@ Name : impl_postprocess
 ==============================================================================
 */
 
-void  EncoderButton::impl_postprocess ()
+template <EncoderLeadingType LeadingType>
+void  EncoderButton <LeadingType>::impl_postprocess ()
 {
    encoder.impl_postprocess ();
    button.impl_postprocess ();

--- a/include/erb/erb-src.gypi
+++ b/include/erb/erb-src.gypi
@@ -40,7 +40,9 @@
       'Display.h',
       'Display.hpp',
       'Encoder.h',
+      'Encoder.hpp',
       'EncoderButton.h',
+      'EncoderButton.hpp',
       'FloatRange.h',
       'GateIn.h',
       'GateIn.hpp',
@@ -88,8 +90,6 @@
       'detail/fnc.hpp',
 
       '../../src/Button.cpp',
-      '../../src/Encoder.cpp',
-      '../../src/EncoderButton.cpp',
       '../../src/GateOut.cpp',
 
       '../../src/detail/Animation.cpp',

--- a/include/erb/vcvrack/BoardGeneric.h
+++ b/include/erb/vcvrack/BoardGeneric.h
@@ -165,7 +165,7 @@ private:
       bool        bipolar;
    };
 
-   struct BindingEncoder
+   struct BindingEncoderLeadingA
    {
       void        process ();
       uint8_t *   data_a_ptr;
@@ -174,7 +174,28 @@ private:
                   param_ptr;
    };
 
-   struct BindingEncoderButton
+   struct BindingEncoderLeadingB
+   {
+      void        process ();
+      uint8_t *   data_a_ptr;
+      uint8_t *   data_b_ptr;
+      rack::engine::Param *
+                  param_ptr;
+   };
+
+   struct BindingEncoderButtonLeadingA
+   {
+      void        process ();
+      uint8_t *   data_a_ptr;
+      uint8_t *   data_b_ptr;
+      uint8_t *   data_sw_ptr;
+      rack::engine::Param *
+                  param_ab_ptr;
+      rack::engine::Param *
+                  param_sw_ptr;
+   };
+
+   struct BindingEncoderButtonLeadingB
    {
       void        process ();
       uint8_t *   data_a_ptr;
@@ -317,8 +338,10 @@ private:
       BindingButton,
       BindingCvIn,
       BindingCvInJackDetection,
-      BindingEncoder,
-      BindingEncoderButton,
+      BindingEncoderLeadingA,
+      BindingEncoderLeadingB,
+      BindingEncoderButtonLeadingA,
+      BindingEncoderButtonLeadingB,
       BindingGateIn,
       BindingGateInJackDetection,
       BindingPot,

--- a/include/erb/vcvrack/BoardGeneric.hpp
+++ b/include/erb/vcvrack/BoardGeneric.hpp
@@ -254,9 +254,9 @@ Name : impl_bind
 */
 
 template <>
-inline void  BoardGeneric::impl_bind (Encoder & control, rack::engine::Param & model)
+inline void  BoardGeneric::impl_bind (Encoder <erb::EncoderLeadingType::A> & control, rack::engine::Param & model)
 {
-   _binding_inputs.push_back (BindingEncoder {
+   _binding_inputs.push_back (BindingEncoderLeadingA {
       .data_a_ptr = const_cast <uint8_t *> (&control.impl_data_a),
       .data_b_ptr = const_cast <uint8_t *> (&control.impl_data_b),
       .param_ptr = &model
@@ -272,11 +272,51 @@ Name : impl_bind
 */
 
 template <>
-inline void  BoardGeneric::impl_bind (EncoderButton & control, rack::engine::Param & model)
+inline void  BoardGeneric::impl_bind (Encoder <erb::EncoderLeadingType::B> & control, rack::engine::Param & model)
+{
+   _binding_inputs.push_back (BindingEncoderLeadingB {
+      .data_a_ptr = const_cast <uint8_t *> (&control.impl_data_a),
+      .data_b_ptr = const_cast <uint8_t *> (&control.impl_data_b),
+      .param_ptr = &model
+   });
+}
+
+
+
+/*
+==============================================================================
+Name : impl_bind
+==============================================================================
+*/
+
+template <>
+inline void  BoardGeneric::impl_bind (EncoderButton <erb::EncoderLeadingType::A> & control, rack::engine::Param & model)
 {
    auto * model_ptr = &model;
 
-   _binding_inputs.push_back (BindingEncoderButton {
+   _binding_inputs.push_back (BindingEncoderButtonLeadingA {
+      .data_a_ptr = const_cast <uint8_t *> (&control.encoder.impl_data_a),
+      .data_b_ptr = const_cast <uint8_t *> (&control.encoder.impl_data_b),
+      .data_sw_ptr = const_cast <uint8_t *> (&control.button.impl_data),
+      .param_ab_ptr = &model_ptr [0],
+      .param_sw_ptr = &model_ptr [1]
+   });
+}
+
+
+
+/*
+==============================================================================
+Name : impl_bind
+==============================================================================
+*/
+
+template <>
+inline void  BoardGeneric::impl_bind (EncoderButton <erb::EncoderLeadingType::B> & control, rack::engine::Param & model)
+{
+   auto * model_ptr = &model;
+
+   _binding_inputs.push_back (BindingEncoderButtonLeadingB {
       .data_a_ptr = const_cast <uint8_t *> (&control.encoder.impl_data_a),
       .data_b_ptr = const_cast <uint8_t *> (&control.encoder.impl_data_b),
       .data_sw_ptr = const_cast <uint8_t *> (&control.button.impl_data),

--- a/src/vcvrack/BoardGeneric.cpp
+++ b/src/vcvrack/BoardGeneric.cpp
@@ -287,11 +287,11 @@ void  BoardGeneric::BindingCvOut::process ()
 
 /*
 ==============================================================================
-Name : BindingEncoder::process
+Name : BindingEncoderLeadingA::process
 ==============================================================================
 */
 
-void  BoardGeneric::BindingEncoder::process ()
+void  BoardGeneric::BindingEncoderLeadingA::process ()
 {
    // Assume 24 notches per rotation
    int phase = int (std::floor (param_ptr->getValue () * 24.f * 4.f)) % 4;
@@ -304,17 +304,53 @@ void  BoardGeneric::BindingEncoder::process ()
 
 /*
 ==============================================================================
-Name : BindingEncoderButton::process
+Name : BindingEncoderLeadingB::process
 ==============================================================================
 */
 
-void  BoardGeneric::BindingEncoderButton::process ()
+void  BoardGeneric::BindingEncoderLeadingB::process ()
+{
+   // Assume 24 notches per rotation
+   int phase = int (std::floor (param_ptr->getValue () * 24.f * 4.f)) % 4;
+
+   *data_a_ptr = (phase == 1) || (phase == 2);
+   *data_b_ptr = (phase == 0) || (phase == 1);
+}
+
+
+
+/*
+==============================================================================
+Name : BindingEncoderButtonLeadingA::process
+==============================================================================
+*/
+
+void  BoardGeneric::BindingEncoderButtonLeadingA::process ()
 {
    // Assume 24 notches per rotation
    int phase = int (std::floor (param_ab_ptr->getValue () * 24.f * 4.f)) % 4;
 
    *data_a_ptr = (phase == 0) || (phase == 1);
    *data_b_ptr = (phase == 1) || (phase == 2);
+
+   *data_sw_ptr = param_sw_ptr->getValue () != 0.f;
+}
+
+
+
+/*
+==============================================================================
+Name : BindingEncoderButtonLeadingB::process
+==============================================================================
+*/
+
+void  BoardGeneric::BindingEncoderButtonLeadingB::process ()
+{
+   // Assume 24 notches per rotation
+   int phase = int (std::floor (param_ab_ptr->getValue () * 24.f * 4.f)) % 4;
+
+   *data_a_ptr = (phase == 1) || (phase == 2);
+   *data_b_ptr = (phase == 0) || (phase == 1);
 
    *data_sw_ptr = param_sw_ptr->getValue () != 0.f;
 }


### PR DESCRIPTION
This PR allows the manufacturer control definition to specify the quadrature encoder type of an `Encoder` or `EncoderButton` control, wether they are "leading A", that is, in clock wise rotation, the A edge is visible before the B edge, or "leading B" otherwise.
