### PR TITLE
Fix rotation for bottom parts

### DIFF
--- a/build-system/erbui/generators/front_pcb/centroid.py
+++ b/build-system/erbui/generators/front_pcb/centroid.py
@@ -152,10 +152,13 @@ class Centroid:
       parts = {}
 
       for footprint in pcb.footprints:
+         rot_orientation = 1
          if footprint.layer == 'F.Cu':
             layer = layer_map ['top']
+            rot_orientation = 1
          elif footprint.layer == 'B.Cu':
             layer = layer_map ['bottom']
+            rot_orientation = -1
          else:
             assert False
 
@@ -169,7 +172,7 @@ class Centroid:
          y = (footprint.at.y - origin_y) * y_mul
          rotation = footprint.at.rotation if footprint.at.rotation else 0
          rotation -= reel_rotation * rot_mul_offset
-         rotation *= rot_mul
+         rotation *= rot_mul * rot_orientation
          if rotation < rotation_range_min:
             rotation += 360
          if rotation > rotation_range_max:


### PR DESCRIPTION
This PR fixes the rotation of bottom parts in the generated centroid.

> [!CAUTION]
> This is a breaking change. All PCBA made with ERB needs to fix their rotation when using bottom parts, for parts for which orientation is critical. This won't affect resistors or non-polarised capacitors.

In kicad, front part rotation is CCW but bottom part rotation is CW. Compensate for this when calculating rotation.