### PR TITLE
Fix quantity for a reference counting by using number of references

### DIFF
--- a/build-system/erbui/generators/front_pcb/bom.py
+++ b/build-system/erbui/generators/front_pcb/bom.py
@@ -69,13 +69,6 @@ class Bom:
 
    def make_parts (self, symbols, field_names, include_non_empty, projection, excluded_references):
 
-      key_quantity_map = {}
-      def inc_key (key):
-         if key in key_quantity_map:
-            key_quantity_map [key] += 1
-         else:
-            key_quantity_map [key] = 1
-
       key_references_map = {}
       def inc_reference (key, reference):
          if key in key_references_map:
@@ -91,17 +84,15 @@ class Bom:
             fields = {field_name: symbol.property (field_name) if symbol.property (field_name) is not None else '' for field_name in field_names}
             if include_non_empty.format (**fields):
                key = projection.format (**fields)
-               inc_key (key)
                inc_reference (key, reference)
                key_desc_map [key] = fields
 
       parts = []
 
-      for key, quantity in key_quantity_map.items ():
-         references = key_references_map [key]
+      for key, references in key_references_map.items ():
          part = {
             'references': ', '.join (sorted (references)),
-            'quantity': quantity,
+            'quantity': len (references),
          }
          part.update (key_desc_map [key])
          desc = key_desc_map [key]


### PR DESCRIPTION
This PR fixes a bug where the quantity field in a BOM was not matching the references field.

A same reference can be counted multiple time when split into different parts, eg. U1A, U1B, etc.
We use the reference field to deduce quantity, because it is the ground truth.