### PR TITLE
Add debouncing sliding window size configuration for encoder

### DIFF
--- a/include/erb/Encoder.h
+++ b/include/erb/Encoder.h
@@ -41,6 +41,8 @@ public:
                   Encoder (const uint8_t & data_a, const uint8_t & data_b);
    virtual        ~Encoder () = default;
 
+   void           configure (size_t nbr_debounce_zeros);
+
                   operator int () const;
 
 
@@ -66,8 +68,10 @@ protected:
 
 private:
 
-   uint8_t        _state_a = 0xff;
-   uint8_t        _state_b = 0xff;
+   uint32_t       _state_a = 0xffffffff;
+   uint32_t       _state_b = 0xffffffff;
+   uint32_t       _test = 0x04;
+   uint32_t       _mask = 0x07;
    int            _val = 0;
 
 

--- a/include/erb/Encoder.hpp
+++ b/include/erb/Encoder.hpp
@@ -13,6 +13,8 @@
 
 /*\\\ INCLUDE FILES \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
+#include <cassert>
+
 
 
 namespace erb
@@ -33,6 +35,26 @@ Encoder <LeadingType>::Encoder (const uint8_t & data_a, const uint8_t & data_b)
 :  impl_data_a (data_a)
 ,  impl_data_b (data_b)
 {
+}
+
+
+
+/*
+==============================================================================
+Name : configure
+Description :
+   Sets the number of expected zeros to emit an event while debouncing.
+   For example 2 zeros will output an event when 100 is observed.
+==============================================================================
+*/
+
+template <EncoderLeadingType LeadingType>
+void  Encoder <LeadingType>::configure (size_t nbr_debounce_zeros)
+{
+   assert (nbr_debounce_zeros < 32);
+
+   _test = 1 << nbr_debounce_zeros;
+   _mask = _test * 2 - 1;
 }
 
 
@@ -62,10 +84,10 @@ Name : impl_preprocess
 template <EncoderLeadingType LeadingType>
 void  Encoder <LeadingType>::impl_preprocess ()
 {
-   _state_a = uint8_t (_state_a << 1) | (impl_data_a != 0);
-   _state_b = uint8_t (_state_b << 1) | (impl_data_b != 0);
+   _state_a = uint32_t (_state_a << 1) | (impl_data_a != 0);
+   _state_b = uint32_t (_state_b << 1) | (impl_data_b != 0);
 
-   if ((_state_a & 0x07) == 0x04 && (_state_b & 0x07) == 0x00)
+   if ((_state_a & _mask) == _test && (_state_b & _mask) == 0)
    {
       if constexpr (LeadingType == EncoderLeadingType::A)
       {
@@ -76,7 +98,7 @@ void  Encoder <LeadingType>::impl_preprocess ()
          _val = 1;
       }
    }
-   else if ((_state_b & 0x07) == 0x04 && (_state_a & 0x07) == 0x00)
+   else if ((_state_b & _mask) == _test && (_state_a & _mask) == 0)
    {
       if constexpr (LeadingType == EncoderLeadingType::A)
       {


### PR DESCRIPTION
This PR adds a function to `Encoder` to explicitly configure the sliding window size with the number of zeros needed in a falling edge to emit an increment.