### PR TITLE
Add invisible port simulator widget

### DIFF
--- a/include/erb/vcvrack/VcvWidgets.h
+++ b/include/erb/vcvrack/VcvWidgets.h
@@ -744,6 +744,15 @@ struct Invisible : rack::ParamWidget
 };
 
 
+struct InvisiblePort : rack::PortWidget
+{
+   InvisiblePort () {
+      box.size = {0, 0};
+   }
+   void  rotate (float) {}
+};
+
+
 template <typename Widget, typename T>
 Widget * createWidgetCentered (rack::math::Vec pos, T & control)
 {


### PR DESCRIPTION
This PR adds a widget to simulate a non-visible port.

Like the flash button, this is used to allow non-visible (ie on PCB only) controls of type `Audio*`, `Cv*`, `Gate*`, for example to control a relay by its `erbui` name for a guitar pedal.
