### PR TITLE
Add sampling time and oversampling options to adc

### DIFF
--- a/include/erb/daisy/AdcDaisy.h
+++ b/include/erb/daisy/AdcDaisy.h
@@ -17,6 +17,7 @@
 
 erb_DISABLE_WARNINGS_DAISY
 #include "per/gpio.h"
+#include "per/adc.h"
 erb_RESTORE_WARNINGS
 
 #include <array>
@@ -30,6 +31,18 @@ class AdcHandle;
 
 namespace erb
 {
+
+
+
+enum class AdcSamplingTimeCycles
+{
+   _1_5, _2_5, _8_5,
+};
+
+enum class AdcOversampling
+{
+   None, _4, _8, _16, _32
+};
 
 
 
@@ -57,7 +70,7 @@ public:
       MuxAddress  address = MuxAddress {};
    };
 
-   inline         AdcDaisy (daisy::AdcHandle & adc, std::initializer_list <Channel> channels);
+   inline         AdcDaisy (daisy::AdcHandle & adc, std::initializer_list <Channel> channels, AdcOversampling oversampling = AdcOversampling::_32, AdcSamplingTimeCycles sampling_time = AdcSamplingTimeCycles::_8_5);
    virtual        ~AdcDaisy () = default;
 
    inline uint16_t
@@ -80,6 +93,12 @@ protected:
 /*\\\ PRIVATE \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
 private:
+
+   static daisy::AdcChannelConfig::ConversionSpeed
+                  to_ConversionSpeed (AdcSamplingTimeCycles sampling_time);
+
+   static daisy::AdcHandle::OverSampling
+                  to_OverSampling (AdcOversampling oversampling);
 
    std::array <uint16_t *, MaxNbrData>
                   _data;

--- a/include/erb/daisy/AdcDaisy.hpp
+++ b/include/erb/daisy/AdcDaisy.hpp
@@ -13,10 +13,6 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-erb_DISABLE_WARNINGS_DAISY
-#include "per/adc.h"
-erb_RESTORE_WARNINGS
-
 
 
 namespace erb
@@ -33,7 +29,7 @@ Name : ctor
 */
 
 template <size_t MaxNbrData>
-AdcDaisy <MaxNbrData>::AdcDaisy (daisy::AdcHandle & adc, std::initializer_list <Channel> channels)
+AdcDaisy <MaxNbrData>::AdcDaisy (daisy::AdcHandle & adc, std::initializer_list <Channel> channels, AdcOversampling oversampling, AdcSamplingTimeCycles sampling_time)
 {
    std::array <daisy::AdcChannelConfig, MaxNbrData> configs;
 
@@ -45,7 +41,7 @@ AdcDaisy <MaxNbrData>::AdcDaisy (daisy::AdcHandle & adc, std::initializer_list <
 
       if (channel.nbr_channels == 1)
       {
-         config.InitSingle (channel.pin);
+         config.InitSingle (channel.pin, to_ConversionSpeed (sampling_time));
       }
       else
       {
@@ -54,12 +50,13 @@ AdcDaisy <MaxNbrData>::AdcDaisy (daisy::AdcHandle & adc, std::initializer_list <
             channel.nbr_channels,
             channel.address.pin_a,
             channel.address.pin_b,
-            channel.address.pin_c
+            channel.address.pin_c,
+            to_ConversionSpeed (sampling_time)
          );
       }
    }
 
-   adc.Init (&configs [0], config_nbr);
+   adc.Init (&configs [0], config_nbr, to_OverSampling (oversampling));
 
    config_nbr = 0;
    size_t channel_nbr = 0;
@@ -111,6 +108,61 @@ uint16_t AdcDaisy <MaxNbrData>::read (size_t index)
 
 
 /*\\\ PRIVATE \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
+
+/*
+==============================================================================
+Name : to_ConversionSpeed
+==============================================================================
+*/
+
+template <size_t MaxNbrData>
+daisy::AdcChannelConfig::ConversionSpeed  AdcDaisy <MaxNbrData>::to_ConversionSpeed (AdcSamplingTimeCycles sampling_time)
+{
+   switch (sampling_time)
+   {
+   case AdcSamplingTimeCycles::_1_5:
+      return daisy::AdcChannelConfig::SPEED_1CYCLES_5;
+
+   case AdcSamplingTimeCycles::_2_5:
+      return daisy::AdcChannelConfig::SPEED_2CYCLES_5;
+
+   case AdcSamplingTimeCycles::_8_5:
+      return daisy::AdcChannelConfig::SPEED_8CYCLES_5;
+   }
+
+   __builtin_unreachable ();
+}
+
+
+/*
+==============================================================================
+Name : to_OverSampling
+==============================================================================
+*/
+
+template <size_t MaxNbrData>
+daisy::AdcHandle::OverSampling   AdcDaisy <MaxNbrData>::to_OverSampling (AdcOversampling oversampling)
+{
+   switch (oversampling)
+   {
+   case AdcOversampling::None:
+      return daisy::AdcHandle::OVS_NONE;
+
+   case AdcOversampling::_4:
+      return daisy::AdcHandle::OVS_4;
+
+   case AdcOversampling::_8:
+      return daisy::AdcHandle::OVS_8;
+
+   case AdcOversampling::_16:
+      return daisy::AdcHandle::OVS_16;
+
+   case AdcOversampling::_32:
+      return daisy::AdcHandle::OVS_32;
+   }
+
+   __builtin_unreachable ();
+}
 
 
 


### PR DESCRIPTION
This PR adds sampling time (times to charge the capacitor for the sample & hold part of the ADC — depends on input impedance on the ADC pin) and oversampling options.

The default values are made for callback rates of 1ms.