### PR TITLE
Fix gyp file definition of buffer size and sample rate

### DIFF
--- a/include/erb/erb-src.gypi
+++ b/include/erb/erb-src.gypi
@@ -8,18 +8,6 @@
 
 
 {
-   'defines': [
-      'erb_BUFFER_SIZE=48',
-      'erb_SAMPLE_RATE=48014',
-   ],
-
-   'all_dependent_settings': {
-      'defines': [
-         'erb_BUFFER_SIZE=48',
-         'erb_SAMPLE_RATE=48014',
-      ],
-   },
-
    'sources': [
       'AudioIn.h',
       'AudioIn.hpp',


### PR DESCRIPTION
This PR fixes a problem when debugging using Xcode or VSCode, where the generated project file (using gyp) would have `erb_BUFFER_SIZE` and `erb_SAMPLE_RATE` defined twice, then taking the wrong value when the user defines it. The defines are already done in the `erbb/vcvrack` generator.