### PR TITLE
Use equality operator to play nicer with standard library

### DIFF
--- a/include/erb/Persistent.hpp
+++ b/include/erb/Persistent.hpp
@@ -61,7 +61,7 @@ template <typename Type, size_t Page, uint64_t Magic, size_t RateLimitMs>
 template <typename Board>
 void  Persistent <Type, Page, Magic, RateLimitMs>::save (Board & board, Type value)
 {
-   if (value != _value)
+   if (!(value == _value))
    {
       _value = value;
       _need_commit_flag = true;


### PR DESCRIPTION
This PR changes the `Persistent` state comparaison by using the equality operator rather than the non-equality one.
This allows to play nicer with the standard library, and use a defaulted equality operator when possible.