### PR TITLE
Add new reference_count member introduced in cairosvg 2.9.0

### DIFF
--- a/build-system/erbui/generators/detail/panel.py
+++ b/build-system/erbui/generators/detail/panel.py
@@ -610,6 +610,7 @@ class ContextOnlySurface (cairosvg.surface.Surface):
       self.filters = {}
       self.images = {}
       self.tree_cache = {(tree.url, tree.get('id')): tree}
+      self.reference_count = 0
 
       self.dpi = 72 # used in `size` for pt units
 


### PR DESCRIPTION
This PR brings compatibility with CairoSvg 2.9.0, which introduces a new `reference_count` member to its `Surface` class.

We have the `ContextOnlySurface` concept, which is missing in Cairo, and we emulate it ourselves. But then we need to conform to their abstraction.

Another possible fix would have been to restrict our build system requirements to `CairoSVG>=2.6.0,<=2.8.2`