### PR TITLE
Add fatfs support

### DIFF
--- a/build-system/erbb/generators/daisy/make.py
+++ b/build-system/erbb/generators/daisy/make.py
@@ -134,6 +134,7 @@ class Make:
       define_map = {
          'erb_BUFFER_SIZE': '48',
          'erb_SAMPLE_RATE': '48014',
+         'erb_USE_FATFS': '0',
       }
 
       for define in defines:
@@ -210,12 +211,23 @@ class Make:
          else:
             return '$(CONFIGURATION)' + path + '.d'
 
+      use_fatfs = False
+      for define in module.defines:
+         if define.key == 'erb_USE_FATFS' and define.value == '1':
+            use_fatfs = True
+
       source_extra_paths = []
       source_extra_paths.append (os.path.abspath (os.path.join (PATH_LIBDAISY, 'core', 'startup_stm32h750xx.c')))
       cmsis_dsp_src_path = os.path.abspath (os.path.join (PATH_LIBDAISY, 'Drivers', 'CMSIS', 'DSP', 'Source'))
       source_extra_paths.append (os.path.join (cmsis_dsp_src_path, 'CommonTables', 'arm_common_tables.c'))
       source_extra_paths.append (os.path.join (cmsis_dsp_src_path, 'FastMathFunctions', 'arm_cos_f32.c'))
       source_extra_paths.append (os.path.join (cmsis_dsp_src_path, 'FastMathFunctions', 'arm_sin_f32.c'))
+      if use_fatfs:
+         fatfs_src_path = os.path.abspath (os.path.join (PATH_LIBDAISY, 'Middlewares', 'Third_Party', 'FatFs', 'src'))
+         source_extra_paths.append (os.path.join (fatfs_src_path, 'diskio.c'))
+         source_extra_paths.append (os.path.join (fatfs_src_path, 'ff.c'))
+         source_extra_paths.append (os.path.join (fatfs_src_path, 'ff_gen_drv.c'))
+         source_extra_paths.append (os.path.join (fatfs_src_path, 'option', 'ccsbcs.c'))
 
       objects = ' '.join (map (lambda x: object_name (x), source_paths))
       objects += ' ' + ' '.join (map (lambda x: object_name (x), source_extra_paths))

--- a/build-system/erbb/generators/fuzz/make.py
+++ b/build-system/erbb/generators/fuzz/make.py
@@ -134,6 +134,7 @@ class Make:
       define_map = {
          'erb_BUFFER_SIZE': '48',
          'erb_SAMPLE_RATE': '48014',
+         'erb_USE_FATFS': '0',
       }
 
       for define in defines:

--- a/build-system/erbb/generators/perf/make.py
+++ b/build-system/erbb/generators/perf/make.py
@@ -134,6 +134,7 @@ class Make:
       define_map = {
          'erb_BUFFER_SIZE': '48',
          'erb_SAMPLE_RATE': '48014',
+         'erb_USE_FATFS': '0',
       }
 
       for define in defines:

--- a/build-system/erbb/generators/simulator/make.py
+++ b/build-system/erbb/generators/simulator/make.py
@@ -108,6 +108,7 @@ class Make:
       define_map = {
          'erb_BUFFER_SIZE': '48',
          'erb_SAMPLE_RATE': '48014',
+         'erb_USE_FATFS': '0',
       }
 
       for define in defines:

--- a/build-system/erbb/generators/vcvrack/project.py
+++ b/build-system/erbb/generators/vcvrack/project.py
@@ -175,6 +175,7 @@ class Project:
       define_map = {
          'erb_BUFFER_SIZE': '48',
          'erb_SAMPLE_RATE': '48014',
+         'erb_USE_FATFS': '0',
       }
 
       for define in defines:

--- a/build-system/erbb/generators/vscode/c_cpp_properties.py
+++ b/build-system/erbb/generators/vscode/c_cpp_properties.py
@@ -98,6 +98,7 @@ class CCppProperties:
       define_map = {
          'erb_BUFFER_SIZE': '48',
          'erb_SAMPLE_RATE': '48014',
+         'erb_USE_FATFS': '0',
       }
 
       for define in module.defines:


### PR DESCRIPTION
This PR adds `fatfs` library files to the firmware target. For now VCV Rack support is not there, and we didn't introduce an abstraction yet.

There was some oddity, because `libDaisy` actually builds with most of the FatFS files, with the exception of `option/ccsbcs.c` for some reason. In the end, we just mimic the `core/Makefile` that is used in Daisy examples.

This is also using the `ffconf.h` defined in libDaisy, which doesn't allow to reconfigure FatFS. One thing we would have wanted would be to have `#define _FS_READONLY 1`, but the difference for compilation seems quite minimal (when not using `f_write` anyway).