### PR TITLE
Use O2 instead of O3

### DIFF
--- a/build-system/erbb/generators/daisy/Makefile_template
+++ b/build-system/erbb/generators/daisy/Makefile_template
@@ -66,7 +66,7 @@ FLAGS += -O0 -g -ggdb -funsafe-math-optimizations
 endif
 
 ifeq ($(CONFIGURATION),Release)
-FLAGS += -O3 -DNDEBUG=1 -funsafe-math-optimizations
+FLAGS += -O2 -DNDEBUG=1 -funsafe-math-optimizations
 endif
 
 ifdef SEMIHOSTING

--- a/build-system/erbb/generators/fuzz/Makefile_template
+++ b/build-system/erbb/generators/fuzz/Makefile_template
@@ -66,7 +66,7 @@ FLAGS += -O0 -g -ggdb -funsafe-math-optimizations
 endif
 
 ifeq ($(CONFIGURATION),Release)
-FLAGS += -O3 -DNDEBUG=1 -funsafe-math-optimizations
+FLAGS += -O2 -DNDEBUG=1 -funsafe-math-optimizations
 endif
 
 ifdef SEMIHOSTING

--- a/build-system/erbb/generators/perf/Makefile_template
+++ b/build-system/erbb/generators/perf/Makefile_template
@@ -66,7 +66,7 @@ FLAGS += -O0 -g -ggdb -funsafe-math-optimizations
 endif
 
 ifeq ($(CONFIGURATION),Release)
-FLAGS += -O3 -DNDEBUG=1 -funsafe-math-optimizations
+FLAGS += -O2 -DNDEBUG=1 -funsafe-math-optimizations
 endif
 
 ifdef SEMIHOSTING

--- a/build-system/erbb/generators/simulator/Makefile_template
+++ b/build-system/erbb/generators/simulator/Makefile_template
@@ -85,7 +85,7 @@ FLAGS += -O0 -g -funsafe-math-optimizations
 endif
 
 ifeq ($(CONFIGURATION),Release)
-FLAGS += -O3 -DNDEBUG=1 -funsafe-math-optimizations
+FLAGS += -O2 -DNDEBUG=1 -funsafe-math-optimizations
 endif
 
 %warnings%


### PR DESCRIPTION
This PR changes the optimisation level from `-O3` to `-O2`.
This leads to smaller code size which has actually a beneficial impact on performance.

For reference `-Os` could not be tested as for some reason it breaks `erbb run performance`.