### PR TITLE
Add precompiler flag to disable sdram usage

### DIFF
--- a/build-system/erbui/generators/daisy/code_template.cpp
+++ b/build-system/erbui/generators/daisy/code_template.cpp
@@ -14,6 +14,7 @@
 #include "erb/module_fnc.h"
 
 #include "erb/def.h"
+#include "erb/config.h"
 
 erb_DISABLE_WARNINGS_DAISY
 #include "daisy.h"
@@ -71,8 +72,8 @@ int main ()
 
    system.Init (config);
 
+#if (erb_SDRAM_USE_FLAG)
    // Init SDRAM
-
    // When using the bootloader priori to v6, SDRAM has been already configured
 
    if (
@@ -86,6 +87,7 @@ int main ()
       SdramHandle sdram;
       sdram.Init ();
    }
+#endif
 
    //-------------------------------------------------------------------------
 

--- a/include/erb/SdramPtr.h
+++ b/include/erb/SdramPtr.h
@@ -13,6 +13,10 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
+#include "erb/config.h"
+
+#if (erb_SDRAM_USE_FLAG)
+
 
 
 namespace erb
@@ -92,6 +96,10 @@ SdramPtr <T>   make_sdram (Args &&... args);
 
 
 #include "erb/SdramPtr.hpp"
+
+
+
+#endif // erb_SDRAM_USE_FLAG
 
 
 

--- a/include/erb/config.h
+++ b/include/erb/config.h
@@ -17,6 +17,16 @@
 
 /*\\\ CONFIG \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
+// 'erb_SDRAM_USE_FLAG' activates the use of SDRAM. If a module doesn't
+// actually use SDRAM, turning this flag off allows to save costs when
+// the daisy board can be ordered without the SDRAM chip.
+// If not defined, it will activate the SDRAM.
+
+#if !defined (erb_SDRAM_USE_FLAG)
+   #define erb_SDRAM_USE_FLAG true
+#endif
+
+
 // 'erb_SDRAM_MEM_POOL_SIZE' represents the maximum amount of memory that can
 // be used for all combined usages of 'SdramPtr' for an entire module.
 // If not defined, it will take the entire Daisy SDRAM memory, so 64MB.

--- a/include/erb/detail/Sdram.h
+++ b/include/erb/detail/Sdram.h
@@ -13,9 +13,10 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-#include "erb/detail/MonotonicMemoryPool.h"
-
 #include "erb/config.h"
+#if (erb_SDRAM_USE_FLAG)
+
+#include "erb/detail/MonotonicMemoryPool.h"
 
 #include <atomic>
 
@@ -92,6 +93,10 @@ private:
 
 
 #include "erb/detail/Sdram.hpp"
+
+
+
+#endif   // erb_SDRAM_USE_FLAG
 
 
 

--- a/include/erb/detail/fnc.hpp
+++ b/include/erb/detail/fnc.hpp
@@ -13,8 +13,12 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
+#include "erb/config.h"
+
 #include "erb/detail/Sram.h"
-#include "erb/detail/Sdram.h"
+#if (erb_SDRAM_USE_FLAG)
+   #include "erb/detail/Sdram.h"
+#endif
 
 #include <algorithm>
 
@@ -35,10 +39,12 @@ void *   allocate_bytes_auto (std::size_t size)
 {
    void * ptr = Sram::allocate_bytes_nullptr_on_error (size);
 
+#if (erb_SDRAM_USE_FLAG)
    if (ptr == nullptr)
    {
       ptr = Sdram::allocate_bytes_nullptr_on_error (size);
    }
+#endif
 
    if (ptr == nullptr)
    {

--- a/include/erb/erb.h
+++ b/include/erb/erb.h
@@ -13,6 +13,8 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
+#include "erb/config.h"
+
 #include "erb/AudioIn.h"
 #include "erb/AudioInJackDetection.h"
 #include "erb/AudioOut.h"
@@ -34,7 +36,10 @@
 #include "erb/LedRgb.h"
 #include "erb/Persistent.h"
 #include "erb/Pot.h"
-#include "erb/SdramPtr.h"
+#if (erb_SDRAM_USE_FLAG)
+   #include "erb/SdramPtr.h"
+#endif
+   #include "erb/SramPtr.h"
 #include "erb/Switch.h"
 
 #include "erb/detail/fnc.h"

--- a/include/erb/vcvrack/ModuleBoard.h
+++ b/include/erb/vcvrack/ModuleBoard.h
@@ -15,7 +15,9 @@
 
 #include "erb/config.h"
 #include "erb/detail/Sram.h"
-#include "erb/detail/Sdram.h"
+#if (erb_SDRAM_USE_FLAG)
+   #include "erb/detail/Sdram.h"
+#endif
 
 #include <array>
 
@@ -51,7 +53,9 @@ public:
                   current ();
 
    Sram &         sram ();
+#if (erb_SDRAM_USE_FLAG)
    Sdram &        sdram ();
+#endif
 
 
 
@@ -75,11 +79,15 @@ private:
 
    std::array <uint8_t, erb_SRAM_MEM_POOL_SIZE>
                   _sram_memory_pool_storage;
+#if (erb_SDRAM_USE_FLAG)
    std::array <uint8_t, erb_SDRAM_MEM_POOL_SIZE>
                   _sdram_memory_pool_storage;
+#endif
 
    Sram           _sram;
+#if (erb_SDRAM_USE_FLAG)
    Sdram          _sdram;
+#endif
 
    static thread_local ModuleBoard *
                   _current_ptr;

--- a/src/detail/Sdram.cpp
+++ b/src/detail/Sdram.cpp
@@ -11,6 +11,8 @@
 
 #include "erb/detail/Sdram.h"
 
+#if (erb_SDRAM_USE_FLAG)
+
 #if defined (erb_TARGET_VCV_RACK)
    #include "erb/vcvrack/ModuleBoard.h"
 #endif
@@ -140,6 +142,10 @@ void *   Sdram::allocate_raw_nullptr_on_error (size_t alignment, size_t size)
 
 
 }  // namespace erb
+
+
+
+#endif   // erb_SDRAM_USE_FLAG
 
 
 

--- a/src/vcvrack/ModuleBoard.cpp
+++ b/src/vcvrack/ModuleBoard.cpp
@@ -32,9 +32,13 @@ Name : ctor
 
 ModuleBoard::ModuleBoard ()
 :  _sram_memory_pool_storage ()
+#if (erb_SDRAM_USE_FLAG)
 ,  _sdram_memory_pool_storage ()
+#endif
 ,  _sram (&_sram_memory_pool_storage [0])
+#if (erb_SDRAM_USE_FLAG)
 ,  _sdram (&_sdram_memory_pool_storage [0])
+#endif
 {
 }
 
@@ -74,10 +78,12 @@ Name : sdram
 ==============================================================================
 */
 
+#if (erb_SDRAM_USE_FLAG)
 Sdram &  ModuleBoard::sdram ()
 {
    return _sdram;
 }
+#endif
 
 
 


### PR DESCRIPTION
This PR adds the `erb_SDRAM_USE_FLAG` precompiler flag configuration, on by default, to deactive SDRAM usage when the module doesn't use SDRAM.

This allows to save production costs, when the Daisy board is available without the SDRAM chip, which is the case for both the Daisy Seed and Daisy Patch Submodule (aka "Memory: 1MB").

To not use SDRAM, one would add in their module `erbb` definition:
```
define erb_SDRAM_USE_FLAG=false
```