### PR TITLE
Handle persistent no rate limit case

### DIFF
--- a/include/erb/Persistent.hpp
+++ b/include/erb/Persistent.hpp
@@ -66,7 +66,7 @@ void  Persistent <Type, Page, Magic, RateLimitMs>::save (Board & board, Type val
       _earliest_commit_tp = Clock::now () + std::chrono::milliseconds {RateLimitMs};
    }
 
-   if (_need_commit_flag && Clock::now () > _earliest_commit_tp)
+   if (_need_commit_flag && (Clock::now () > _earliest_commit_tp || RateLimitMs == 0))
    {
       uint64_t magic = Magic;
       std::array <uint8_t, sizeof (Magic) + sizeof (Type)> data;


### PR DESCRIPTION
This PR handles the case where we don't want persistent rate limitation, for example during a production line calibration phase.
