### PR TITLE
Debounce encoder

### DIFF
--- a/include/erb/Encoder.hpp
+++ b/include/erb/Encoder.hpp
@@ -65,7 +65,7 @@ void  Encoder <LeadingType>::impl_preprocess ()
    _state_a = uint8_t (_state_a << 1) | (impl_data_a != 0);
    _state_b = uint8_t (_state_b << 1) | (impl_data_b != 0);
 
-   if ((_state_a & 0x03) == 0x02 && (_state_b & 0x03) == 0x00)
+   if ((_state_a & 0x07) == 0x04 && (_state_b & 0x07) == 0x00)
    {
       if constexpr (LeadingType == EncoderLeadingType::A)
       {
@@ -76,7 +76,7 @@ void  Encoder <LeadingType>::impl_preprocess ()
          _val = 1;
       }
    }
-   else if ((_state_b & 0x03) == 0x02 && (_state_a & 0x03) == 0x00)
+   else if ((_state_b & 0x07) == 0x04 && (_state_a & 0x07) == 0x00)
    {
       if constexpr (LeadingType == EncoderLeadingType::A)
       {


### PR DESCRIPTION
This PR debounces the encoder by waiting for two 0s on a falling edge, instead of just one before.

When the buffer size is 12 or 16 samples, we are reading the GPIOs at 3kHz and 4kHz respectively. In this case we can observe (we measured) that our encoder A/B tends to bounce sometimes once. So we wait for more zeros on the falling edge.

This was tested on a real hardware and seems to be better than before.