### PR TITLE
Erbb vcvrack 2.5 support

### DIFF
--- a/.github/workflows/macos_12.yml
+++ b/.github/workflows/macos_12.yml
@@ -1,4 +1,4 @@
-name: macOS 11
+name: macOS 12
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
 jobs:
   software_cpp:
     name: Software C++
-    runs-on: macos-11
+    runs-on: macos-12
     defaults:
       run:
         shell: bash -l {0} # Source profile for each step
@@ -55,27 +55,27 @@ jobs:
         run: mkdir init && cd init && erbb init --name Init && erbb configure && erbb build && erbb build hardware && erbb build simulator && erbb build simulator --xcode
         working-directory: samples
       - name: VCV Rack headless run
-        run: /Applications/VCV\ Rack\ 2\ Free.app/Contents/MacOS/Rack -h <<< '\n' && cat $HOME/Documents/Rack2/log.txt
+        run: /Applications/VCV\ Rack\ 2\ Free.app/Contents/MacOS/Rack -h <<< '\n' && cat $HOME/Library/Application\ Support/Rack2/log.txt
       - name: Check micropatch
-        run: grep "Loaded ErbPluginMicropatch" $HOME/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginMicropatch" $HOME/Library/Application\ Support/Rack2/log.txt
       - name: Check bypass
-        run: grep "Loaded ErbPluginBypass" $HOME/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginBypass" $HOME/Library/Application\ Support/Rack2/log.txt
       - name: Check drop
-        run: grep "Loaded ErbPluginDrop" $HOME/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginDrop" $HOME/Library/Application\ Support/Rack2/log.txt
       - name: Check reverb
-        run: grep "Loaded ErbPluginReverb" $HOME/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginReverb" $HOME/Library/Application\ Support/Rack2/log.txt
       - name: Check kick
-        run: grep "Loaded ErbPluginKick" $HOME/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginKick" $HOME/Library/Application\ Support/Rack2/log.txt
       - name: Check custom
-        run: grep "Loaded ErbPluginCustom" $HOME/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginCustom" $HOME/Library/Application\ Support/Rack2/log.txt
       - name: Check frohmager
-        run: grep "Loaded ErbPluginFrohmager" $HOME/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFrohmager" $HOME/Library/Application\ Support/Rack2/log.txt
       - name: Check init
-        run: grep "Loaded ErbPluginInit" $HOME/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginInit" $HOME/Library/Application\ Support/Rack2/log.txt
 
   software_max:
     name: Software Max/MSP/Gen~
-    runs-on: macos-11
+    runs-on: macos-12
     defaults:
       run:
         shell: bash -l {0} # Source profile for each step
@@ -95,13 +95,13 @@ jobs:
         run: erbb configure && erbb build simulator && erbb build && erbb build hardware
         working-directory: test/max2
       - name: VCV Rack headless run
-        run: /Applications/VCV\ Rack\ 2\ Free.app/Contents/MacOS/Rack -h <<< '\n' && cat $HOME/Documents/Rack2/log.txt
+        run: /Applications/VCV\ Rack\ 2\ Free.app/Contents/MacOS/Rack -h <<< '\n' && cat $HOME/Library/Application\ Support/Rack2/log.txt
       - name: Check max
-        run: grep "Loaded ErbPluginMax" $HOME/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginMax" $HOME/Library/Application\ Support/Rack2/log.txt
 
   software_faust:
     name: Software Faust
-    runs-on: macos-11
+    runs-on: macos-12
     defaults:
       run:
         shell: bash -l {0} # Source profile for each step
@@ -128,15 +128,15 @@ jobs:
         run: erbb configure && erbb build simulator && erbb build && erbb build hardware && erbb build simulator --xcode
         working-directory: test/faust3
       - name: VCV Rack headless run
-        run: /Applications/VCV\ Rack\ 2\ Free.app/Contents/MacOS/Rack -h <<< '\n' && cat $HOME/Documents/Rack2/log.txt
+        run: /Applications/VCV\ Rack\ 2\ Free.app/Contents/MacOS/Rack -h <<< '\n' && cat $HOME/Library/Application\ Support/Rack2/log.txt
       - name: Check samples/faust
-        run: grep "Loaded ErbPluginFlanger" $HOME/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFlanger" $HOME/Library/Application\ Support/Rack2/log.txt
       - name: Check test/faust
-        run: grep "Loaded ErbPluginFaust" $HOME/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFaust" $HOME/Library/Application\ Support/Rack2/log.txt
 
   hardware:
     name: Hardware
-    runs-on: macos-11
+    runs-on: macos-12
     defaults:
       run:
         shell: bash -l {0} # Source profile for each step
@@ -150,7 +150,7 @@ jobs:
 
   unit_tests:
     name: Unit Tests
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
         with:
@@ -162,7 +162,7 @@ jobs:
 
   erbb_tests:
     name: Erbb/Erbui Tests
-    runs-on: macos-11
+    runs-on: macos-12
     defaults:
       run:
         shell: bash -l {0} # Source profile for each step

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: curl https://vcvrack.com/downloads/RackFree-2.4.0-lin-x64.zip | jar xv
+      - run: curl https://vcvrack.com/downloads/RackFree-2.5.2-lin-x64.zip | jar xv
       - run: chmod u+x ./Rack2Free/Rack
       - run: sudo apt-get update
       - run: sudo apt-get install libjack-jackd2-dev libpulse-dev
@@ -59,24 +59,24 @@ jobs:
         run: mkdir init && cd init && erbb init --name Init && erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: samples
       - name: VCV Rack headless run
-        run: ./Rack -h <<< '\n' && cat $HOME/.Rack2/log.txt
+        run: ./Rack -h <<< '\n' && cat $HOME/.local/share/Rack2/log.txt
         working-directory: Rack2Free
       - name: Check micropatch
-        run: grep "Loaded ErbPluginMicropatch" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginMicropatch" $HOME/.local/share/Rack2/log.txt
       - name: Check bypass
-        run: grep "Loaded ErbPluginBypass" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginBypass" $HOME/.local/share/Rack2/log.txt
       - name: Check drop
-        run: grep "Loaded ErbPluginDrop" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginDrop" $HOME/.local/share/Rack2/log.txt
       - name: Check reverb
-        run: grep "Loaded ErbPluginReverb" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginReverb" $HOME/.local/share/Rack2/log.txt
       - name: Check kick
-        run: grep "Loaded ErbPluginKick" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginKick" $HOME/.local/share/Rack2/log.txt
       - name: Check custom
-        run: grep "Loaded ErbPluginCustom" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginCustom" $HOME/.local/share/Rack2/log.txt
       - name: Check frohmager
-        run: grep "Loaded ErbPluginFrohmager" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFrohmager" $HOME/.local/share/Rack2/log.txt
       - name: Check init
-        run: grep "Loaded ErbPluginInit" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginInit" $HOME/.local/share/Rack2/log.txt
 
   software_faust:
     name: Software Faust
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: curl https://vcvrack.com/downloads/RackFree-2.4.0-lin-x64.zip | jar xv
+      - run: curl https://vcvrack.com/downloads/RackFree-2.5.2-lin-x64.zip | jar xv
       - run: chmod u+x ./Rack2Free/Rack
       - run: sudo apt-get update
       - run: sudo apt-get install libjack-jackd2-dev libpulse-dev faust
@@ -110,12 +110,12 @@ jobs:
         run: erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: test/faust3
       - name: VCV Rack headless run
-        run: ./Rack -h <<< '\n' && cat $HOME/.Rack2/log.txt
+        run: ./Rack -h <<< '\n' && cat $HOME/.local/share/Rack2/log.txt
         working-directory: Rack2Free
       - name: Check faust
-        run: grep "Loaded ErbPluginFaust" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFaust" $HOME/.local/share/Rack2/log.txt
       - name: Check flanger
-        run: grep "Loaded ErbPluginFlanger" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFlanger" $HOME/.local/share/Rack2/log.txt
 
   hardware:
     name: Hardware

--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: curl https://vcvrack.com/downloads/RackFree-2.4.0-lin-x64.zip | jar xv
+      - run: curl https://vcvrack.com/downloads/RackFree-2.5.2-lin-x64.zip | jar xv
       - run: chmod u+x ./Rack2Free/Rack
       - run: sudo apt-get update
       - run: sudo apt-get install libjack-jackd2-dev libpulse-dev
@@ -59,24 +59,24 @@ jobs:
         run: mkdir init && cd init && erbb init --name Init && erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: samples
       - name: VCV Rack headless run
-        run: ./Rack -h <<< '\n' && cat $HOME/.Rack2/log.txt
+        run: ./Rack -h <<< '\n' && cat $HOME/.local/share/Rack2/log.txt
         working-directory: Rack2Free
       - name: Check micropatch
-        run: grep "Loaded ErbPluginMicropatch" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginMicropatch" $HOME/.local/share/Rack2/log.txt
       - name: Check bypass
-        run: grep "Loaded ErbPluginBypass" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginBypass" $HOME/.local/share/Rack2/log.txt
       - name: Check drop
-        run: grep "Loaded ErbPluginDrop" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginDrop" $HOME/.local/share/Rack2/log.txt
       - name: Check reverb
-        run: grep "Loaded ErbPluginReverb" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginReverb" $HOME/.local/share/Rack2/log.txt
       - name: Check kick
-        run: grep "Loaded ErbPluginKick" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginKick" $HOME/.local/share/Rack2/log.txt
       - name: Check custom
-        run: grep "Loaded ErbPluginCustom" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginCustom" $HOME/.local/share/Rack2/log.txt
       - name: Check frohmager
-        run: grep "Loaded ErbPluginFrohmager" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFrohmager" $HOME/.local/share/Rack2/log.txt
       - name: Check init
-        run: grep "Loaded ErbPluginInit" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginInit" $HOME/.local/share/Rack2/log.txt
 
   software_faust:
     name: Software Faust
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: curl https://vcvrack.com/downloads/RackFree-2.4.0-lin-x64.zip | jar xv
+      - run: curl https://vcvrack.com/downloads/RackFree-2.5.2-lin-x64.zip | jar xv
       - run: chmod u+x ./Rack2Free/Rack
       - run: sudo apt-get update
       - run: sudo apt-get install libjack-jackd2-dev libpulse-dev faust
@@ -110,12 +110,12 @@ jobs:
         run: erbb configure && erbb build && erbb build hardware && erbb build simulator
         working-directory: test/faust3
       - name: VCV Rack headless run
-        run: ./Rack -h <<< '\n' && cat $HOME/.Rack2/log.txt
+        run: ./Rack -h <<< '\n' && cat $HOME/.local/share/Rack2/log.txt
         working-directory: Rack2Free
       - name: Check faust
-        run: grep "Loaded ErbPluginFaust" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFaust" $HOME/.local/share/Rack2/log.txt
       - name: Check flanger
-        run: grep "Loaded ErbPluginFlanger" $HOME/.Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFlanger" $HOME/.local/share/Rack2/log.txt
 
   hardware:
     name: Hardware

--- a/.github/workflows/windows_2019.yml
+++ b/.github/workflows/windows_2019.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: choco install vcvrack --version=2.4.1
+      - run: choco install vcvrack --version=2.5.2
       - name: VCV Rack headless first run
         run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n'
       - run: python3 build-system/install.py
@@ -54,23 +54,23 @@ jobs:
         run: mkdir init && cd init && erbb init --name Init && erbb configure && erbb build && erbb build simulator && erbb build hardware
         working-directory: samples
       - name: VCV Rack headless run
-        run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n' && cat $USERPROFILE/Documents/Rack2/log.txt
+        run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n' && cat $LOCALAPPDATA/Rack2/log.txt
       - name: Check micropatch
-        run: grep "Loaded ErbPluginMicropatch" $USERPROFILE/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginMicropatch" $LOCALAPPDATA/Rack2/log.txt
       - name: Check bypass
-        run: grep "Loaded ErbPluginBypass" $USERPROFILE/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginBypass" $LOCALAPPDATA/Rack2/log.txt
       - name: Check drop
-        run: grep "Loaded ErbPluginDrop" $USERPROFILE/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginDrop" $LOCALAPPDATA/Rack2/log.txt
       - name: Check reverb
-        run: grep "Loaded ErbPluginReverb" $USERPROFILE/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginReverb" $LOCALAPPDATA/Rack2/log.txt
       - name: Check kick
-        run: grep "Loaded ErbPluginKick" $USERPROFILE/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginKick" $LOCALAPPDATA/Rack2/log.txt
       - name: Check custom
-        run: grep "Loaded ErbPluginCustom" $USERPROFILE/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginCustom" $LOCALAPPDATA/Rack2/log.txt
       - name: Check frohmager
-        run: grep "Loaded ErbPluginFrohmager" $USERPROFILE/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFrohmager" $LOCALAPPDATA/Rack2/log.txt
       - name: Check init
-        run: grep "Loaded ErbPluginInit" $USERPROFILE/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginInit" $LOCALAPPDATA/Rack2/log.txt
 
   software_max:
     name: Software Max/MSP/Gen~
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: choco install vcvrack --version=2.4.1
+      - run: choco install vcvrack --version=2.5.2
       - name: VCV Rack headless first run
         run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n'
       - run: python3 build-system/install.py
@@ -94,9 +94,9 @@ jobs:
         run: erbb configure && erbb build simulator && erbb build && erbb build hardware
         working-directory: test/max2
       - name: VCV Rack headless run
-        run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n' && cat $USERPROFILE/Documents/Rack2/log.txt
+        run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n' && cat $LOCALAPPDATA/Rack2/log.txt
       - name: Check max
-        run: grep "Loaded ErbPluginMax" $USERPROFILE/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginMax" $LOCALAPPDATA/Rack2/log.txt
 
   software_faust_2_37_3:
     name: Software Faust 2.37.3
@@ -112,7 +112,7 @@ jobs:
       - run: ./Faust-2.37.3-win64.exe //S
       - run: echo 'export PATH=$PATH:/c/Program\ Files/Faust/bin' >> ~/.bash_profile
       - run: cat ~/.bash_profile
-      - run: choco install vcvrack --version=2.4.1
+      - run: choco install vcvrack --version=2.5.2
       - name: VCV Rack headless first run
         run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n'
       - run: python3 build-system/install.py
@@ -130,11 +130,11 @@ jobs:
         run: erbb configure && erbb build simulator && erbb build && erbb build hardware
         working-directory: test/faust3
       - name: VCV Rack headless run
-        run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n' && cat $USERPROFILE/Documents/Rack2/log.txt
+        run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n' && cat $LOCALAPPDATA/Rack2/log.txt
       - name: Check faust
-        run: grep "Loaded ErbPluginFaust" $USERPROFILE/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFaust" $LOCALAPPDATA/Rack2/log.txt
       - name: Check flanger
-        run: grep "Loaded ErbPluginFlanger" $USERPROFILE/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFlanger" $LOCALAPPDATA/Rack2/log.txt
 
   software_faust:
     name: Software Faust
@@ -150,7 +150,7 @@ jobs:
       - run: ./Faust-2.41.1-win64.exe //S
       - run: echo 'export PATH=$PATH:/c/Program\ Files/Faust/bin' >> ~/.bash_profile
       - run: cat ~/.bash_profile
-      - run: choco install vcvrack --version=2.4.1
+      - run: choco install vcvrack --version=2.5.2
       - name: VCV Rack headless first run
         run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n'
       - run: python3 build-system/install.py
@@ -168,8 +168,8 @@ jobs:
         run: erbb configure && erbb build simulator && erbb build && erbb build hardware
         working-directory: test/faust3
       - name: VCV Rack headless run
-        run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n' && cat $USERPROFILE/Documents/Rack2/log.txt
+        run: c:/Program\ Files/VCV/Rack2Free/Rack.exe -h <<< '\n' && cat $LOCALAPPDATA/Rack2/log.txt
       - name: Check faust
-        run: grep "Loaded ErbPluginFaust" $USERPROFILE/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFaust" $LOCALAPPDATA/Rack2/log.txt
       - name: Check flanger
-        run: grep "Loaded ErbPluginFlanger" $USERPROFILE/Documents/Rack2/log.txt
+        run: grep "Loaded plugin ErbPluginFlanger" $LOCALAPPDATA/Rack2/log.txt

--- a/build-system/erbb/__init__.py
+++ b/build-system/erbb/__init__.py
@@ -861,25 +861,25 @@ def deploy_simulator (name, path, configuration):
       sys.exit ('Unknown target %s' % name)
 
    if platform.system () == 'Darwin':
+      rack2_folder = os.path.abspath (
+         os.path.join (os.path.expanduser ("~"), 'Library', 'Application Support', 'Rack2')
+      )
       if platform.machine () == 'x86_64':
-         vcv_plugins_path = os.path.abspath (
-            os.path.join (os.path.expanduser ("~"), 'Documents', 'Rack2', 'plugins-mac-x64')
-         )
+         vcv_plugins_path = os.path.join (rack2_folder, 'plugins-mac-x64')
       elif platform.machine () == 'arm64':
-         vcv_plugins_path = os.path.abspath (
-            os.path.join (os.path.expanduser ("~"), 'Documents', 'Rack2', 'plugins-mac-arm64')
-         )
+         vcv_plugins_path = os.path.join (rack2_folder, 'plugins-mac-arm64')
       else:
          sys.exit (1)
 
    elif platform.system () == 'Windows':
       vcv_plugins_path = os.path.abspath (
-         os.path.join (os.environ ['USERPROFILE'], 'Documents', 'Rack2', 'plugins-win-x64')
+         os.path.join (os.environ ['LOCALAPPDATA'], 'Rack2', 'plugins-win-x64')
       )
 
    elif platform.system () == 'Linux':
+      xdg_data_home = os.environ.get('XDG_DATA_HOME', os.path.abspath (os.path.join (os.path.expanduser ("~"), '.local', 'share')))
       vcv_plugins_path = os.path.abspath (
-         os.path.join (os.path.expanduser ("~"), '.Rack2', 'plugins-lin-x64')
+         os.path.join (xdg_data_home, 'Rack2', 'plugins-lin-x64')
       )
 
    vcv_plugin_path = os.path.join (vcv_plugins_path, name)

--- a/build-system/erbb/generators/action/action_vcvrack_install_template.py
+++ b/build-system/erbb/generators/action/action_vcvrack_install_template.py
@@ -18,18 +18,20 @@ PATH_THIS = os.path.abspath (os.path.dirname (__file__))
 PATH_ROOT = os.path.abspath (os.path.dirname (os.path.dirname (PATH_THIS)))
 
 if platform.system () == 'Darwin':
+   rack2_folder = os.path.abspath (os.path.join (os.path.expanduser ("~"), 'Library', 'Application Support', 'Rack2'))
    if platform.machine () == 'x86_64':
-      PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.path.expanduser ("~"), 'Documents', 'Rack2', 'plugins-mac-x64'))
+      PATH_VCV_PLUGINS = os.path.join (rack2_folder, 'plugins-mac-x64')
    elif platform.machine () == 'arm64':
-      PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.path.expanduser ("~"), 'Documents', 'Rack2', 'plugins-mac-arm64'))
+      PATH_VCV_PLUGINS = os.path.join (rack2_folder, 'plugins-mac-arm64')
    else:
       sys.exit (1)
 
 elif platform.system () == 'Linux':
-   PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.path.expanduser ("~"), '.Rack2', 'plugins-lin-x64'))
+   xdg_data_home = os.environ.get('XDG_DATA_HOME', os.path.abspath (os.path.join (os.path.expanduser ("~"), '.local', 'share')))
+   PATH_VCV_PLUGINS = os.path.abspath (os.path.join (xdg_data_home, 'Rack2', 'plugins-lin-x64'))
 
 elif platform.system () == 'Windows':
-   PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.environ ['USERPROFILE'], 'Documents', 'Rack2', 'plugins-win-x64'))
+   PATH_VCV_PLUGINS = os.path.abspath (os.path.join (os.environ ['LOCALAPPDATA'], 'Rack2', 'plugins-win-x64'))
 
 PATH_VCV_PLUGIN = os.path.abspath (os.path.join (PATH_VCV_PLUGINS, '%module.name%'))
 PATH_VCV_PLUGIN_RES = os.path.abspath (os.path.join (PATH_VCV_PLUGIN, 'res'))

--- a/build-system/erbb/generators/simulator/Makefile_template
+++ b/build-system/erbb/generators/simulator/Makefile_template
@@ -36,7 +36,7 @@ LDFLAGS += -L$(RACK_DIR)/$(ARCH_OS)-$(ARCH_CPU) -lRack
 ifdef ARCH_MAC
 	LDFLAGS += -undefined dynamic_lookup
 	TARGET := plugin.dylib
-	RACK_USER_DIR ?= $(HOME)/Documents/Rack2
+	RACK_USER_DIR ?= $(HOME)/Library/Application\ Support/Rack2
 	FLAGS += -DARCH_MAC
 	CXXFLAGS += -stdlib=libc++
 	LDFLAGS += -stdlib=libc++
@@ -47,7 +47,8 @@ endif
 
 ifdef ARCH_LIN
 	TARGET := plugin.so
-	RACK_USER_DIR ?= $(HOME)/.Rack2
+	XDG_DATA_HOME ?= $(HOME)/.local/share
+	RACK_USER_DIR ?= $(XDG_DATA_HOME)/Rack2
 	FLAGS += -DARCH_LIN
 	# This prevents static variables in the DSO (dynamic shared object) from
 	# being preserved after dlclose().
@@ -62,7 +63,7 @@ endif
 ifdef ARCH_WIN
 	LDFLAGS += -static-libstdc++
 	TARGET := plugin.dll
-	RACK_USER_DIR ?= "$(USERPROFILE)"/Documents/Rack2
+	RACK_USER_DIR ?= "$(LOCALAPPDATA)"/Rack2
 	FLAGS += -DARCH_WIN
 	FLAGS += -D_USE_MATH_DEFINES
 	FLAGS += -municode

--- a/documentation/setup/linux-cpp-cli.md
+++ b/documentation/setup/linux-cpp-cli.md
@@ -11,7 +11,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 
 - [`git`](https://git-scm.com/download)
 - [Python 3](https://www.python.org/downloads/)
-- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.5](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/linux-cpp-vscode.md
+++ b/documentation/setup/linux-cpp-vscode.md
@@ -12,7 +12,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download)
 - [Python 3](https://www.python.org/downloads/)
 - [Visual Studio Code](https://code.visualstudio.com/download)
-- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.5](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/linux-faust.md
+++ b/documentation/setup/linux-faust.md
@@ -12,7 +12,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download)
 - [Python 3](https://www.python.org/downloads/)
 - [Faust](https://faust.grame.fr)
-- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.5](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/macos-cpp-cli.md
+++ b/documentation/setup/macos-cpp-cli.md
@@ -13,7 +13,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download)
 - [Python 3](https://www.python.org/downloads/)
 - [Xcode command line tools](https://developer.apple.com/xcode/)
-- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.5](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/macos-cpp-vscode.md
+++ b/documentation/setup/macos-cpp-vscode.md
@@ -14,7 +14,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [Python 3](https://www.python.org/downloads/)
 - [Xcode command line tools](https://developer.apple.com/xcode/)
 - [Visual Studio Code](https://code.visualstudio.com/download)
-- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.5](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/macos-cpp-xcode.md
+++ b/documentation/setup/macos-cpp-xcode.md
@@ -13,7 +13,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download)
 - [Python 3](https://www.python.org/downloads/)
 - [Xcode version 11 or later](https://developer.apple.com/xcode/)
-- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.5](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/macos-faust.md
+++ b/documentation/setup/macos-faust.md
@@ -14,7 +14,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [Python 3](https://www.python.org/downloads/)
 - [Xcode command line tools](https://developer.apple.com/xcode/)
 - [Faust](https://faust.grame.fr)
-- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.5](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/macos-max.md
+++ b/documentation/setup/macos-max.md
@@ -14,7 +14,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [Python 3](https://www.python.org/downloads/)
 - [Xcode command line tools](https://developer.apple.com/xcode/)
 - [Max](https://cycling74.com/products/max) at least version 8
-- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.5](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/windows-cpp-cli.md
+++ b/documentation/setup/windows-cpp-cli.md
@@ -11,7 +11,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 
 - [`git`](https://git-scm.com/download) and in particular the Git Bash shell
 - [Python 3](https://www.python.org/downloads/)
-- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.5](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/windows-cpp-vscode.md
+++ b/documentation/setup/windows-cpp-vscode.md
@@ -12,7 +12,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download) and in particular the Git Bash shell
 - [Python 3](https://www.python.org/downloads/)
 - [Visual Studio Code](https://code.visualstudio.com/download)
-- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.5](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/windows-faust.md
+++ b/documentation/setup/windows-faust.md
@@ -12,7 +12,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download) and in particular the Git Bash shell
 - [Python 3](https://www.python.org/downloads/)
 - [Faust](https://faust.grame.fr)
-- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.5](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 

--- a/documentation/setup/windows-max.md
+++ b/documentation/setup/windows-max.md
@@ -12,7 +12,7 @@ Before we can setup Eurorack-blocks, we will need to have on your system:
 - [`git`](https://git-scm.com/download) and in particular the Git Bash shell
 - [Python 3](https://www.python.org/downloads/)
 - [Max](https://cycling74.com/products/max) at least version 8
-- [VCV Rack at least version 2.4](https://vcvrack.com/Rack)
+- [VCV Rack at least version 2.5](https://vcvrack.com/Rack)
 
 If you are a developer, there is a chance that most of them are installed already.
 


### PR DESCRIPTION
This PR adds support for VCV Rack 2.5. In particular the path to the plug-in modules changed again.

### macOS

In the [code](https://github.com/VCVRack/Rack/blob/58f2482df860fe878581423aedc8cadb1d94eb50/src/asset.mm#L11) it is the first path returned by
```
NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
```

It happens that in core python, there is no way to get this path cleanly. So for now we are hardcoding the path, which might breaks on some macOS installations. Anyway this is also what the [makefile does](https://github.com/VCVRack/Rack/blob/58f2482df860fe878581423aedc8cadb1d94eb50/plugin.mk#L43).

The GitHub workflow was updated to macOS 12, as it just so happens that macOS 11 runner image is unavailable on the same day.

### Linux

The path was also changed on [Linux](https://github.com/VCVRack/Rack/blob/58f2482df860fe878581423aedc8cadb1d94eb50/src/asset.cpp#L162). We also support `XDG_DATA_HOME`.

### Windows

The path was also changed on [Windows](https://github.com/VCVRack/Rack/blob/58f2482df860fe878581423aedc8cadb1d94eb50/src/asset.cpp#L118).
