### PR TITLE
Fix rotation for bottom parts

### DIFF
--- a/build-system/erbui/generators/front_pcb/centroid.py
+++ b/build-system/erbui/generators/front_pcb/centroid.py
@@ -152,13 +152,14 @@ class Centroid:
       parts = {}
 
       for footprint in pcb.footprints:
-         rot_orientation = 1
          if footprint.layer == 'F.Cu':
             layer = layer_map ['top']
-            rot_orientation = 1
+            rot_mul_alt = 1
+            rot_offset = 0
          elif footprint.layer == 'B.Cu':
             layer = layer_map ['bottom']
-            rot_orientation = -1
+            rot_mul_alt = -1
+            rot_offset = 180
          else:
             assert False
 
@@ -171,8 +172,9 @@ class Centroid:
          x = footprint.at.x - origin_x
          y = (footprint.at.y - origin_y) * y_mul
          rotation = footprint.at.rotation if footprint.at.rotation else 0
-         rotation -= reel_rotation * rot_mul_offset
-         rotation *= rot_mul * rot_orientation
+         rotation += rot_offset
+         rotation -= rot_mul_alt * reel_rotation * rot_mul_offset
+         rotation *= rot_mul * rot_mul_alt
          if rotation < rotation_range_min:
             rotation += 360
          if rotation > rotation_range_max:


### PR DESCRIPTION
This PR fixes the rotation of bottom parts in the generated centroid.

> [!CAUTION]
> This is a breaking change. All PCBA made with ERB needs to fix their rotation when using bottom parts, for parts for which orientation is critical. This won't affect resistors or non-polarised capacitors.

- Centroid doesn't make a difference for rotation between top and bottom. In Kicad, the footprint is just flipped, so seen from one face, the footprint will align with the same rotation. This means that footprints must be rotated 180° when on the bottom face,
- Centroid doesn't make a difference for rotation between top and bottom. In Kicad, front part rotation is CCW but bottom part rotation is CW. This means we need to rotate the other way on the bottom,
- Reel rotation is irrelevant of top or bottom, so we need to compensate for all those applied rotation for it.

We tested this with 3 parts:
- A diode that is OK with 0 reel rotation
- A cap with 180 reel rotation
- A TL074 with 90 reel rotation

We did a test file with all 4 rotations on each side, then compared.

![image](https://github.com/ohmtech-rdi/eurorack-blocks/assets/11056842/e3c4fbdb-5304-4bdb-9166-91ab4934c56d)

![image](https://github.com/ohmtech-rdi/eurorack-blocks/assets/11056842/8e0f484b-35ae-41ea-8edb-dbfdec9a1c9b)

(the misaligned pads seem to be a weird bug in JLCPCB preview for some reason. The gerbers were fine, and we were only considering the centroid anyway)