### PR TITLE
Read as binary, as the gzip check in cairo is expecting bytes, not str

### DIFF
--- a/build-system/erbui/generators/detail/panel.py
+++ b/build-system/erbui/generators/detail/panel.py
@@ -446,7 +446,7 @@ class Panel:
       if render_mode == 'translucence' and not image.is_layer_translucence: return
       if render_mode == 'translucence_no_fill' and not image.is_layer_translucence: return
 
-      with open (image.file) as file:
+      with open (image.file, 'rb') as file:
          tree = cairosvg.parser.Tree (file_obj=file)
          surface = ContextOnlySurface (tree, context)
 


### PR DESCRIPTION
This PR fixes a problem of Eurorack-blocks using Cairo:
```
TypeError: startswith first arg must be str or a tuple of str, not bytes
```

The test [used to be in 2.7.1](https://github.com/Kozea/CairoSVG/blob/2.7.1/cairosvg/parser.py#L388):
```
if len(bytestring) >= 2 and bytestring[:2] == b'\x1f\x8b':
```
But is [now with 2.8.0](https://github.com/Kozea/CairoSVG/blob/2.8.0/cairosvg/parser.py#L388C13-L388C51) (released 2 days ago):
```
if bytestring.startswith(b'\x1f\x8b'):
```
Which triggers the error.

Cairo was always expecting a `bytestring` (hence the name of the variable), and it so happen that we were not supporting compressed SVG, but that was never tested. We now read the file in binary mode.

- Fixes #697 

Thanks @liamge for the report and fix suggestion!