### PR TITLE
Fix module dragging in vcv when using invisible widgets

### DIFF
--- a/include/erb/vcvrack/VcvWidgets.h
+++ b/include/erb/vcvrack/VcvWidgets.h
@@ -737,7 +737,9 @@ private:
 
 struct Invisible : rack::ParamWidget
 {
-   Invisible () = default;
+   Invisible () {
+      box.size = {0, 0};
+   }
    void  rotate (float) {}
 };
 


### PR DESCRIPTION
This PR fixes module dragging in vcv when using invisible widgets, by giving an empty bounding box to the widget.